### PR TITLE
[SPARK-47889][FOLLOWUP] Add `gradlew` to `.licenserc.yaml`

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -15,5 +15,6 @@ header:
     - 'NOTICE'
     - '.asf.yaml'
     - '**/*.gradle'
+    - gradlew
 
   comment: on-failure


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `gradlew` to `.licenserc.yaml` as a follow-up of
- #4

### Why are the changes needed?

To recover CI.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No,