### PR TITLE
[SPARK-48015] Update `build.gradle` to fix deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,14 @@ subprojects {
   apply plugin: 'idea'
   apply plugin: 'eclipse'
   apply plugin: 'java'
-  sourceCompatibility = 17
-  targetCompatibility = 17
+
+  java {
+    sourceCompatibility = 17
+    targetCompatibility = 17
+  }
 
   repositories {
     mavenCentral()
-    jcenter()
   }
 
   apply plugin: 'checkstyle'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `build.gradle` to fix deprecation warnings.

### Why are the changes needed?

**AFTER**
```
$ ./gradlew build --warning-mode all

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD

BUILD SUCCESSFUL in 331ms
16 actionable tasks: 16 up-to-date
```

**BEFORE**
```
$ ./gradlew build --warning-mode all

> Configure project :
Build file '/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle': line 20
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_1ab30mf3g41rlj3ezxkowdftr$_run_closure1.doCall$original(/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle:20)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_1ab30mf3g41rlj3ezxkowdftr.run(/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle:16)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle': line 21
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_1ab30mf3g41rlj3ezxkowdftr$_run_closure1.doCall$original(/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle:21)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_1ab30mf3g41rlj3ezxkowdftr.run(/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle:16)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle': line 25
The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 9.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_6.html#jcenter_deprecation
        at build_1ab30mf3g41rlj3ezxkowdftr$_run_closure1$_closure2.doCall$original(/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle:25)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_1ab30mf3g41rlj3ezxkowdftr$_run_closure1.doCall$original(/Users/dongjoon/APACHE/spark-kubernetes-operator/build.gradle:23)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD

BUILD SUCCESSFUL in 353ms
16 actionable tasks: 16 up-to-date
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually build with `--warning-mode all`.
```
$ ./gradlew build --warning-mode all

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD

BUILD SUCCESSFUL in 331ms
16 actionable tasks: 16 up-to-date
```

### Was this patch authored or co-authored using generative AI tooling?

No.