### PR TITLE
[SPARK-48120] Enable autolink to SPARK jira issue

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,7 @@ github:
     merge: false
     squash: true
     rebase: true
+  autolink_jira: SPARK
 
 notifications:
   pullrequests: reviews@spark.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `autolink` feature to `SPARK` jira issue like `Apache Spark` repository.

### Why are the changes needed?

Since we share the same JIRA project name, we need to link it.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.