### PR TITLE
[SPARK-48326] Use the official Apache Spark 4.0.0-preview1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,6 @@ subprojects {
 
   repositories {
     mavenCentral()
-    // TODO(SPARK-48326) Upgrade submission worker base Spark version to 4.0.0-preview2
-    maven {
-      url "https://repository.apache.org/content/repositories/orgapachespark-1454/"
-    }
   }
 
   apply plugin: 'checkstyle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,6 @@ lombokVersion=1.18.32
 
 # Spark
 scalaVersion=2.13
-# TODO(SPARK-48326) Upgrade submission worker base Spark version to 4.0.0-preview2
 sparkVersion=4.0.0-preview1
 
 # Logging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the official Apache Spark `4.0.0-preview1` artifacts.

### Why are the changes needed?

The current used artifact is not the latest RC3 and will be removed.

- https://repository.apache.org/content/repositories/orgapachespark-1454/

For the record, the latest RC was the following. And, it becomes the official artifact.
- https://repository.apache.org/content/repositories/orgapachespark-1456/ (RC3)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.