### PR TITLE
[SPARK-48528] Refine K8s Operator `merge_spark_pr.py` to use `kubernetes-operator-x.y.z` version

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -305,7 +305,9 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     versions = [
         x
         for x in versions
-        if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)
+        if not x.raw["released"]
+        and not x.raw["archived"]
+        and re.match(r"kubernetes-operator-\d+\.\d+\.\d+", x.name)
     ]
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to refine `merge_spark_pr.py` to use `kubernetes-operator-x.y.z` version like the following.

```
Enter number of user, or userid, to assign to (blank to leave unassigned):0
[<JIRA Version: name='kubernetes-operator-0.1.0', id='12354567'>]
```

### Why are the changes needed?

Previously, it uses Apache Spark's versions like 4.0.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

I manually tested like the following by printing the versions.
```
Enter number of user, or userid, to assign to (blank to leave unassigned):0
[<JIRA Version: name='kubernetes-operator-0.1.0', id='12354567'>]
```

### Was this patch authored or co-authored using generative AI tooling?

No.