### PR TITLE
[SPARK-48606] Upgrade `google-java-format` to 1.22.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ subprojects {
   spotless {
     java {
       endWithNewline()
-      googleJavaFormat('1.17.0')
+      googleJavaFormat('1.22.0')
       importOrder(
         'java',
         'javax',


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `google-java-format` from 1.17.0 to 1.22.0.

### Why are the changes needed?

`google-java-format` plugin of Spark Kubernetes Operator repository is too old and may hit old bugs like the following. The latest version is recommended.
```
java.lang.Exception: google-java-format 1.17.0 is currently being used, but outdated.
google-java-format 1.19.2 is the recommended version, which may have fixed this problem.
google-java-format 1.19.2 requires JVM 11+.
```

Releases:
- https://github.com/google/google-java-format/releases/tag/v1.22.0
- https://github.com/google/google-java-format/releases/tag/v1.21.0
- https://github.com/google/google-java-format/releases/tag/v1.20.0
- https://github.com/google/google-java-format/releases/tag/v1.19.2
- https://github.com/google/google-java-format/releases/tag/v1.19.1
- https://github.com/google/google-java-format/releases/tag/v1.19.0
- https://github.com/google/google-java-format/releases/tag/v1.18.1
- https://github.com/google/google-java-format/releases/tag/v1.18.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No