### PR TITLE
[SPARK-48952] Use `BasePluginExtension` in `spark-operator/build.gradle`

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -53,6 +53,8 @@ shadowJar {
   transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
 }
 
-description = "Spark Kubernetes Operator"
-def artifact = "spark-kubernetes-operator"
-archivesBaseName = artifact
+base {
+  description = "Spark Kubernetes Operator"
+  def artifact = "spark-kubernetes-operator"
+  archivesName = artifact
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `BasePluginExtension` in `spark-operator/build.gradle`.

### Why are the changes needed?

**BEFORE**
```
$ ./gradlew test --warning-mode all

> Configure project :spark-operator
Build file '/Users/dongjoon/APACHE/spark-kubernetes-operator/spark-operator/build.gradle': line 59
The BasePluginExtension.archivesBaseName property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the archivesName property instead. For more information, please refer to https://docs.gradle.org/8.7/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugins.BasePluginExtension:archivesName in the Gradle documentation.
        at build_1pl46tz9v8uzxd6mxgrewtcjs$_run_closure5.doCall$original(/Users/dongjoon/APACHE/spark-kubernetes-operator/spark-operator/build.gradle:59)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_1pl46tz9v8uzxd6mxgrewtcjs.run(/Users/dongjoon/APACHE/spark-kubernetes-operator/spark-operator/build.gradle:56)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD

BUILD SUCCESSFUL in 394ms
13 actionable tasks: 13 up-to-date
```

**AFTER**
```
$ ./gradlew test --warning-mode all

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD

BUILD SUCCESSFUL in 391ms
13 actionable tasks: 13 up-to-date
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and do manual test with `./gradlew test --warning-mode all`.

### Was this patch authored or co-authored using generative AI tooling?

No.