### PR TITLE
[SPARK-48968] Avoid unnecessary task configuration in `spark-operator-api`

### DIFF
--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -27,7 +27,8 @@ test {
 
 // Adds additional printer columns to generated yaml
 // This requires yq
-task finalizeGeneratedCRD(type: Exec, dependsOn: jar) {
+tasks.register('finalizeGeneratedCRD', Exec) {
+  dependsOn jar
   println "Updating PrinterColumns for generated CRD"
   commandLine 'sh', './src/main/resources/printer-columns.sh'
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to avoid unnecessary task configuration in `spark-operator-api`.

### Why are the changes needed?

To follow the Gradle guideline:
- https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.