### PR TITLE
[SPARK-48969] Fix `spark-operator` module to define test framework explicitly

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -32,6 +32,8 @@ dependencies {
   }
   testImplementation platform("org.junit:junit-bom:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
   testImplementation("org.mockito:mockito-core:$mockitoVersion")
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `spark-operator` module to define test framework explicitly.

### Why are the changes needed?

- https://docs.gradle.org/8.9/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

    > If using JUnit 5, an explicit runtimeOnly dependency on junit-platform-launcher is required in addition to the existing implementation dependency on the test engine.

**BEFORE**
```
$ ./gradlew clean test --warning-mode=fail
...
> Task :spark-operator:test
The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.9/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

FAILURE: Build failed with an exception.
...
BUILD FAILED in 6s
16 actionable tasks: 16 executed
```

**AFTER**
```
$ ./gradlew clean test --warning-mode=fail
...
BUILD SUCCESSFUL in 6s
16 actionable tasks: 16 executed
```


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and do the manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.