### PR TITLE
[SPARK-48971] Ban `org.apache.commons.collections` in favor of `collections4`

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -203,6 +203,7 @@
     <module name="IllegalImport">
       <property name="illegalPkgs" value="org.apache.log4j"/>
       <property name="illegalPkgs" value="org.apache.commons.lang"/>
+      <property name="illegalPkgs" value="org.apache.commons.collections"/>
     </module>
   </module>
 </module>

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
   implementation project(":spark-operator-api")
 
-  implementation("org.apache.spark:spark-kubernetes_$scalaVersion:$sparkVersion")
+  implementation("org.apache.spark:spark-kubernetes_$scalaVersion:$sparkVersion") {
+    exclude group: 'commons-collections', module: 'commons-collections'
+  }
 
   compileOnly("org.projectlombok:lombok:$lombokVersion")
   annotationProcessor("org.projectlombok:lombok:$lombokVersion")

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -26,7 +26,7 @@ import scala.Option;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.spark.SparkConf;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `org.apache.commons.collections` in favor of `org.apache.commons.collections4`.

### Why are the changes needed?

Since Apache Spark 3.3.0 (SPARK-37968), Apache Spark uses `collections4` while keeping `org.apache.commons.collections` for Hadoop 3 compatibility (SPARK-38696).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.