### PR TITLE
[SPARK-48382][FOLLOWUP] Use `final` keyword for the applicable variables

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/BaseStatus.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/BaseStatus.java
@@ -34,10 +34,10 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BaseStatus<S, STATE extends BaseState<S>, AS extends BaseAttemptSummary> {
-  @Getter STATE currentState;
-  @Getter SortedMap<Long, STATE> stateTransitionHistory;
-  @Getter AS previousAttemptSummary;
-  @Getter AS currentAttemptSummary;
+  @Getter final STATE currentState;
+  @Getter final SortedMap<Long, STATE> stateTransitionHistory;
+  @Getter final AS previousAttemptSummary;
+  @Getter final AS currentAttemptSummary;
 
   public BaseStatus(STATE initState, AS currentAttemptSummary) {
     this.currentState = initState;

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java
@@ -39,7 +39,7 @@ import org.apache.spark.k8s.operator.utils.ModelUtils;
 @Builder
 @Slf4j
 public class ConfigOption<T> {
-  @Getter @Builder.Default private boolean enableDynamicOverride = true;
+  @Getter @Builder.Default private final boolean enableDynamicOverride = true;
   @Getter private String key;
   @Getter private String description;
   private T defaultValue;

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/MetricsService.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/MetricsService.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MetricsService {
   HttpServer server;
-  MetricsSystem metricsSystem;
+  final MetricsSystem metricsSystem;
 
   public MetricsService(MetricsSystem metricsSystem, Executor executor) {
     this.metricsSystem = metricsSystem;

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptor.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptor.java
@@ -42,7 +42,7 @@ import org.apache.spark.metrics.source.Source;
 
 @Slf4j
 public class KubernetesMetricsInterceptor implements Interceptor, Source {
-  MetricRegistry metricRegistry;
+  final MetricRegistry metricRegistry;
   public static final String NAMESPACES = "namespaces";
   public static final String HTTP_REQUEST_GROUP = "http.request";
   public static final String HTTP_REQUEST_FAILED_GROUP = "failed";

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/LoggingUtils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/LoggingUtils.java
@@ -32,7 +32,7 @@ public class LoggingUtils {
   public static final class TrackedMDC {
     public static final String AppAttemptIdKey = "resource.app.attemptId";
     private final ReentrantLock lock = new ReentrantLock();
-    private Set<String> keys = new HashSet<>();
+    private final Set<String> keys = new HashSet<>();
 
     public void set(final SparkApplication application) {
       if (application != null && application.getStatus() != null) {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/sink/MockSink.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/sink/MockSink.java
@@ -31,8 +31,8 @@ import org.apache.spark.metrics.sink.Sink;
 @SuppressWarnings("PMD")
 public class MockSink implements Sink {
   private static final Logger logger = LoggerFactory.getLogger(MockSink.class);
-  private Properties properties;
-  private MetricRegistry metricRegistry;
+  private final Properties properties;
+  private final MetricRegistry metricRegistry;
   public static final String DEFAULT_UNIT = "SECONDS";
   public static final int DEFAULT_PERIOD = 20;
   public static final String KEY_PERIOD = "period";


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to use `final` keyword for the applicable variables.

- #12

### Why are the changes needed?

To be clear about the semantic of the variables.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.