### PR TITLE
[SPARK-49020] Avoid `raw` type usage

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java
@@ -78,7 +78,7 @@ public class ConfigOption<T> {
     }
   }
 
-  public static Object resolveValueToPrimitiveType(Class clazz, String value) {
+  public static Object resolveValueToPrimitiveType(Class<?> clazz, String value) {
     if (Boolean.class == clazz || Boolean.TYPE == clazz) {
       return Boolean.parseBoolean(value);
     }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/ClassLoadingUtils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/ClassLoadingUtils.java
@@ -47,7 +47,7 @@ public class ClassLoadingUtils {
       try {
         Set<String> listenerNames = Utils.sanitizeCommaSeparatedStrAsSet(implementationClassNames);
         for (String name : listenerNames) {
-          Class listenerClass = Class.forName(name);
+          Class<?> listenerClass = Class.forName(name);
           if (clazz.isAssignableFrom(listenerClass)) {
             listeners.add((T) listenerClass.getConstructor().newInstance());
           }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java
@@ -109,7 +109,7 @@ class SentinelManagerTest {
     Assertions.assertEquals(generation, 1L);
 
     // Spark Reconciler Handle Sentinel Resources at the first time
-    SentinelManager sentinelManager = new SentinelManager<SparkApplication>();
+    var sentinelManager = new SentinelManager<SparkApplication>();
     sentinelManager.handleSentinelResourceReconciliation(sparkApplication, kubernetesClient);
     KubernetesResourceList<SparkApplication> crList2 =
         kubernetesClient.resources(SparkApplication.class).inNamespace(DEFAULT).list();
@@ -119,8 +119,8 @@ class SentinelManagerTest {
 
     Assertions.assertEquals(sparkConf2.get(Constants.SENTINEL_RESOURCE_DUMMY_FIELD), "1");
     Assertions.assertEquals(generation2, 2L);
-    SentinelManager.SentinelResourceState state2 =
-        (SentinelManager.SentinelResourceState)
+    var state2 =
+        (SentinelManager<SparkApplication>.SentinelResourceState)
             sentinelManager.getSentinelResources().get(ResourceID.fromResource(mockApp));
     long previousGeneration2 = state2.previousGeneration;
     Assertions.assertTrue(sentinelManager.allSentinelsAreHealthy());
@@ -137,8 +137,8 @@ class SentinelManagerTest {
     Assertions.assertNotEquals(
         sparkConf2.get(Constants.SENTINEL_RESOURCE_DUMMY_FIELD),
         sparkConf3.get(Constants.SENTINEL_RESOURCE_DUMMY_FIELD));
-    SentinelManager.SentinelResourceState state3 =
-        (SentinelManager.SentinelResourceState)
+    var state3 =
+        (SentinelManager<SparkApplication>.SentinelResourceState)
             sentinelManager.getSentinelResources().get(ResourceID.fromResource(mockApp));
     Assertions.assertEquals(state3.previousGeneration, previousGeneration2);
     // Given the 2 * SENTINEL_RESOURCE_RECONCILIATION_DELAY_SECONDS, the reconcile method is
@@ -168,9 +168,9 @@ class SentinelManagerTest {
     namespaces.add(DEFAULT);
     namespaces.add(SPARK_DEMO);
 
-    try (MockedStatic<Utils> mockUtils = mockStatic(Utils.class)) {
+    try (var mockUtils = mockStatic(Utils.class)) {
       mockUtils.when(Utils::getWatchedNamespaces).thenReturn(namespaces);
-      SentinelManager sentinelManager = new SentinelManager<SparkApplication>();
+      var sentinelManager = new SentinelManager<SparkApplication>();
       NonNamespaceOperation<
               SparkApplication,
               KubernetesResourceList<SparkApplication>,
@@ -187,9 +187,8 @@ class SentinelManagerTest {
       cr1.create(mockApp1);
       cr2.create(mockApp2);
 
-      KubernetesResourceList<SparkApplication> crList1 =
-          kubernetesClient.resources(SparkApplication.class).inNamespace(DEFAULT).list();
-      KubernetesResourceList<SparkApplication> crList2 =
+      var crList1 = kubernetesClient.resources(SparkApplication.class).inNamespace(DEFAULT).list();
+      var crList2 =
           kubernetesClient.resources(SparkApplication.class).inNamespace(SPARK_DEMO).list();
       SparkApplication sparkApplication1 = crList1.getItems().get(0);
       SparkApplication sparkApplication2 = crList2.getItems().get(0);

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
@@ -143,7 +143,7 @@ class HealthProbeTest {
 
   @Test
   void testHealthProbeWithSentinelHealthWithMultiOperators() {
-    SentinelManager sentinelManager = mock(SentinelManager.class);
+    var sentinelManager = mock(SentinelManager.class);
     HealthProbe healthyProbe =
         new HealthProbe(operators, Collections.singletonList(sentinelManager));
     isRunning.set(true);

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ProbeServiceTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ProbeServiceTest.java
@@ -49,7 +49,7 @@ class ProbeServiceTest {
     RuntimeInfo runtimeInfo = mock(RuntimeInfo.class);
     when(operator.getRuntimeInfo()).thenReturn(runtimeInfo);
     when(runtimeInfo.isStarted()).thenReturn(true).thenReturn(true);
-    SentinelManager sentinelManager = mock(SentinelManager.class);
+    var sentinelManager = mock(SentinelManager.class);
     when(runtimeInfo.unhealthyInformerWrappingEventSourceHealthIndicator())
         .thenReturn(new HashMap<>());
     when(sentinelManager.allSentinelsAreHealthy()).thenReturn(true);
@@ -73,7 +73,7 @@ class ProbeServiceTest {
     when(runtimeInfo.isStarted()).thenReturn(true).thenReturn(true);
     when(runtimeInfo1.isStarted()).thenReturn(true).thenReturn(true);
 
-    SentinelManager sentinelManager = mock(SentinelManager.class);
+    var sentinelManager = mock(SentinelManager.class);
     when(runtimeInfo.unhealthyInformerWrappingEventSourceHealthIndicator())
         .thenReturn(new HashMap<>());
     when(runtimeInfo1.unhealthyInformerWrappingEventSourceHealthIndicator())
@@ -99,7 +99,7 @@ class ProbeServiceTest {
     when(runtimeInfo.isStarted()).thenReturn(true).thenReturn(true);
     when(runtimeInfo1.isStarted()).thenReturn(true).thenReturn(true);
 
-    SentinelManager sentinelManager = mock(SentinelManager.class);
+    var sentinelManager = mock(SentinelManager.class);
     KubernetesClient client = mock(KubernetesClient.class);
     when(runtimeInfo.unhealthyInformerWrappingEventSourceHealthIndicator())
         .thenReturn(new HashMap<>());

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
@@ -32,7 +32,6 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.RuntimeInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.apache.spark.k8s.operator.utils.ProbeUtil;
@@ -62,7 +61,7 @@ class ReadinessProbeTest {
     when(sparkConfMonitorRuntimeInfo.isStarted()).thenReturn(true);
     when(sparkConfMonitor.getKubernetesClient()).thenReturn(client);
     ReadinessProbe readinessProbe = new ReadinessProbe(Arrays.asList(operator));
-    try (MockedStatic mockedStatic = Mockito.mockStatic(ProbeUtil.class)) {
+    try (var mockedStatic = Mockito.mockStatic(ProbeUtil.class)) {
       readinessProbe.handle(httpExchange);
       mockedStatic.verify(() -> ProbeUtil.sendMessage(httpExchange, 200, "started"));
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to avoid `raw` type usage.

- https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html
> A raw type is the name of a generic class or interface without any type arguments.

### Why are the changes needed?

We need to use use generic types like the following.

```java
- Class listenerClass = Class.forName(name);
+ Class<?> listenerClass = Class.forName(name);
```

```java
- public static Object resolveValueToPrimitiveType(Class clazz, String value) {
+ public static Object resolveValueToPrimitiveType(Class<?> clazz, String value) {
```

Or, we can use `var` syntax like the following.

```java
- SentinelManager sentinelManager = new SentinelManager<SparkApplication>();
+ var sentinelManager = new SentinelManager<SparkApplication>();
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.