### PR TITLE
[SPARK-49036] Exclude `JUnitAssertionsShouldIncludeMessage/JUnitTestContainsTooManyAsserts` PMD rules and simplify test code

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -21,13 +21,12 @@
   <description>
     Spark Operator Ruleset
   </description>
-  <rule ref="category/java/bestpractices.xml"/>
+  <rule ref="category/java/bestpractices.xml">
+    <exclude name="JUnitAssertionsShouldIncludeMessage" />
+    <exclude name="JUnitTestContainsTooManyAsserts" />
+  </rule>
   <rule ref="category/java/security.xml"/>
   <rule ref="rulesets/java/basic.xml"/>
-  <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
-    <properties>
-      <property name="maximumAsserts" value="10"/>
-    </properties>
-  </rule><!-- exclude on generated files -->
+  <!-- exclude on generated files -->
   <exclude-pattern>.*/src/generated/.*</exclude-pattern>
 </ruleset>

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/RestartPolicyTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/RestartPolicyTest.java
@@ -28,8 +28,9 @@ import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Drive
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.ExecutorsStartTimedOut;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Failed;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Succeeded;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.k8s.operator.status.ApplicationStateSummary;
@@ -39,24 +40,24 @@ class RestartPolicyTest {
   @Test
   void testAttemptRestartOnState() {
     for (ApplicationStateSummary stateSummary : ApplicationStateSummary.values()) {
-      Assertions.assertTrue(attemptRestartOnState(RestartPolicy.Always, stateSummary));
-      Assertions.assertFalse(attemptRestartOnState(RestartPolicy.Never, stateSummary));
+      assertTrue(attemptRestartOnState(RestartPolicy.Always, stateSummary));
+      assertFalse(attemptRestartOnState(RestartPolicy.Never, stateSummary));
       if (!stateSummary.isStopping()) {
-        Assertions.assertFalse(attemptRestartOnState(OnFailure, stateSummary));
-        Assertions.assertFalse(attemptRestartOnState(OnInfrastructureFailure, stateSummary));
+        assertFalse(attemptRestartOnState(OnFailure, stateSummary));
+        assertFalse(attemptRestartOnState(OnInfrastructureFailure, stateSummary));
       }
     }
-    Assertions.assertFalse(attemptRestartOnState(OnFailure, Succeeded));
-    Assertions.assertFalse(attemptRestartOnState(OnInfrastructureFailure, Succeeded));
-    Assertions.assertTrue(attemptRestartOnState(OnFailure, Failed));
-    Assertions.assertFalse(attemptRestartOnState(OnInfrastructureFailure, Failed));
-    Assertions.assertTrue(attemptRestartOnState(OnFailure, DriverStartTimedOut));
-    Assertions.assertTrue(attemptRestartOnState(OnInfrastructureFailure, DriverStartTimedOut));
-    Assertions.assertTrue(attemptRestartOnState(OnFailure, DriverReadyTimedOut));
-    Assertions.assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverReadyTimedOut));
-    Assertions.assertTrue(attemptRestartOnState(OnFailure, DriverEvicted));
-    Assertions.assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverEvicted));
-    Assertions.assertTrue(attemptRestartOnState(OnFailure, ExecutorsStartTimedOut));
-    Assertions.assertTrue(attemptRestartOnState(OnInfrastructureFailure, ExecutorsStartTimedOut));
+    assertFalse(attemptRestartOnState(OnFailure, Succeeded));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, Succeeded));
+    assertTrue(attemptRestartOnState(OnFailure, Failed));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, Failed));
+    assertTrue(attemptRestartOnState(OnFailure, DriverStartTimedOut));
+    assertTrue(attemptRestartOnState(OnInfrastructureFailure, DriverStartTimedOut));
+    assertTrue(attemptRestartOnState(OnFailure, DriverReadyTimedOut));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverReadyTimedOut));
+    assertTrue(attemptRestartOnState(OnFailure, DriverEvicted));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverEvicted));
+    assertTrue(attemptRestartOnState(OnFailure, ExecutorsStartTimedOut));
+    assertTrue(attemptRestartOnState(OnInfrastructureFailure, ExecutorsStartTimedOut));
   }
 }

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/status/ApplicationStatusTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/status/ApplicationStatusTest.java
@@ -21,8 +21,10 @@ package org.apache.spark.k8s.operator.status;
 
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Submitted;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Succeeded;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.k8s.operator.spec.ResourceRetainPolicy;
@@ -34,9 +36,9 @@ class ApplicationStatusTest {
   @Test
   void testInitStatus() {
     ApplicationStatus applicationStatus = new ApplicationStatus();
-    Assertions.assertEquals(Submitted, applicationStatus.currentState.currentStateSummary);
-    Assertions.assertEquals(1, applicationStatus.getStateTransitionHistory().size());
-    Assertions.assertEquals(
+    assertEquals(Submitted, applicationStatus.currentState.currentStateSummary);
+    assertEquals(1, applicationStatus.getStateTransitionHistory().size());
+    assertEquals(
         applicationStatus.currentState, applicationStatus.getStateTransitionHistory().get(0L));
   }
 
@@ -45,8 +47,8 @@ class ApplicationStatusTest {
     ApplicationStatus applicationStatus = new ApplicationStatus();
     ApplicationState newState = new ApplicationState(ApplicationStateSummary.RunningHealthy, "foo");
     ApplicationStatus newStatus = applicationStatus.appendNewState(newState);
-    Assertions.assertEquals(2, newStatus.getStateTransitionHistory().size());
-    Assertions.assertEquals(newState, newStatus.getStateTransitionHistory().get(1L));
+    assertEquals(2, newStatus.getStateTransitionHistory().size());
+    assertEquals(newState, newStatus.getStateTransitionHistory().get(1L));
   }
 
   @Test
@@ -61,23 +63,23 @@ class ApplicationStatusTest {
     ApplicationStatus updatedStatusReleaseResource =
         status.terminateOrRestart(
             noRetryConfig, ResourceRetainPolicy.Never, messageOverride, false);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.ResourceReleased,
         updatedStatusReleaseResource.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
+    assertTrue(
         updatedStatusReleaseResource.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
+    assertEquals(
         0L, updatedStatusReleaseResource.getCurrentAttemptSummary().getAttemptInfo().getId());
 
     ApplicationStatus updatedStatusRetainResource =
         status.terminateOrRestart(
             noRetryConfig, ResourceRetainPolicy.Always, messageOverride, false);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.TerminatedWithoutReleaseResources,
         updatedStatusRetainResource.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
+    assertTrue(
         updatedStatusRetainResource.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
+    assertEquals(
         0L, updatedStatusRetainResource.getCurrentAttemptSummary().getAttemptInfo().getId());
   }
 
@@ -95,56 +97,49 @@ class ApplicationStatusTest {
     ApplicationStatus restartReleaseResource =
         status.terminateOrRestart(
             alwaysRetryConfig, ResourceRetainPolicy.Never, messageOverride, false);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.ScheduledToRestart,
         restartReleaseResource.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
-        restartReleaseResource.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
-        1L, restartReleaseResource.getCurrentAttemptSummary().getAttemptInfo().getId());
+    assertTrue(restartReleaseResource.getCurrentState().getMessage().contains(messageOverride));
+    assertEquals(1L, restartReleaseResource.getCurrentAttemptSummary().getAttemptInfo().getId());
 
     ApplicationStatus restartRetainResource =
         status.terminateOrRestart(
             alwaysRetryConfig, ResourceRetainPolicy.Always, messageOverride, false);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.ScheduledToRestart,
         restartRetainResource.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
-        restartRetainResource.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
-        1L, restartRetainResource.getCurrentAttemptSummary().getAttemptInfo().getId());
+    assertTrue(restartRetainResource.getCurrentState().getMessage().contains(messageOverride));
+    assertEquals(1L, restartRetainResource.getCurrentAttemptSummary().getAttemptInfo().getId());
 
     // trim state history for new restart
     ApplicationStatus restartTrimHistory =
         status.terminateOrRestart(
             alwaysRetryConfig, ResourceRetainPolicy.Never, messageOverride, true);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.ScheduledToRestart,
         restartTrimHistory.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
-        restartTrimHistory.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
-        1L, restartTrimHistory.getCurrentAttemptSummary().getAttemptInfo().getId());
-    Assertions.assertEquals(1L, restartTrimHistory.getStateTransitionHistory().size());
-    Assertions.assertNotNull(
-        restartTrimHistory.getPreviousAttemptSummary().getStateTransitionHistory());
-    Assertions.assertEquals(
+    assertTrue(restartTrimHistory.getCurrentState().getMessage().contains(messageOverride));
+    assertEquals(1L, restartTrimHistory.getCurrentAttemptSummary().getAttemptInfo().getId());
+    assertEquals(1L, restartTrimHistory.getStateTransitionHistory().size());
+    assertNotNull(restartTrimHistory.getPreviousAttemptSummary().getStateTransitionHistory());
+    assertEquals(
         status.getStateTransitionHistory(),
         restartTrimHistory.getPreviousAttemptSummary().getStateTransitionHistory());
 
     ApplicationStatus restartRetainResourceTrimHistory =
         status.terminateOrRestart(
             alwaysRetryConfig, ResourceRetainPolicy.Always, messageOverride, true);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.ScheduledToRestart,
         restartRetainResourceTrimHistory.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
+    assertTrue(
         restartRetainResourceTrimHistory.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
+    assertEquals(
         1L, restartRetainResourceTrimHistory.getCurrentAttemptSummary().getAttemptInfo().getId());
-    Assertions.assertNotNull(
+    assertNotNull(
         restartRetainResourceTrimHistory.getPreviousAttemptSummary().getStateTransitionHistory());
-    Assertions.assertEquals(
+    assertEquals(
         status.getStateTransitionHistory(),
         restartRetainResourceTrimHistory.getPreviousAttemptSummary().getStateTransitionHistory());
 
@@ -156,23 +151,23 @@ class ApplicationStatusTest {
     ApplicationStatus maxRestartExceededReleaseResource =
         restartFailed.terminateOrRestart(
             alwaysRetryConfig, ResourceRetainPolicy.Never, messageOverride, false);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.ResourceReleased,
         maxRestartExceededReleaseResource.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
+    assertTrue(
         maxRestartExceededReleaseResource.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
+    assertEquals(
         1L, maxRestartExceededReleaseResource.getCurrentAttemptSummary().getAttemptInfo().getId());
 
     ApplicationStatus maxRestartExceededRetainResource =
         restartFailed.terminateOrRestart(
             alwaysRetryConfig, ResourceRetainPolicy.Always, messageOverride, false);
-    Assertions.assertEquals(
+    assertEquals(
         ApplicationStateSummary.TerminatedWithoutReleaseResources,
         maxRestartExceededRetainResource.getCurrentState().getCurrentStateSummary());
-    Assertions.assertTrue(
+    assertTrue(
         maxRestartExceededRetainResource.getCurrentState().getMessage().contains(messageOverride));
-    Assertions.assertEquals(
+    assertEquals(
         1L, maxRestartExceededRetainResource.getCurrentAttemptSummary().getAttemptInfo().getId());
   }
 }

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/utils/ModelUtilsTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/utils/ModelUtilsTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.spark.k8s.operator.utils;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,28 +100,28 @@ class ModelUtilsTest {
   @Test
   void testOverrideDriverTemplateEnabled() {
     ApplicationSpec applicationSpec = new ApplicationSpec();
-    Assertions.assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
+    assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
 
     BaseApplicationTemplateSpec driverSpec = new BaseApplicationTemplateSpec();
     applicationSpec.setDriverSpec(driverSpec);
-    Assertions.assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
+    assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
 
     driverSpec.setPodTemplateSpec(buildSamplePodTemplateSpec());
     applicationSpec.setDriverSpec(driverSpec);
-    Assertions.assertTrue(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
+    assertTrue(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
   }
 
   @Test
   void testOverrideExecutorTemplateEnabled() {
     ApplicationSpec applicationSpec = new ApplicationSpec();
-    Assertions.assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
+    assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
 
     BaseApplicationTemplateSpec executorSpec = new BaseApplicationTemplateSpec();
     applicationSpec.setExecutorSpec(executorSpec);
-    Assertions.assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
+    assertFalse(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
 
     executorSpec.setPodTemplateSpec(buildSamplePodTemplateSpec());
     applicationSpec.setDriverSpec(executorSpec);
-    Assertions.assertTrue(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
+    assertTrue(ModelUtils.overrideDriverTemplateEnabled(applicationSpec));
   }
 }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/MetricsSystemTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/MetricsSystemTest.java
@@ -19,12 +19,15 @@
 
 package org.apache.spark.k8s.operator.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.k8s.operator.metrics.sink.MockSink;
@@ -38,12 +41,12 @@ class MetricsSystemTest {
     Set<Source> sourcesList = metricsSystem.getSources();
     Set<Sink> sinks = metricsSystem.getSinks();
     metricsSystem.start();
-    Assertions.assertEquals(1, sourcesList.size());
+    assertEquals(1, sourcesList.size());
     // By default, only prometheus sink is enabled
-    Assertions.assertEquals(1, sinks.size());
-    Assertions.assertFalse(metricsSystem.getRegistry().getMetrics().isEmpty());
+    assertEquals(1, sinks.size());
+    assertFalse(metricsSystem.getRegistry().getMetrics().isEmpty());
     metricsSystem.stop();
-    Assertions.assertTrue(metricsSystem.getRegistry().getMetrics().isEmpty());
+    assertTrue(metricsSystem.getRegistry().getMetrics().isEmpty());
   }
 
   @Test
@@ -53,15 +56,15 @@ class MetricsSystemTest {
     properties.put("sink.mocksink.period", "10");
     MetricsSystem metricsSystem = new MetricsSystem(properties);
     metricsSystem.start();
-    Assertions.assertEquals(2, metricsSystem.getSinks().size());
+    assertEquals(2, metricsSystem.getSinks().size());
     Optional<Sink> mockSinkOptional =
         metricsSystem.getSinks().stream().filter(sink -> sink instanceof MockSink).findFirst();
-    Assertions.assertTrue(mockSinkOptional.isPresent());
+    assertTrue(mockSinkOptional.isPresent());
     Sink mockSink = mockSinkOptional.get();
     metricsSystem.stop();
     MockSink sink = (MockSink) mockSink;
-    Assertions.assertEquals(sink.getPollPeriod(), 10);
-    Assertions.assertEquals(sink.getTimeUnit(), TimeUnit.SECONDS);
+    assertEquals(sink.getPollPeriod(), 10);
+    assertEquals(sink.getTimeUnit(), TimeUnit.SECONDS);
   }
 
   @Test
@@ -72,6 +75,6 @@ class MetricsSystemTest {
     properties.put("sink.console.class", "org.apache.spark.metrics.sink.ConsoleSink");
     MetricsSystem metricsSystem = new MetricsSystem(properties);
     metricsSystem.start();
-    Assertions.assertEquals(3, metricsSystem.getSinks().size());
+    assertEquals(3, metricsSystem.getSinks().size());
   }
 }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetricsTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetricsTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.spark.k8s.operator.metrics.source;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Map;
 
 import com.codahale.metrics.Metric;
@@ -32,7 +35,6 @@ import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceAction;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,30 +65,26 @@ class OperatorJosdkMetricsTest {
     TestingExecutionBase<SparkApplication> successExecution = new TestingExecutionBase<>();
     operatorMetrics.timeControllerExecution(successExecution);
     Map<String, Metric> metrics = operatorMetrics.metricRegistry().getMetrics();
-    Assertions.assertEquals(4, metrics.size());
-    Assertions.assertTrue(metrics.containsKey("sparkapplication.test-controller.reconcile.both"));
-    Assertions.assertTrue(
-        metrics.containsKey("sparkapplication.testns.test-controller.reconcile.both"));
-    Assertions.assertTrue(
-        metrics.containsKey("sparkapplication.test-controller.reconcile.success.both"));
-    Assertions.assertTrue(
+    assertEquals(4, metrics.size());
+    assertTrue(metrics.containsKey("sparkapplication.test-controller.reconcile.both"));
+    assertTrue(metrics.containsKey("sparkapplication.testns.test-controller.reconcile.both"));
+    assertTrue(metrics.containsKey("sparkapplication.test-controller.reconcile.success.both"));
+    assertTrue(
         metrics.containsKey("sparkapplication.testns.test-controller.reconcile.success.both"));
 
     FooTestingExecutionBase<SparkApplication> failedExecution = new FooTestingExecutionBase<>();
     try {
       operatorMetrics.timeControllerExecution(failedExecution);
     } catch (Exception e) {
-      Assertions.assertEquals(e.getMessage(), "Foo exception");
-      Assertions.assertEquals(8, metrics.size());
-      Assertions.assertTrue(
-          metrics.containsKey("sparkapplication.test-controller.reconcile.failure"));
-      Assertions.assertTrue(
+      assertEquals(e.getMessage(), "Foo exception");
+      assertEquals(8, metrics.size());
+      assertTrue(metrics.containsKey("sparkapplication.test-controller.reconcile.failure"));
+      assertTrue(
           metrics.containsKey(
               "sparkapplication.test-controller.reconcile.failure.exception"
                   + ".nosuchfieldexception"));
-      Assertions.assertTrue(
-          metrics.containsKey("sparkapplication.testns.test-controller.reconcile.failure"));
-      Assertions.assertTrue(
+      assertTrue(metrics.containsKey("sparkapplication.testns.test-controller.reconcile.failure"));
+      assertTrue(
           metrics.containsKey(
               "sparkapplication.testns.test-controller.reconcile.failure."
                   + "exception.nosuchfieldexception"));
@@ -97,24 +95,22 @@ class OperatorJosdkMetricsTest {
   void testReconciliationFinished() {
     operatorMetrics.finishedReconciliation(buildNamespacedResource(), metadata);
     Map<String, Metric> metrics = operatorMetrics.metricRegistry().getMetrics();
-    Assertions.assertEquals(2, metrics.size());
-    Assertions.assertTrue(metrics.containsKey("configmap.default.reconciliation.finished"));
-    Assertions.assertTrue(metrics.containsKey("configmap.reconciliation.finished"));
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.containsKey("configmap.default.reconciliation.finished"));
+    assertTrue(metrics.containsKey("configmap.reconciliation.finished"));
   }
 
   @Test
   void testReconciliationExecutionStartedAndFinished() {
     operatorMetrics.reconciliationExecutionStarted(buildNamespacedResource(), metadata);
     Map<String, Metric> metrics = operatorMetrics.metricRegistry().getMetrics();
-    Assertions.assertEquals(2, metrics.size());
-    Assertions.assertTrue(
-        metrics.containsKey("configmap.test-controller-name.reconciliations.executions"));
-    Assertions.assertTrue(
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.containsKey("configmap.test-controller-name.reconciliations.executions"));
+    assertTrue(
         metrics.containsKey("configmap.default.test-controller-name.reconciliations.executions"));
     operatorMetrics.reconciliationExecutionFinished(buildNamespacedResource(), metadata);
-    Assertions.assertEquals(3, metrics.size());
-    Assertions.assertTrue(
-        metrics.containsKey("configmap.test-controller-name.reconciliations.queue.size"));
+    assertEquals(3, metrics.size());
+    assertTrue(metrics.containsKey("configmap.test-controller-name.reconciliations.queue.size"));
   }
 
   @Test
@@ -122,9 +118,9 @@ class OperatorJosdkMetricsTest {
     Event event = new ResourceEvent(ResourceAction.ADDED, resourceId, buildNamespacedResource());
     operatorMetrics.receivedEvent(event, metadata);
     Map<String, Metric> metrics = operatorMetrics.metricRegistry().getMetrics();
-    Assertions.assertEquals(2, metrics.size());
-    Assertions.assertTrue(metrics.containsKey("sparkapplication.added.resource.event"));
-    Assertions.assertTrue(metrics.containsKey("sparkapplication.testns.added.resource.event"));
+    assertEquals(2, metrics.size());
+    assertTrue(metrics.containsKey("sparkapplication.added.resource.event"));
+    assertTrue(metrics.containsKey("sparkapplication.testns.added.resource.event"));
   }
 
   private static class TestingExecutionBase<T> implements Metrics.ControllerExecution<T> {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconcilerTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.spark.k8s.operator.reconciler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -33,7 +36,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
@@ -102,15 +104,15 @@ class SparkAppReconcilerTest {
           app.getStatus()
               .appendNewState(new ApplicationState(ApplicationStateSummary.RunningHealthy, "")));
       DeleteControl deleteControl = reconciler.cleanup(app, mockContext);
-      Assertions.assertFalse(deleteControl.isRemoveFinalizer());
+      assertFalse(deleteControl.isRemoveFinalizer());
       utils.verify(() -> ReconcilerUtils.deleteResourceIfExists(mockClient, mockDriver, false));
-      Assertions.assertEquals(
+      assertEquals(
           ApplicationStateSummary.ResourceReleased,
           app.getStatus().getCurrentState().getCurrentStateSummary());
 
       // proceed delete for terminated app
       deleteControl = reconciler.cleanup(app, mockContext);
-      Assertions.assertTrue(deleteControl.isRemoveFinalizer());
+      assertTrue(deleteControl.isRemoveFinalizer());
     }
   }
 }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppResourceSpecFactoryTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppResourceSpecFactoryTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.spark.k8s.operator.reconciler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -31,7 +33,6 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -58,15 +59,15 @@ class SparkAppResourceSpecFactoryTest {
         SparkAppResourceSpecFactory.buildResourceSpec(app, mockClient, mockWorker);
     verify(mockWorker).getResourceSpec(eq(app), eq(mockClient), any());
     Map<String, String> props = captor.getValue();
-    Assertions.assertTrue(props.containsKey("spark.kubernetes.namespace"));
-    Assertions.assertEquals("foo", props.get("spark.kubernetes.namespace"));
+    assertTrue(props.containsKey("spark.kubernetes.namespace"));
+    assertEquals("foo", props.get("spark.kubernetes.namespace"));
     ArgumentCaptor<ObjectMeta> metaArgumentCaptor = ArgumentCaptor.forClass(ObjectMeta.class);
     verify(mockDriver).setMetadata(metaArgumentCaptor.capture());
-    Assertions.assertEquals(mockSpec, spec);
+    assertEquals(mockSpec, spec);
     ObjectMeta metaOverride = metaArgumentCaptor.getValue();
-    Assertions.assertEquals(1, metaOverride.getOwnerReferences().size());
-    Assertions.assertEquals("bar-app", metaOverride.getOwnerReferences().get(0).getName());
-    Assertions.assertEquals("uid", metaOverride.getOwnerReferences().get(0).getUid());
-    Assertions.assertEquals(app.getKind(), metaOverride.getOwnerReferences().get(0).getKind());
+    assertEquals(1, metaOverride.getOwnerReferences().size());
+    assertEquals("bar-app", metaOverride.getOwnerReferences().get(0).getName());
+    assertEquals("uid", metaOverride.getOwnerReferences().get(0).getUid());
+    assertEquals(app.getKind(), metaOverride.getOwnerReferences().get(0).getKind());
   }
 }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppCleanUpStepTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppCleanUpStepTest.java
@@ -19,11 +19,10 @@
 
 package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.k8s.operator.SparkApplication;
@@ -40,6 +39,6 @@ class AppCleanUpStepTest {
         .getApplicationTolerations()
         .getApplicationTimeoutConfig()
         .setForceTerminationGracePeriodMillis(3000L);
-    Assertions.assertTrue(appCleanUpStep.enableForceDelete(app));
+    assertTrue(appCleanUpStep.enableForceDelete(app));
   }
 }

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
@@ -20,6 +20,10 @@
 package org.apache.spark.k8s.operator;
 
 import static org.apache.spark.k8s.operator.SparkAppSubmissionWorker.DEFAULT_ID_LENGTH_LIMIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
@@ -33,7 +37,6 @@ import java.util.Map;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 
@@ -73,31 +76,31 @@ class SparkAppSubmissionWorkerTest {
 
       SparkAppSubmissionWorker submissionWorker = new SparkAppSubmissionWorker();
       SparkAppDriverConf conf = submissionWorker.buildDriverConf(mockApp, overrides);
-      Assertions.assertEquals(6, constructorArgs.get(conf).size());
+      assertEquals(6, constructorArgs.get(conf).size());
 
       // validate SparkConf with override
-      Assertions.assertTrue(constructorArgs.get(conf).get(0) instanceof SparkConf);
+      assertTrue(constructorArgs.get(conf).get(0) instanceof SparkConf);
       SparkConf createdConf = (SparkConf) constructorArgs.get(conf).get(0);
-      Assertions.assertEquals("bar", createdConf.get("foo"));
-      Assertions.assertEquals("5", createdConf.get("spark.executor.instances"));
+      assertEquals("bar", createdConf.get("foo"));
+      assertEquals("5", createdConf.get("spark.executor.instances"));
 
-      Assertions.assertEquals(
+      assertEquals(
           "ns1",
           createdConf.get("spark.kubernetes.namespace"),
           "namespace from CR takes highest precedence");
 
       // validate main resources
-      Assertions.assertTrue(constructorArgs.get(conf).get(2) instanceof JavaMainAppResource);
+      assertTrue(constructorArgs.get(conf).get(2) instanceof JavaMainAppResource);
       JavaMainAppResource mainResource = (JavaMainAppResource) constructorArgs.get(conf).get(2);
-      Assertions.assertTrue(mainResource.primaryResource().isEmpty());
+      assertTrue(mainResource.primaryResource().isEmpty());
 
-      Assertions.assertEquals("foo-class", constructorArgs.get(conf).get(3));
+      assertEquals("foo-class", constructorArgs.get(conf).get(3));
 
-      Assertions.assertTrue(constructorArgs.get(conf).get(4) instanceof String[]);
+      assertTrue(constructorArgs.get(conf).get(4) instanceof String[]);
       String[] capturedArgs = (String[]) constructorArgs.get(conf).get(4);
-      Assertions.assertEquals(2, capturedArgs.length);
-      Assertions.assertEquals("a", capturedArgs[0]);
-      Assertions.assertEquals("b", capturedArgs[1]);
+      assertEquals(2, capturedArgs.length);
+      assertEquals("a", capturedArgs[0]);
+      assertEquals("b", capturedArgs[1]);
     }
   }
 
@@ -117,12 +120,12 @@ class SparkAppSubmissionWorkerTest {
 
       SparkAppSubmissionWorker submissionWorker = new SparkAppSubmissionWorker();
       SparkAppDriverConf conf = submissionWorker.buildDriverConf(mockApp, Collections.emptyMap());
-      Assertions.assertEquals(6, constructorArgs.get(conf).size());
+      assertEquals(6, constructorArgs.get(conf).size());
 
       // validate main resources
-      Assertions.assertTrue(constructorArgs.get(conf).get(2) instanceof PythonMainAppResource);
+      assertInstanceOf(PythonMainAppResource.class, constructorArgs.get(conf).get(2));
       PythonMainAppResource mainResource = (PythonMainAppResource) constructorArgs.get(conf).get(2);
-      Assertions.assertEquals("foo", mainResource.primaryResource());
+      assertEquals("foo", mainResource.primaryResource());
     }
   }
 
@@ -142,12 +145,12 @@ class SparkAppSubmissionWorkerTest {
 
       SparkAppSubmissionWorker submissionWorker = new SparkAppSubmissionWorker();
       SparkAppDriverConf conf = submissionWorker.buildDriverConf(mockApp, Collections.emptyMap());
-      Assertions.assertEquals(6, constructorArgs.get(conf).size());
+      assertEquals(6, constructorArgs.get(conf).size());
 
       // validate main resources
-      Assertions.assertTrue(constructorArgs.get(conf).get(2) instanceof RMainAppResource);
+      assertInstanceOf(RMainAppResource.class, constructorArgs.get(conf).get(2));
       RMainAppResource mainResource = (RMainAppResource) constructorArgs.get(conf).get(2);
-      Assertions.assertEquals("foo", mainResource.primaryResource());
+      assertEquals("foo", mainResource.primaryResource());
     }
   }
 
@@ -169,16 +172,16 @@ class SparkAppSubmissionWorkerTest {
     String appId1 = SparkAppSubmissionWorker.generateSparkAppId(mockApp1);
     String appId2 = SparkAppSubmissionWorker.generateSparkAppId(mockApp2);
 
-    Assertions.assertNotEquals(appId1, appId2);
-    Assertions.assertTrue(appId1.contains(appName1));
-    Assertions.assertTrue(appId1.length() <= DEFAULT_ID_LENGTH_LIMIT);
-    Assertions.assertTrue(appId2.length() <= DEFAULT_ID_LENGTH_LIMIT);
+    assertNotEquals(appId1, appId2);
+    assertTrue(appId1.contains(appName1));
+    assertTrue(appId1.length() <= DEFAULT_ID_LENGTH_LIMIT);
+    assertTrue(appId2.length() <= DEFAULT_ID_LENGTH_LIMIT);
     // multiple invoke shall give same result
-    Assertions.assertEquals(
+    assertEquals(
         appId1,
         SparkAppSubmissionWorker.generateSparkAppId(mockApp1),
         "Multiple invoke of generateSparkAppId shall give same result.");
-    Assertions.assertEquals(
+    assertEquals(
         appId2,
         SparkAppSubmissionWorker.generateSparkAppId(mockApp2),
         "Multiple invoke of generateSparkAppId shall give same result.");
@@ -191,16 +194,16 @@ class SparkAppSubmissionWorkerTest {
     when(mockStatus2.getCurrentAttemptSummary()).thenReturn(mockAttempt);
 
     String appId1Attempt2 = SparkAppSubmissionWorker.generateSparkAppId(mockApp1);
-    Assertions.assertTrue(appId1Attempt2.contains(appName1));
-    Assertions.assertNotEquals(appId1, appId1Attempt2);
-    Assertions.assertTrue(appId1Attempt2.length() <= DEFAULT_ID_LENGTH_LIMIT);
+    assertTrue(appId1Attempt2.contains(appName1));
+    assertNotEquals(appId1, appId1Attempt2);
+    assertTrue(appId1Attempt2.length() <= DEFAULT_ID_LENGTH_LIMIT);
 
     String appId2Attempt2 = SparkAppSubmissionWorker.generateSparkAppId(mockApp2);
-    Assertions.assertNotEquals(appId2, appId2Attempt2);
-    Assertions.assertEquals(appId2Attempt2, SparkAppSubmissionWorker.generateSparkAppId(mockApp2));
-    Assertions.assertTrue(appId2Attempt2.length() <= DEFAULT_ID_LENGTH_LIMIT);
+    assertNotEquals(appId2, appId2Attempt2);
+    assertEquals(appId2Attempt2, SparkAppSubmissionWorker.generateSparkAppId(mockApp2));
+    assertTrue(appId2Attempt2.length() <= DEFAULT_ID_LENGTH_LIMIT);
 
-    Assertions.assertEquals(appId1Attempt2, SparkAppSubmissionWorker.generateSparkAppId(mockApp1));
+    assertEquals(appId1Attempt2, SparkAppSubmissionWorker.generateSparkAppId(mockApp1));
   }
 
   @Test
@@ -213,6 +216,6 @@ class SparkAppSubmissionWorkerTest {
         new ObjectMetaBuilder().withName(appName).withNamespace(namespaceName).build();
     when(mockApp.getMetadata()).thenReturn(appMeta);
     String appId = SparkAppSubmissionWorker.generateSparkAppId(mockApp);
-    Assertions.assertTrue(appId.length() <= DEFAULT_ID_LENGTH_LIMIT);
+    assertTrue(appId.length() <= DEFAULT_ID_LENGTH_LIMIT);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, `PMD Source Code Analyzer` fails to detect our test code issues.

This PR aims to simplify assertion test code like the following desirable patterns for better source code analysis.
1. Use better assertion method
```java
- Assertions.assertTrue(constructorArgs.get(conf).get(2) instanceof PythonMainAppResource);
+ assertInstanceOf(PythonMainAppResource.class, constructorArgs.get(conf).get(2));
```

2. Avoid repeating `Assertions.` in the test code by using static import statements to help PMD analyze the code easily
```java
- Assertions.assertEquals(generation, 1L);
+ assertEquals(generation, 1L);
```

In addition, according to the existing written test code, we need to exclude the following two rules because we have many rule violation already.
-  `JUnitAssertionsShouldIncludeMessage`
- `JUnitTestContainsTooManyAsserts`

### Why are the changes needed?

To keep the test code in a simple and uniform form via PMC Source Code Analyzer.
- The existing pattern, `Assertions.*` was not covered by PMC Source Code Analyzer properly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.