### PR TITLE
[SPARK-49129] Fix `ENTRYPOINT` to point `/opt/spark-operator/operator/docker-entrypoint.sh`

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -42,5 +42,5 @@ RUN chown -R spark:spark $SPARK_OPERATOR_HOME && \
     chown spark:spark docker-entrypoint.sh
 
 USER spark
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/opt/spark-operator/operator/docker-entrypoint.sh"]
 CMD ["help"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ENTRYPOINT` to point `/opt/spark-operator/operator/docker-entrypoint.sh`

### Why are the changes needed?

**BEFORE**
```
$ docker run -it spark-kubernetes-operator:0.1.0
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/docker-entrypoint.sh": stat /docker-entrypoint.sh: no such file or directory: unknown.
```

**AFTER**
```
$ docker run -it spark-kubernetes-operator:0.1.0
Usage: docker-entrypoint.sh (operator)
    Or docker-entrypoint.sh help
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because we don't have a CI test coverage for this.
```
$ docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
$ docker run -it spark-kubernetes-operator:0.1.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.
