### PR TITLE
[SPARK-49132] Minimize docker image by removing redundant `chown` commands

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -30,16 +30,13 @@ ENV APP_VERSION=$APP_VERSION
 ENV OPERATOR_JAR=spark-kubernetes-operator-$APP_VERSION-all.jar
 
 WORKDIR $SPARK_OPERATOR_WORK_DIR
-
 RUN groupadd --system --gid=$SPARK_UID spark && \
-    useradd --system --home-dir $SPARK_OPERATOR_HOME --uid=$SPARK_UID --gid=spark spark
+    useradd --system --home-dir $SPARK_OPERATOR_HOME --uid=$SPARK_UID --gid=spark spark && \
+    chown -R spark:spark $SPARK_OPERATOR_HOME
 
-COPY --from=builder /app/spark-operator/build/libs/$OPERATOR_JAR .
-COPY --from=builder /app/build-tools/docker/docker-entrypoint.sh .
+COPY --from=builder --chown=spark:spark /app/spark-operator/build/libs/$OPERATOR_JAR .
+COPY --from=builder --chown=spark:spark /app/build-tools/docker/docker-entrypoint.sh .
 
-RUN chown -R spark:spark $SPARK_OPERATOR_HOME && \
-    chown spark:spark $OPERATOR_JAR && \
-    chown spark:spark docker-entrypoint.sh
 
 USER spark
 ENTRYPOINT ["/opt/spark-operator/operator/docker-entrypoint.sh"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to minimize docker image from `892MB` to `654MB` by removing redundant `chown` commands.

### Why are the changes needed?

**BEFORE**
```
$ docker images spark-kubernetes-operator
REPOSITORY                        TAG                 IMAGE ID       CREATED             SIZE
spark-kubernetes-operator         0.1.0               ff9288592e36   3 minutes ago       892MB
```

**AFTER**
```
$ docker images spark-kubernetes-operator
REPOSITORY                  TAG       IMAGE ID       CREATED         SIZE
spark-kubernetes-operator   0.1.0     4e405928e3ce   3 minutes ago   654MB
```

### Does this PR introduce _any_ user-facing change?

No because this is not released yet.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.