### PR TITLE
[SPARK-49144] Use the latest `setup-java` v4 with `cache` feature

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,13 +36,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Build with Gradle
         run: |
-          set -o pipefail; ./gradlew build; set +o pipefail
+          ./gradlew build
   build-image:
     name: "Build Operator Image CI"
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `setup-java` from `v2` to `v4` with `cache` feature for `Gradle`

- https://github.com/actions/setup-java/blob/main/README.md#caching-packages-dependencies

### Why are the changes needed?

So far, our CI has no dependency cache.

### Does this PR introduce _any_ user-facing change?

No, this is an infra PR.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.