### PR TITLE
[SPARK-49148] Use the latest PMD 6.x rules instead of the deprecated ones

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ subprojects {
 
   apply plugin: 'pmd'
   pmd {
-    ruleSets = ["java-basic", "java-braces"]
     ruleSetFiles = files("$rootDir/config/pmd/ruleset.xml")
     toolVersion = pmdVersion
     consoleOutput = true

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -19,14 +19,73 @@
 
 <ruleset name="pmd ruleset">
   <description>
-    Spark Operator Ruleset
+    Apache Spark Operator Ruleset
   </description>
   <rule ref="category/java/bestpractices.xml">
     <exclude name="JUnitAssertionsShouldIncludeMessage" />
     <exclude name="JUnitTestContainsTooManyAsserts" />
   </rule>
+  <rule ref="category/java/codestyle.xml">
+    <exclude name="AtLeastOneConstructor" />
+    <exclude name="CommentDefaultAccessModifier" />
+    <exclude name="ConfusingTernary" />
+    <exclude name="FieldDeclarationsShouldBeAtStartOfClass" />
+    <exclude name="FieldNamingConventions" />
+    <exclude name="GenericsNaming" />
+    <exclude name="LinguisticNaming" />
+    <exclude name="LocalVariableCouldBeFinal" />
+    <exclude name="LongVariable" />
+    <exclude name="MethodArgumentCouldBeFinal" />
+    <exclude name="OnlyOneReturn" />
+    <exclude name="PrematureDeclaration" />
+    <exclude name="ShortVariable" />
+    <exclude name="TooManyStaticImports" />
+    <exclude name="UseUnderscoresInNumericLiterals" />
+    <exclude name="UselessParentheses" />
+  </rule>
+  <rule ref="category/java/design.xml">
+    <exclude name="AbstractClassWithoutAnyMethod" />
+    <exclude name="AvoidCatchingGenericException" />
+    <exclude name="AvoidThrowingRawExceptionTypes" />
+    <exclude name="ClassWithOnlyPrivateConstructorsShouldBeFinal" />
+    <exclude name="CognitiveComplexity" />
+    <exclude name="CyclomaticComplexity" />
+    <exclude name="ExcessiveImports" />
+    <exclude name="ImmutableField" />
+    <exclude name="LawOfDemeter" />
+    <exclude name="NPathComplexity" />
+    <exclude name="SignatureDeclareThrowsException" />
+    <exclude name="TooManyMethods" />
+    <exclude name="UseUtilityClass" />
+  </rule>
+  <rule ref="category/java/documentation.xml">
+    <exclude name="CommentRequired" />
+    <exclude name="CommentSize" />
+  </rule>
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="AssignmentInOperand" />
+    <exclude name="AvoidCatchingThrowable" />
+    <exclude name="AvoidDuplicateLiterals" />
+    <exclude name="AvoidFieldNameMatchingMethodName" />
+    <exclude name="AvoidLiteralsInIfCondition" />
+    <exclude name="CloseResource" />
+    <exclude name="ConstructorCallsOverridableMethod" />
+    <exclude name="MissingSerialVersionUID" />
+    <exclude name="NullAssignment" />
+    <exclude name="TestClassWithoutTestCases" />
+    <exclude name="UseLocaleWithCaseConversions" />
+    <exclude name="UseProperClassLoader" />
+  </rule>
+  <rule ref="category/java/multithreading.xml">
+    <exclude name="DoNotUseThreads" />
+    <exclude name="UseConcurrentHashMap" />
+  </rule>
+  <rule ref="category/java/performance.xml">
+    <exclude name="AvoidFileStream" />
+    <exclude name="AvoidInstantiatingObjectsInLoops" />
+    <exclude name="RedundantFieldInitializer" />
+  </rule>
   <rule ref="category/java/security.xml"/>
-  <rule ref="rulesets/java/basic.xml"/>
   <!-- exclude on generated files -->
   <exclude-pattern>.*/src/generated/.*</exclude-pattern>
 </ruleset>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -19,7 +19,7 @@
 
 <ruleset name="pmd ruleset">
   <description>
-    Apache Spark Operator Ruleset
+    Apache Spark Kubernetes Operator Ruleset
   </description>
   <rule ref="category/java/bestpractices.xml">
     <exclude name="JUnitAssertionsShouldIncludeMessage" />


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the latest PMD 6.x rules instead of the deprecated ones.

### Why are the changes needed?

There are 204 warnings from PMD like the following. We had better fix it before we do the release.

- https://github.com/apache/spark-kubernetes-operator/actions/runs/10290307906/job/28479975975

```
Use Rule name category/java/errorprone.xml/BrokenNullCheck instead of the deprecated Rule name rulesets/java/basic.xml/BrokenNullCheck. PMD 7.0.0 will remove support for this deprecated Rule name usage.
```

```
$ ./gradlew clean build | grep PMD | wc -l
     204 
```
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the CI link.

Or, manually check.
```
$ ./gradlew clean build | grep PMD | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

No.