### PR TITLE
[SPARK-49153] Increase `Gradle` JVM memory to `4g` like Spark repo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,9 @@
 group=org.apache.spark.k8s.operator
 version=0.1.0
 
+# Gradle
+org.gradle.jvmargs=-Xmx4g
+
 # Caution: fabric8 version should be aligned with Spark dependency
 fabric8Version=6.12.1
 commonsLang3Version=3.14.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase `Gradle` JVM memory to `4g` like Spark repo.
- https://docs.gradle.org/current/userguide/performance.html#increase_the_heap_size

### Why are the changes needed?

Unlike CI, in the local build, Gradle Daemon is reused. The compilation is unstable like the following because the default Gradle JVM memory is 512MB.

```
> Task :spark-operator:compileTestJava
Note: /Users/dongjoon/APACHE/spark-kubernetes-operator/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
[1.372s][warning][codecache] CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
[1.372s][warning][codecache] Try increasing the code cache size using -XX:ReservedCodeCacheSize=
CodeCache: size=2944Kb used=2943Kb max_used=2943Kb free=0Kb
 bounds [0x0000000105004000, 0x00000001052e4000, 0x00000001052e4000]
 total_blobs=1102 nmethods=464 adapters=554
 compilation: disabled (not enough contiguous free space left)
              stopped_count=1, restarted_count=0
 full_count=1 
```

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Check the JVM setting via `jps` locally.

### Was this patch authored or co-authored using generative AI tooling?

No.