### PR TITLE
[SPARK-49159] Enforce `FieldDeclarationsShouldBeAtStartOfClass`, `LinguisticNaming` and `ClassWithOnlyPrivateConstructorsShouldBeFinal` rules

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -28,10 +28,8 @@
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor" />
     <exclude name="CommentDefaultAccessModifier" />
-    <exclude name="FieldDeclarationsShouldBeAtStartOfClass" />
     <exclude name="FieldNamingConventions" />
     <exclude name="GenericsNaming" />
-    <exclude name="LinguisticNaming" />
     <exclude name="LocalVariableCouldBeFinal" />
     <exclude name="LongVariable" />
     <exclude name="MethodArgumentCouldBeFinal" />
@@ -43,7 +41,6 @@
   <rule ref="category/java/design.xml">
     <exclude name="AbstractClassWithoutAnyMethod" />
     <exclude name="AvoidCatchingGenericException" />
-    <exclude name="ClassWithOnlyPrivateConstructorsShouldBeFinal" />
     <exclude name="CognitiveComplexity" />
     <exclude name="CyclomaticComplexity" />
     <exclude name="ExcessiveImports" />

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ApplicationStateSummary.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ApplicationStateSummary.java
@@ -99,6 +99,18 @@ public enum ApplicationStateSummary implements BaseStateSummary {
    */
   TerminatedWithoutReleaseResources;
 
+  public static final Set<ApplicationStateSummary> infrastructureFailures =
+      Set.of(DriverStartTimedOut, ExecutorsStartTimedOut, SchedulingFailure);
+
+  public static final Set<ApplicationStateSummary> failures =
+      Set.of(
+          DriverStartTimedOut,
+          ExecutorsStartTimedOut,
+          SchedulingFailure,
+          DriverEvicted,
+          Failed,
+          DriverReadyTimedOut);
+
   public boolean isInitializing() {
     return Submitted.equals(this) || ScheduledToRestart.equals(this);
   }
@@ -126,18 +138,6 @@ public enum ApplicationStateSummary implements BaseStateSummary {
   public boolean isStopping() {
     return RunningWithBelowThresholdExecutors.ordinal() < this.ordinal() && !isTerminated();
   }
-
-  public static final Set<ApplicationStateSummary> infrastructureFailures =
-      Set.of(DriverStartTimedOut, ExecutorsStartTimedOut, SchedulingFailure);
-
-  public static final Set<ApplicationStateSummary> failures =
-      Set.of(
-          DriverStartTimedOut,
-          ExecutorsStartTimedOut,
-          SchedulingFailure,
-          DriverEvicted,
-          Failed,
-          DriverReadyTimedOut);
 
   @Override
   public boolean isFailure() {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/ReconcileProgress.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/ReconcileProgress.java
@@ -34,7 +34,7 @@ import lombok.Data;
  * the frequency
  */
 @Data
-public class ReconcileProgress {
+public final class ReconcileProgress {
   private boolean completed;
   boolean requeue;
   private Duration requeueAfterDuration;

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java
@@ -63,9 +63,7 @@ public class TestUtils {
     return System.currentTimeMillis() - startTime;
   }
 
-  public static <T> T setConfigKey(ConfigOption<T> configKey, T newValue) {
-    T originalPropertyValue = configKey.getValue();
+  public static <T> void setConfigKey(ConfigOption<T> configKey, T newValue) {
     Whitebox.setInternalState(configKey, "defaultValue", newValue);
-    return originalPropertyValue;
   }
 }

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppDriverConf.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppDriverConf.java
@@ -28,7 +28,7 @@ import org.apache.spark.deploy.k8s.KubernetesVolumeUtils;
 import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils;
 import org.apache.spark.deploy.k8s.submit.MainAppResource;
 
-public class SparkAppDriverConf extends KubernetesDriverConf {
+public final class SparkAppDriverConf extends KubernetesDriverConf {
   private SparkAppDriverConf(
       SparkConf sparkConf,
       String appId,


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to enforce `FieldDeclarationsShouldBeAtStartOfClass`, `LinguisticNaming` and `ClassWithOnlyPrivateConstructorsShouldBeFinal` rules

### Why are the changes needed?
To ensure future code quality.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.