### PR TITLE
[SPARK-49165] Fix `RestartPolicyTest` to cover `SchedulingFailure`

### DIFF
--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/RestartPolicyTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/RestartPolicyTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.spark.k8s.operator.spec;
 
+import static org.apache.spark.k8s.operator.spec.RestartPolicy.Always;
+import static org.apache.spark.k8s.operator.spec.RestartPolicy.Never;
 import static org.apache.spark.k8s.operator.spec.RestartPolicy.OnFailure;
 import static org.apache.spark.k8s.operator.spec.RestartPolicy.OnInfrastructureFailure;
 import static org.apache.spark.k8s.operator.spec.RestartPolicy.attemptRestartOnState;
@@ -27,6 +29,7 @@ import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Drive
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.DriverStartTimedOut;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.ExecutorsStartTimedOut;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Failed;
+import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.SchedulingFailure;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.Succeeded;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,8 +43,8 @@ class RestartPolicyTest {
   @Test
   void testAttemptRestartOnState() {
     for (ApplicationStateSummary stateSummary : ApplicationStateSummary.values()) {
-      assertTrue(attemptRestartOnState(RestartPolicy.Always, stateSummary));
-      assertFalse(attemptRestartOnState(RestartPolicy.Never, stateSummary));
+      assertTrue(attemptRestartOnState(Always, stateSummary));
+      assertFalse(attemptRestartOnState(Never, stateSummary));
       if (!stateSummary.isStopping()) {
         assertFalse(attemptRestartOnState(OnFailure, stateSummary));
         assertFalse(attemptRestartOnState(OnInfrastructureFailure, stateSummary));
@@ -59,5 +62,6 @@ class RestartPolicyTest {
     assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverEvicted));
     assertTrue(attemptRestartOnState(OnFailure, ExecutorsStartTimedOut));
     assertTrue(attemptRestartOnState(OnInfrastructureFailure, ExecutorsStartTimedOut));
+    assertTrue(attemptRestartOnState(OnInfrastructureFailure, SchedulingFailure));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `RestartPolicyTest` to cover `SchedulingFailure`.

### Why are the changes needed?

`SchedulingFailure` is defined as one of `infrastructureFailures`, but it's not tested properly.
https://github.com/apache/spark-kubernetes-operator/blob/026bc0faa332eb8843901ecaee729e1bf3104bdc/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ApplicationStateSummary.java#L102-L103

`RestartPolicy` should allow `OnInfrastructureFailure` on `SchedulingFailure`.
https://github.com/apache/spark-kubernetes-operator/blob/026bc0faa332eb8843901ecaee729e1bf3104bdc/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/RestartPolicy.java#L36

### Does this PR introduce _any_ user-facing change?

No, this is a test case change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.