### PR TITLE
[SPARK-49168] Add `OpenContainers` Annotations to docker image

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -23,6 +23,10 @@ RUN ./gradlew clean build -x test
 FROM azul/zulu-openjdk:21
 ARG APP_VERSION
 ARG SPARK_UID=185
+LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache Spark Kubernetes Operator"
+LABEL org.opencontainers.image.version="${APP_VERSION}"
 
 ENV SPARK_OPERATOR_HOME=/opt/spark-operator
 ENV SPARK_OPERATOR_WORK_DIR=/opt/spark-operator/operator


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `OpenContainers` Annotations to docker image.

- https://specs.opencontainers.org/image-spec/annotations/

### Why are the changes needed?

**AFTER**
```
$ docker inspect spark-kubernetes-operator:0.1.0 | jq '.[0].Config.Labels'
{
  "org.opencontainers.image.authors": "Apache Spark project <dev@spark.apache.org>",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.ref.name": "Apache Spark Kubernetes Operator",
  "org.opencontainers.image.version": "0.1.0"
}
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.
```
$ docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
$ docker inspect spark-kubernetes-operator:0.1.0 | jq '.[0].Config.Labels'
```

### Was this patch authored or co-authored using generative AI tooling?

No.