### PR TITLE
[SPARK-49236] Update `README.md` with `build/test/CI` info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# spark-kubernetes-operator
+# Apache Spark K8s Operator
+
+Apache Spark K8s Operator is a subproject of [Apache Spark](https://spark.apache.org/) and
+aims to extend K8s resource manager to manage Apache Spark applications via
+[Operator Pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
+
+[![GitHub Actions Build](https://github.com/apache/spark-kubernetes-operator/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/apache/spark-kubernetes-operator/actions/workflows/build_and_test.yml)
+
+## Building Spark K8s Operator
+
+Spark K8s Operator is built using Gradle.
+To build, run:
+
+```bash
+./gradlew build -x test
+```
+
+## Running Tests
+
+```bash
+./gradlew build
+```
+
+## Contributing
+
+Please review the [Contribution to Spark guide](https://spark.apache.org/contributing.html)
+for information on how to get started contributing to the project.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `README.md` with `build/test/CI status` information. 

### Why are the changes needed?

To help new comers. You can see the result in the PR branch like the following.
- https://github.com/dongjoon-hyun/spark-kubernetes-operator/tree/SPARK-49236

<img width="896" alt="Screenshot 2024-08-14 at 09 30 10" src="https://github.com/user-attachments/assets/b398e703-5cdf-4d58-a31c-93e3f991f75e">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.