### PR TITLE
[SPARK-49237] Speed up docker image building by excluding `check` instead of `test`

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -18,7 +18,7 @@ FROM gradle:8.9.0-jdk17-jammy AS builder
 ARG APP_VERSION
 WORKDIR /app
 COPY . .
-RUN ./gradlew clean build -x test
+RUN ./gradlew clean build -x check
 
 FROM azul/zulu-openjdk:21
 ARG APP_VERSION


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to speed up docker image building and reducing the required memory by excluding `check` instead of `test`.

### Why are the changes needed?

Initially, we exclude only `test` task. However, we can exclude the whole `check` lifecycle completely.
- https://github.com/apache/spark-kubernetes-operator/pull/28

This is required in three ways.
- Speeding up docker image building.
- Reducing required memory resources during image building.
- Enabling `K8s integration tests` test pipeline later in the limited `GitHub Action CI` test pipeline.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.