### PR TITLE
[SPARK-49239] Add `k8s-integration-tests` GitHub Action CI job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,3 +54,29 @@ jobs:
         run: |
           docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
           docker run spark-kubernetes-operator:0.1.0
+  k8s-integration-tests:
+    name: "K8s Integration Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: start minikube
+        run: |
+          # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/
+          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          sudo install minikube-linux-amd64 /usr/local/bin/minikube
+          rm minikube-linux-amd64
+          # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
+          minikube start --cpus 2 --memory 6144
+      - name: Print K8S pods and nodes info
+        run: |
+          kubectl get pods -A
+          kubectl describe node
+      - name: Run Spark K8s Operator on K8S
+        run: |
+          kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
+          eval $(minikube docker-env)
+          docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
+          kubectl run spark-kubernetes-operator --image=spark-kubernetes-operator:0.1.0
+          kubectl get pods -A
+          kubectl logs spark-kubernetes-operator

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,6 +77,7 @@ jobs:
           kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
           eval $(minikube docker-env)
           docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
-          kubectl run spark-kubernetes-operator --image=spark-kubernetes-operator:0.1.0
+          kubectl run spark-kubernetes-operator --image=spark-kubernetes-operator:0.1.0 --restart=Never
+          sleep 5
           kubectl get pods -A
           kubectl logs spark-kubernetes-operator


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `k8s-integration-tests` GitHub Action CI job.

### Why are the changes needed?

To improve test coverage.
![Screenshot 2024-08-14 at 12 30 36](https://github.com/user-attachments/assets/1e7e113e-c271-46c2-b533-18b2b7933931)



### Does this PR introduce _any_ user-facing change?

No because this is an INFRA PR.

### How was this patch tested?

Pass the CIs with newly added test CI job.
- https://github.com/apache/spark-kubernetes-operator/actions/runs/10393752429/job/28781953162?pr=48
```
pod/spark-kubernetes-operator created
NAMESPACE     NAME                               READY   STATUS      RESTARTS      AGE
default       spark-kubernetes-operator          0/1     Completed   0             5s
```

### Was this patch authored or co-authored using generative AI tooling?

No.