### PR TITLE
[SPARK-49253] Install and test Helm chart in K8s integration test CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -90,7 +90,7 @@ jobs:
           sleep 5
           kubectl get pods -A
           kubectl logs spark-kubernetes-operator
-          kubectl delete spark-kubernetes-operator
+          kubectl delete pod spark-kubernetes-operator
           # helm
           ./gradlew spark-operator-api:relocateGeneratedCRD
           helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -84,3 +84,7 @@ jobs:
           sleep 5
           kubectl get pods -A
           kubectl logs spark-kubernetes-operator
+          # helm
+          ./gradlew spark-operator-api:relocateGeneratedCRD
+          helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
+          helm test spark-kubernetes-operator

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'adopt'
+          cache: 'gradle'
       - name: start minikube
         run: |
           # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/
@@ -84,6 +90,7 @@ jobs:
           sleep 5
           kubectl get pods -A
           kubectl logs spark-kubernetes-operator
+          kubectl delete spark-kubernetes-operator
           # helm
           ./gradlew spark-operator-api:relocateGeneratedCRD
           helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/

--- a/spark-operator-api/src/main/resources/printer-columns.sh
+++ b/spark-operator-api/src/main/resources/printer-columns.sh
@@ -20,7 +20,7 @@
 # This is a workaround. See https://github.com/fabric8io/kubernetes-client/issues/3069
 # We do a yq to add printer columns
 
-script_path=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-crd_path="${script_path}/../../../build/classes/java/main/META-INF/fabric8/sparkapplications.org.apache.spark-v1.yml"
-yq -i '.spec.versions[0] += ({"additionalPrinterColumns": [{"jsonPath": ".status.currentState.currentStateSummary", "name": "Current State", "type": "string"}, {"jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date"}]})' $crd_path
+SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
+CRD_PATH="${SCRIPT_PATH}/../../../build/classes/java/main/META-INF/fabric8/sparkapplications.org.apache.spark-v1.yml"
+yq -i '.spec.versions[0] += ({"additionalPrinterColumns": [{"jsonPath": ".status.currentState.currentStateSummary", "name": "Current State", "type": "string"}, {"jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date"}]})' ${CRD_PATH}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install and test `Apache Spark Operator` Helm chart in K8s integration test CI.

### Why are the changes needed?

To have a test coverage for `install` and `test` Helm commands.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.

- https://github.com/apache/spark-kubernetes-operator/actions/runs/10413990677/job/28842267762?pr=49

```
NAME: spark-kubernetes-operator
LAST DEPLOYED: Fri Aug 16 03:12:01 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
NAME: spark-kubernetes-operator
LAST DEPLOYED: Fri Aug 16 03:12:01 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE:     spark-kubernetes-operator-test-operator-rbac
Last Started:   Fri Aug 16 03:12:09 2024
Last Completed: Fri Aug 16 03:12:12 2024
Phase:          Succeeded
TEST SUITE:     spark-kubernetes-operator-test-app-rbac
Last Started:   Fri Aug 16 03:12:02 2024
Last Completed: Fri Aug 16 03:12:09 2024
Phase:          Succeeded
```

### Was this patch authored or co-authored using generative AI tooling?

No.