### PR TITLE
[SPARK-49256] Upgrade `kubernetes-client` to 6.13.3 and `commons-lang3` to 3.16.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ version=0.1.0
 org.gradle.jvmargs=-Xmx4g
 
 # Caution: fabric8 version should be aligned with Spark dependency
-fabric8Version=6.12.1
-commonsLang3Version=3.14.0
+fabric8Version=6.13.3
+commonsLang3Version=3.16.0
 commonsIOVersion=2.16.1
 lombokVersion=1.18.32
 operatorSDKVersion=4.9.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `kubernetes-client` to 6.13.3 and `commons-lang3` to 3.16.0 to match with Apache Spark 4.

### Why are the changes needed?

To make the dependency up-to-date.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.