### PR TITLE
[SPARK-49270] Add `sql.yaml` example

### DIFF
--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: org.apache.spark/v1alpha1
+kind: SparkApplication
+metadata:
+  name: sql
+spec:
+  mainClass: "org.apache.spark.examples.sql.JavaSparkSQLCli"
+  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  driverArgs: [ "SHOW DATABASES", "SHOW TABLES", "SELECT VERSION()"  ]
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.log.structuredLogging.enabled: "false"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Spark SQL example, `sql.yaml`.

### Why are the changes needed?

To provide an example for SQL users.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.
```
$ kubectl apply -f examples/sql.yaml
sparkapplication.org.apache.spark/sql created

$ kubectl get sparkapp
NAME   CURRENT STATE    AGE
sql    RunningHealthy   9s

$ kubectl get sparkapp
NAME   CURRENT STATE      AGE
sql    ResourceReleased   19s

$ kubectl delete sparkapp sql
sparkapplication.org.apache.spark "sql" deleted
```

### Was this patch authored or co-authored using generative AI tooling?

No.