### PR TITLE
[SPARK-49271] Improve `gradlew` to support both `curl` and `wget`

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,12 @@ APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
 APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
-if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
+if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar -a "$(command -v curl)" ]; then
     curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.10.0/gradle/wrapper/gradle-wrapper.jar
+fi
+# If the file still doesn't exist, let's try `wget` and cross our fingers
+if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar -a "$(command -v wget)" ]; then
+    wget -O $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.10.0/gradle/wrapper/gradle-wrapper.jar
 fi
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `gradlew` to support both `curl` and `wget`.

### Why are the changes needed?

`curl` doesn't exist in some docker images like the following.

**BEFORE**
```
$ docker run -it --rm -v $PWD:/spark alpine/java:21-jdk -- sh
/ # cd /spark/
/spark # ./gradlew
./gradlew: line 90: curl: not found
Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain
Caused by: java.lang.ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain
/spark #
```

**AFTER**
```
$ docker run -it --rm -v $PWD:/spark alpine/java:21-jdk -- sh
/ # cd /spark/
/spark # ./gradlew clean
Connecting to raw.githubusercontent.com (185.199.108.133:443)
saving to '/spark/gradle/wrapper/gradle-wrapper.jar'
gradle-wrapper.jar   100% |*************************************************************************************************************************************| 43583  0:00:00 ETA
'/spark/gradle/wrapper/gradle-wrapper.jar' saved
Downloading https://services.gradle.org/distributions/gradle-8.10-all.zip
.....................10%......................20%......................30%.....................40%......................50%......................60%......................70%.....................80%......................90%......................100%

Welcome to Gradle 8.10!

Here are the highlights of this release:
 - Support for Java 23
 - Faster configuration cache
 - Better configuration cache reports

For more details see https://docs.gradle.org/8.10/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)
> Task :spark-operator:clean
> Task :spark-operator-api:clean
> Task :spark-submission-worker:clean

BUILD SUCCESSFUL in 38s
3 actionable tasks: 3 executed
/spark #
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.