### PR TITLE
[SPARK-49272] Update `Dockerfile` to use `alpine/java:17-jdk` instead of `gradle:8.9.0-jdk17-jammy`

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM gradle:8.9.0-jdk17-jammy AS builder
+FROM alpine/java:17-jdk AS builder
 ARG APP_VERSION
 WORKDIR /app
 COPY . .

--- a/gradlew
+++ b/gradlew
@@ -92,6 +92,9 @@ fi
 # If the file still doesn't exist, let's try `wget` and cross our fingers
 if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar -a "$(command -v wget)" ]; then
     wget -O $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.10.0/gradle/wrapper/gradle-wrapper.jar
+    if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
+        wget -O $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://185.199.111.133/gradle/gradle/v8.10.0/gradle/wrapper/gradle-wrapper.jar
+    fi
 fi
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims the following.

1. Use `alpine/java:17-jdk` instead of `gradle:8.9.0-jdk17-jammy` as a Docker image builder image. 
2. Improves `grades` by adding a last fallback to handle DNS error like the following.
```
#14 5.254 wget: bad address 'raw.githubusercontent.com'
```

### Why are the changes needed?

`alpine` Java 17 image is 65% smaller. And, we currently use grade wrapper to download newer gradle zip file.
```
$ docker images | head -n3
REPOSITORY            TAG                              IMAGE ID       CREATED         SIZE
alpine/java           17-jdk                           c6b1a03c388c   6 days ago      318MB
gradle                8.9.0-jdk17-jammy                28e51bcaedf1   5 weeks ago     710MB
```

Technically, we already upgraded to `Gradle 8.10.0` and we don't use `8.9.0`.

- #47

In addition, `185.199.111.133` is one of the official IP of `raw.githubusercontent.com`.
- https://www.nslookup.io/domains/raw.githubusercontent.com/dns-records/#google

<img width="641" alt="Screenshot 2024-08-17 at 09 35 55" src="https://github.com/user-attachments/assets/e3ab798b-d92e-4b9a-b010-b71778725e83">

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.