### PR TITLE
[SPARK-49276] Use API Group `spark.apache.org`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/app-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/app-rbac.yaml
@@ -161,7 +161,7 @@ metadata:
 {{- end }}
 {{- if $appResources.sparkApplicationSentinel.create }}
 {{- range $sentinelNs := .Values.appResources.sparkApplicationSentinel.sentinelNamespaces.data }}
-apiVersion: org.apache.spark/v1alpha1
+apiVersion: spark.apache.org/v1alpha1
 kind: SparkApplication
 metadata:
   name: {{ $appResources.sparkApplicationSentinel.name }}

--- a/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
@@ -36,7 +36,7 @@ rules:
     verbs:
       - '*'
   - apiGroups:
-      - "org.apache.spark"
+      - "spark.apache.org"
     resources:
       - '*'
     verbs:

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: org.apache.spark/v1alpha1
+apiVersion: spark.apache.org/v1alpha1
 kind: SparkApplication
 metadata:
   name: pi

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: org.apache.spark/v1alpha1
+apiVersion: spark.apache.org/v1alpha1
 kind: SparkApplication
 metadata:
   name: sql

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -36,7 +36,7 @@ tasks.register('finalizeGeneratedCRD', Exec) {
 // Copy generated yaml to Helm charts
 tasks.register('relocateGeneratedCRD', Copy) {
   dependsOn finalizeGeneratedCRD
-  from "build/classes/java/main/META-INF/fabric8/sparkapplications.org.apache.spark-v1.yml"
+  from "build/classes/java/main/META-INF/fabric8/sparkapplications.spark.apache.org-v1.yml"
   into "../build-tools/helm/spark-kubernetes-operator/crds"
   rename '(.+).yml', '$1.yaml'
 }

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
@@ -20,7 +20,7 @@
 package org.apache.spark.k8s.operator;
 
 public class Constants {
-  public static final String API_GROUP = "org.apache.spark";
+  public static final String API_GROUP = "spark.apache.org";
   public static final String API_VERSION = "v1alpha1";
   public static final String LABEL_SPARK_APPLICATION_NAME = "spark.operator/spark-app-name";
   public static final String LABEL_SPARK_OPERATOR_NAME = "spark.operator/name";

--- a/spark-operator-api/src/main/resources/printer-columns.sh
+++ b/spark-operator-api/src/main/resources/printer-columns.sh
@@ -21,6 +21,6 @@
 # We do a yq to add printer columns
 
 SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
-CRD_PATH="${SCRIPT_PATH}/../../../build/classes/java/main/META-INF/fabric8/sparkapplications.org.apache.spark-v1.yml"
+CRD_PATH="${SCRIPT_PATH}/../../../build/classes/java/main/META-INF/fabric8/sparkapplications.spark.apache.org-v1.yml"
 yq -i '.spec.versions[0] += ({"additionalPrinterColumns": [{"jsonPath": ".status.currentState.currentStateSummary", "name": "Current State", "type": "string"}, {"jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date"}]})' ${CRD_PATH}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use API Group `spark.apache.org`.
```
-apiVersion: org.apache.spark/...
+apiVersion: spark.apache.org/...
```

### Why are the changes needed?

K8s convention follows domain name styles instead of package name styles.
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition

```
apiVersion: apiextensions.k8s.io/v1
```

```
# group name to use for REST API: /apis/<group>/<version>
group: stable.example.com
```
### Does this PR introduce _any_ user-facing change?

No, this is not released yet.

### How was this patch tested?

Pass the CIs.

In addition, we can check via K8s API Server.

**BEFORE**
```
$ kubectl proxy --port=8080 &
$ curl -s http://localhost:8080/ | grep spark
    "/apis/org.apache.spark",
    "/apis/org.apache.spark/v1alpha1",
```

**AFTER**
```
$ kubectl proxy --port=8080 &
$ curl -s http://localhost:8080/ | grep spark
    "/apis/spark.apache.org",
    "/apis/spark.apache.org/v1alpha1",
```

### Was this patch authored or co-authored using generative AI tooling?

No.