### PR TITLE
[SPARK-49277] Refactor `RestartPolicyTest` to test per case

### DIFF
--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/RestartPolicyTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/RestartPolicyTest.java
@@ -41,27 +41,48 @@ import org.apache.spark.k8s.operator.status.ApplicationStateSummary;
 class RestartPolicyTest {
 
   @Test
-  void testAttemptRestartOnState() {
+  void testAlways() {
     for (ApplicationStateSummary stateSummary : ApplicationStateSummary.values()) {
       assertTrue(attemptRestartOnState(Always, stateSummary));
+    }
+  }
+
+  @Test
+  void testNever() {
+    for (ApplicationStateSummary stateSummary : ApplicationStateSummary.values()) {
       assertFalse(attemptRestartOnState(Never, stateSummary));
+    }
+  }
+
+  @Test
+  void testOnFailure() {
+    for (ApplicationStateSummary stateSummary : ApplicationStateSummary.values()) {
       if (!stateSummary.isStopping()) {
         assertFalse(attemptRestartOnState(OnFailure, stateSummary));
-        assertFalse(attemptRestartOnState(OnInfrastructureFailure, stateSummary));
       }
     }
     assertFalse(attemptRestartOnState(OnFailure, Succeeded));
-    assertFalse(attemptRestartOnState(OnInfrastructureFailure, Succeeded));
     assertTrue(attemptRestartOnState(OnFailure, Failed));
-    assertFalse(attemptRestartOnState(OnInfrastructureFailure, Failed));
     assertTrue(attemptRestartOnState(OnFailure, DriverStartTimedOut));
-    assertTrue(attemptRestartOnState(OnInfrastructureFailure, DriverStartTimedOut));
     assertTrue(attemptRestartOnState(OnFailure, DriverReadyTimedOut));
-    assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverReadyTimedOut));
     assertTrue(attemptRestartOnState(OnFailure, DriverEvicted));
-    assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverEvicted));
     assertTrue(attemptRestartOnState(OnFailure, ExecutorsStartTimedOut));
+  }
+
+  @Test
+  void testOnInfrastructureFailure() {
+    assertTrue(attemptRestartOnState(OnInfrastructureFailure, DriverStartTimedOut));
     assertTrue(attemptRestartOnState(OnInfrastructureFailure, ExecutorsStartTimedOut));
     assertTrue(attemptRestartOnState(OnInfrastructureFailure, SchedulingFailure));
+
+    for (ApplicationStateSummary stateSummary : ApplicationStateSummary.values()) {
+      if (!stateSummary.isStopping()) {
+        assertFalse(attemptRestartOnState(OnInfrastructureFailure, stateSummary));
+      }
+    }
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, Succeeded));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, Failed));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverReadyTimedOut));
+    assertFalse(attemptRestartOnState(OnInfrastructureFailure, DriverEvicted));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This aims to refactor `RestartPolicyTest` to test per case. There is no change in terms of test coverage.

### Why are the changes needed?

`RestartPolicy` has four enum values. We had better have four test cases.

https://github.com/apache/spark-kubernetes-operator/blob/7b3dc1c77ecaf1309127bdb7d494ef81915bec34/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/RestartPolicy.java#L24-L28

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.