### PR TITLE
[SPARK-49278] Revise `reconcilesteps` package and `SparkAppReconciler`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverTimeoutObserver.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverTimeoutObserver.java
@@ -63,22 +63,22 @@ public class AppDriverTimeoutObserver extends BaseAppDriverObserver {
     ApplicationTimeoutConfig timeoutConfig =
         spec.getApplicationTolerations().getApplicationTimeoutConfig();
     switch (currentStatus.getCurrentState().getCurrentStateSummary()) {
-      case DriverRequested:
+      case DriverRequested -> {
         timeoutThreshold = timeoutConfig.getDriverStartTimeoutMillis();
         supplier = SparkAppStatusUtils::driverLaunchTimedOut;
-        break;
-      case DriverStarted:
+      }
+      case DriverStarted -> {
         timeoutThreshold = timeoutConfig.getDriverReadyTimeoutMillis();
         supplier = SparkAppStatusUtils::driverReadyTimedOut;
-        break;
-      case DriverReady:
-      case InitializedBelowThresholdExecutors:
+      }
+      case DriverReady, InitializedBelowThresholdExecutors -> {
         timeoutThreshold = timeoutConfig.getExecutorStartTimeoutMillis();
         supplier = SparkAppStatusUtils::executorLaunchTimedOut;
-        break;
-      default:
+      }
+      default -> {
         // No timeout check needed for other states
         return Optional.empty();
+      }
     }
     Instant lastTransitionTime =
         Instant.parse(currentStatus.getCurrentState().getLastTransitionTime());

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverTimeoutObserver.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverTimeoutObserver.java
@@ -63,22 +63,22 @@ public class AppDriverTimeoutObserver extends BaseAppDriverObserver {
     ApplicationTimeoutConfig timeoutConfig =
         spec.getApplicationTolerations().getApplicationTimeoutConfig();
     switch (currentStatus.getCurrentState().getCurrentStateSummary()) {
-      case DriverRequested -> {
+      case DriverRequested:
         timeoutThreshold = timeoutConfig.getDriverStartTimeoutMillis();
         supplier = SparkAppStatusUtils::driverLaunchTimedOut;
-      }
-      case DriverStarted -> {
+        break;
+      case DriverStarted:
         timeoutThreshold = timeoutConfig.getDriverReadyTimeoutMillis();
         supplier = SparkAppStatusUtils::driverReadyTimedOut;
-      }
-      case DriverReady, InitializedBelowThresholdExecutors -> {
+        break;
+      case DriverReady:
+      case InitializedBelowThresholdExecutors:
         timeoutThreshold = timeoutConfig.getExecutorStartTimeoutMillis();
         supplier = SparkAppStatusUtils::executorLaunchTimedOut;
-      }
-      default -> {
+        break;
+      default:
         // No timeout check needed for other states
         return Optional.empty();
-      }
     }
     Instant lastTransitionTime =
         Instant.parse(currentStatus.getCurrentState().getLastTransitionTime());

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppInitStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppInitStep.java
@@ -45,7 +45,7 @@ import org.apache.spark.k8s.operator.status.ApplicationStatus;
 import org.apache.spark.k8s.operator.utils.ReconcilerUtils;
 import org.apache.spark.k8s.operator.utils.SparkAppStatusRecorder;
 
-/** Request all driver and driver resources when starting an attempt */
+/** Request all driver and its resources when starting an attempt */
 @Slf4j
 public class AppInitStep extends AppReconcileStep {
   @Override

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppReconcileStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppReconcileStep.java
@@ -26,7 +26,6 @@ import static org.apache.spark.k8s.operator.utils.SparkAppStatusUtils.driverUnex
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.Pod;
 
@@ -56,7 +55,7 @@ public abstract class AppReconcileStep {
               .map(o -> o.observe(driverPodOptional.get(), app.getSpec(), app.getStatus()))
               .filter(Optional::isPresent)
               .map(Optional::get)
-              .collect(Collectors.toList());
+              .toList();
       if (stateUpdates.isEmpty()) {
         return proceed();
       } else {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppRunningStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppRunningStep.java
@@ -19,6 +19,7 @@
 
 package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
 
+import static org.apache.spark.k8s.operator.Constants.*;
 import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.completeAndDefaultRequeue;
 
 import java.util.Collections;
@@ -26,7 +27,6 @@ import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.Pod;
 
-import org.apache.spark.k8s.operator.Constants;
 import org.apache.spark.k8s.operator.context.SparkAppContext;
 import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
 import org.apache.spark.k8s.operator.reconciler.observers.AppDriverRunningObserver;
@@ -51,17 +51,17 @@ public class AppRunningStep extends AppReconcileStep {
         || instanceConfig.getInitExecutors() == 0L
         || !prevStateSummary.isStarting() && instanceConfig.getMinExecutors() == 0L) {
       proposedStateSummary = ApplicationStateSummary.RunningHealthy;
-      stateMessage = Constants.RUNNING_HEALTHY_MESSAGE;
+      stateMessage = RUNNING_HEALTHY_MESSAGE;
     } else {
       Set<Pod> executors = context.getExecutorsForApplication();
       long runningExecutors = executors.stream().filter(PodUtils::isPodReady).count();
       if (prevStateSummary.isStarting()) {
         if (runningExecutors >= instanceConfig.getInitExecutors()) {
           proposedStateSummary = ApplicationStateSummary.RunningHealthy;
-          stateMessage = Constants.RUNNING_HEALTHY_MESSAGE;
+          stateMessage = RUNNING_HEALTHY_MESSAGE;
         } else if (runningExecutors > 0L) {
           proposedStateSummary = ApplicationStateSummary.InitializedBelowThresholdExecutors;
-          stateMessage = Constants.INITIALIZED_WITH_BELOW_THRESHOLD_EXECUTORS_MESSAGE;
+          stateMessage = INITIALIZED_WITH_BELOW_THRESHOLD_EXECUTORS_MESSAGE;
         } else {
           // keep previous state for 0 executor
           proposedStateSummary = prevStateSummary;
@@ -69,10 +69,10 @@ public class AppRunningStep extends AppReconcileStep {
       } else {
         if (runningExecutors >= instanceConfig.getMinExecutors()) {
           proposedStateSummary = ApplicationStateSummary.RunningHealthy;
-          stateMessage = Constants.RUNNING_HEALTHY_MESSAGE;
+          stateMessage = RUNNING_HEALTHY_MESSAGE;
         } else {
           proposedStateSummary = ApplicationStateSummary.RunningWithBelowThresholdExecutors;
-          stateMessage = Constants.RUNNING_WITH_BELOW_THRESHOLD_EXECUTORS_MESSAGE;
+          stateMessage = RUNNING_WITH_BELOW_THRESHOLD_EXECUTORS_MESSAGE;
         }
       }
     }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppUnknownStateStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppUnknownStateStep.java
@@ -31,7 +31,7 @@ import org.apache.spark.k8s.operator.status.ApplicationStateSummary;
 import org.apache.spark.k8s.operator.utils.SparkAppStatusRecorder;
 
 /** Abnormal state handler */
-public class UnknownStateStep extends AppReconcileStep {
+public class AppUnknownStateStep extends AppReconcileStep {
   @Override
   public ReconcileProgress reconcile(
       SparkAppContext context, SparkAppStatusRecorder statusRecorder) {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppValidateStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppValidateStep.java
@@ -21,19 +21,19 @@ package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
 
 import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.completeAndImmediateRequeue;
 import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.proceed;
+import static org.apache.spark.k8s.operator.spec.DeploymentMode.ClientMode;
 import static org.apache.spark.k8s.operator.utils.SparkAppStatusUtils.isValidApplicationStatus;
 
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.spark.k8s.operator.context.SparkAppContext;
 import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
-import org.apache.spark.k8s.operator.spec.DeploymentMode;
 import org.apache.spark.k8s.operator.status.ApplicationState;
 import org.apache.spark.k8s.operator.status.ApplicationStateSummary;
 import org.apache.spark.k8s.operator.status.ApplicationStatus;
 import org.apache.spark.k8s.operator.utils.SparkAppStatusRecorder;
 
-/** Validates the submitted app. This can be re-factored into webhook in future. */
+/** Validates the submitted app. This can be re-factored into webhook in the future. */
 @Slf4j
 public class AppValidateStep extends AppReconcileStep {
   @Override
@@ -43,7 +43,7 @@ public class AppValidateStep extends AppReconcileStep {
       log.warn("Spark application found with empty status. Resetting to initial state.");
       statusRecorder.persistStatus(context, new ApplicationStatus());
     }
-    if (DeploymentMode.ClientMode.equals(context.getResource().getSpec())) {
+    if (ClientMode.equals(context.getResource().getSpec())) {
       ApplicationState failure =
           new ApplicationState(ApplicationStateSummary.Failed, "Client mode is not supported yet.");
       statusRecorder.persistStatus(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revise `reconciler` package.

### Why are the changes needed?

- Rename `UnknownStateStep` to `AppUnknownStateStep` like the other steps for consistency.
- Revise comments and Java `import`statement syntax usages.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.