### PR TITLE
[SPARK-49280] Add `pi-with-one-pod.yaml` example

### DIFF
--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: pi-with-one-pod
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  sparkConf:
+    spark.kubernetes.driver.master: "local[10]"
+    spark.kubernetes.driver.request.cores: "5"
+    spark.kubernetes.driver.limit.cores: "5"
+    spark.log.structuredLogging.enabled: "false"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi-with-one-pod.yaml` example as a single pod Spark job example.

### Why are the changes needed?

Apache Spark supports a single pod submission for both `K8s direct submission` and new `Apache Spark K8s Operator`.

We had better show the feature parity.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

```
$ k apply -f examples/pi-with-one-pod.yaml
sparkapplication.spark.apache.org/pi-with-one-pod created

$ k get sparkapp
NAME              CURRENT STATE      AGE
pi-with-one-pod   ResourceReleased   20s
```

### Was this patch authored or co-authored using generative AI tooling?

No.
