### PR TITLE
[SPARK-49289] Fix `docker-entrypoint.sh` to quote the environment variables

### DIFF
--- a/build-tools/docker/docker-entrypoint.sh
+++ b/build-tools/docker/docker-entrypoint.sh
@@ -26,7 +26,7 @@ if [ "$1" = "help" ]; then
 elif [ "$1" = "operator" ]; then
   echo "Starting Operator..."
 
-  exec java -cp "./$OPERATOR_JAR" $LOG_CONFIG $OPERATOR_JAVA_OPTS org.apache.spark.k8s.operator.SparkOperator
+  exec java -cp "./$OPERATOR_JAR" "$LOG_CONFIG" "$OPERATOR_JAVA_OPTS" org.apache.spark.k8s.operator.SparkOperator
 fi
 
 args=("${args[@]}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `docker-entrypoint.sh` to quote the environment variables.

### Why are the changes needed?

To protect Spark Operator by preventing any potential misuse of  `OPERATOR_JAVA_OPTS` or `LOG_CONFIG` variables

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.