### PR TITLE
[SPARK-49290] Remove `commons-lang3` dependency from `spark-operator-api`

### DIFF
--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   annotationProcessor("io.fabric8:crd-generator-apt:$fabric8Version")
 
   // utils
-  implementation("org.apache.commons:commons-lang3:$commonsLang3Version")
   implementation("commons-io:commons-io:$commonsIOVersion")
   implementation("org.projectlombok:lombok:$lombokVersion")
   annotationProcessor("org.projectlombok:lombok:$lombokVersion")

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ApplicationStatus.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ApplicationStatus.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.apache.commons.lang3.StringUtils;
 
 import org.apache.spark.k8s.operator.spec.ResourceRetainPolicy;
 import org.apache.spark.k8s.operator.spec.RestartConfig;
@@ -109,7 +108,7 @@ public class ApplicationStatus
     if (currentAttemptSummary.getAttemptInfo().getId() >= restartConfig.getMaxRestartAttempts()) {
       String stateMessage =
           String.format(EXCEED_MAX_RETRY_ATTEMPT_MESSAGE, restartConfig.getMaxRestartAttempts());
-      if (StringUtils.isNotEmpty(stateMessageOverride)) {
+      if (stateMessageOverride != null && !stateMessageOverride.isEmpty()) {
         stateMessage += stateMessageOverride;
       }
       // max number of restart attempt reached

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/utils/ModelUtils.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/utils/ModelUtils.java
@@ -34,7 +34,6 @@ import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
-import org.apache.commons.lang3.StringUtils;
 
 import org.apache.spark.k8s.operator.SparkApplication;
 import org.apache.spark.k8s.operator.spec.ApplicationSpec;
@@ -67,7 +66,8 @@ public final class ModelUtils {
       return containerStatusList;
     }
     Map<String, String> sparkConf = appSpec.getSparkConf();
-    if (sparkConf == null || StringUtils.isEmpty(sparkConf.get(DRIVER_SPARK_CONTAINER_PROP_KEY))) {
+    String key = sparkConf.get(DRIVER_SPARK_CONTAINER_PROP_KEY);
+    if (key == null || key.isEmpty()) {
       return containerStatusList;
     }
     String mainContainerName = sparkConf.get(DRIVER_SPARK_CONTAINER_PROP_KEY);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `commons-lang3` dependency from `spark-operator-api`.

### Why are the changes needed?

To simply `spark-operator-api` module.

**BEFORE**
```
$ gradle :spark-operator-api:dependencyInsight --dependency commons-lang3

> Task :spark-operator-api:dependencyInsight
org.apache.commons:commons-lang3:3.16.0
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 17           |

org.apache.commons:commons-lang3:3.16.0
\--- compileClasspath

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 359ms
1 actionable task: 1 executed
```

**AFTER**
```
$ gradle :spark-operator-api:dependencyInsight --dependency commons-lang3

> Task :spark-operator-api:dependencyInsight
No dependencies matching given input were found in configuration ':spark-operator-api:compileClasspath'

BUILD SUCCESSFUL in 348ms
1 actionable task: 1 executed
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.