### PR TITLE
[SPARK-49291] Fix `javadoc` generation and add `lint` test pipeline to prevent

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew build
-      - name: Validate helm chart linting
-        run: |
-          helm lint --strict build-tools/helm/spark-kubernetes-operator
   build-image:
     name: "Build Operator Image CI"
     runs-on: ubuntu-latest
@@ -95,3 +92,24 @@ jobs:
           ./gradlew spark-operator-api:relocateGeneratedCRD
           helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
           helm test spark-kubernetes-operator
+  lint:
+    name: "Linter and documentation"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'adopt'
+          cache: 'gradle'
+      - name: Linters
+        run: |
+          ./gradlew build -x test
+      - name: Javadoc Generation
+        run: |
+          ./gradlew javadoc
+      - name: Validate helm chart linting
+        run: |
+          helm lint --strict build-tools/helm/spark-kubernetes-operator

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -52,7 +52,7 @@ import org.apache.spark.k8s.operator.reconciler.SparkAppReconciler;
 import org.apache.spark.k8s.operator.utils.SparkAppStatusRecorder;
 
 /**
- * Entry point for Spark Operator. Bootstrap the operator app by starting watch & reconciler for
+ * Entry point for Spark Operator. Bootstrap the operator app by starting watch and reconciler for
  * SparkApps, starting watch for hot property loading, if enabled, and starting metrics server with
  * sentinel monitor if enabled
  */

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java
@@ -40,8 +40,8 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * This serves dynamic configuration for Spark Operator. When enabled, Operator assumes config file
- * is located in given config map. It would keep watch the config map & apply changes when update is
- * detected.
+ * is located in given config map. It would keep watch the config map and apply changes when update
+ * is detected.
  */
 @ControllerConfiguration
 @RequiredArgsConstructor

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/SparkAppStatusUtils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/SparkAppStatusUtils.java
@@ -24,7 +24,7 @@ import org.apache.spark.k8s.operator.SparkApplication;
 import org.apache.spark.k8s.operator.status.ApplicationState;
 import org.apache.spark.k8s.operator.status.ApplicationStateSummary;
 
-/** Handy utils for create & manage Application Status */
+/** Handy utils for create and manage Application Status */
 public final class SparkAppStatusUtils {
 
   private SparkAppStatusUtils() {}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
@@ -47,8 +47,8 @@ import org.apache.spark.k8s.operator.status.BaseStatus;
  * <a href="https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/AppStatusRecorder.java">Flink Operator Status Recorder</a>
  * </pre>
  *
- * Enables additional (extendable) observers for Spark App status. Cache & version locking might be
- * removed in future version as batch app does not expect spec change after submitted.
+ * Enables additional (extendable) observers for Spark App status. Cache and version locking might
+ * be removed in future version as batch app does not expect spec change after submitted.
  */
 @Slf4j
 public class StatusRecorder<


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `javadoc` generation and add `lint` GitHub Action job to prevent.

In addition, `HelmChart` lint step is also moved into new `lint` GitHub Action job.

### Why are the changes needed?

Currently, `javadoc` task fails due to `bad HTML entity` errors.
```
$ ./gradlew javadoc
...
> Task :spark-operator:javadoc FAILED
/Users/dongjoon/APACHE/spark-kubernetes-operator/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java:43: error: bad HTML entity
 * is located in given config map. It would keep watch the config map & apply changes when update is
...
4 errors
...
BUILD FAILED in 1s
8 actionable tasks: 1 executed, 7 up-to-date
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with newly added `lint` CI test job.

### Was this patch authored or co-authored using generative AI tooling?

No.