### PR TITLE
[SPARK-49293] Add `_MESSAGE` postfix to `DRIVER_(READY|RUNNING)`

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
@@ -64,8 +64,8 @@ public class Constants {
       "The driver has not responded to the initial health check request within the "
           + "allotted start-up time. This can be configured by setting "
           + ".spec.applicationTolerations.applicationTimeoutConfig.";
-  public static final String DRIVER_RUNNING = "Driver has started running.";
-  public static final String DRIVER_READY = "Driver has reached ready state.";
+  public static final String DRIVER_RUNNING_MESSAGE = "Driver has started running.";
+  public static final String DRIVER_READY_MESSAGE = "Driver has reached ready state.";
   public static final String SUBMITTED_STATE_MESSAGE =
       "Spark application has been created on Kubernetes Cluster.";
   public static final String UNKNOWN_STATE_MESSAGE = "Cannot process application status.";

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverReadyObserver.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverReadyObserver.java
@@ -19,7 +19,7 @@
 
 package org.apache.spark.k8s.operator.reconciler.observers;
 
-import static org.apache.spark.k8s.operator.Constants.DRIVER_READY;
+import static org.apache.spark.k8s.operator.Constants.DRIVER_READY_MESSAGE;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.DriverReady;
 
 import java.util.Optional;
@@ -40,7 +40,7 @@ public class AppDriverReadyObserver extends BaseAppDriverObserver {
       return Optional.empty();
     }
     if (PodUtils.isPodReady(driver)) {
-      return Optional.of(new ApplicationState(DriverReady, DRIVER_READY));
+      return Optional.of(new ApplicationState(DriverReady, DRIVER_READY_MESSAGE));
     }
     return observeDriverTermination(driver, true, spec);
   }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverStartObserver.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/observers/AppDriverStartObserver.java
@@ -19,7 +19,7 @@
 
 package org.apache.spark.k8s.operator.reconciler.observers;
 
-import static org.apache.spark.k8s.operator.Constants.DRIVER_RUNNING;
+import static org.apache.spark.k8s.operator.Constants.DRIVER_RUNNING_MESSAGE;
 import static org.apache.spark.k8s.operator.status.ApplicationStateSummary.DriverStarted;
 
 import java.util.Optional;
@@ -40,7 +40,7 @@ public class AppDriverStartObserver extends BaseAppDriverObserver {
       return Optional.empty();
     }
     if (PodUtils.isDriverPodStarted(driver, spec)) {
-      return Optional.of(new ApplicationState(DriverStarted, DRIVER_RUNNING));
+      return Optional.of(new ApplicationState(DriverStarted, DRIVER_RUNNING_MESSAGE));
     }
     return observeDriverTermination(driver, false, spec);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename
- `DRIVER_RUNNING` -> `DRIVER_RUNNING_MESSAGE`
- `DRIVER_READY` -> `DRIVER_READY_MESSAGE`

### Why are the changes needed?

To match the constant string patterns in `Constants.java`. These two are the only exceptions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review because this is a renaming.

### Was this patch authored or co-authored using generative AI tooling?

No.