### PR TITLE
[SPARK-49296] Add `deploy.gradle` to support publish-related tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ buildscript {
 assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17): "Java 17 or newer is " +
     "required"
 
+allprojects {
+  group = "org.apache.spark.k8s.operator"
+  version = "0.1.0"
+}
+
 subprojects {
   apply plugin: 'idea'
   apply plugin: 'eclipse'
@@ -104,3 +109,5 @@ subprojects {
     }
   }
 }
+
+apply from: 'deploy.gradle'

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+if (project.hasProperty('release') && JavaVersion.current().getMajorVersion().toString() != '17') {
+  throw new GradleException("Releases must be built with Java 17")
+}
+
+subprojects {
+  apply plugin: 'maven-publish'
+  apply plugin: 'signing'
+  afterEvaluate {
+    task sourceJar(type: Jar, dependsOn: classes) {
+      archiveClassifier.set('sources')
+      from sourceSets.main.allSource
+      group 'build'
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+      archiveClassifier.set('javadoc')
+      from javadoc.destinationDir
+      group 'build'
+    }
+
+    task testJar(type: Jar) {
+      archiveClassifier.set('tests')
+      from sourceSets.test.output
+    }
+
+    artifacts {
+      archives sourceJar
+      archives javadocJar
+      archives testJar
+    }
+
+    // add LICENSE and NOTICE
+    [jar, sourceJar, javadocJar, testJar].each { task ->
+      task.from(rootDir) {
+        include 'LICENSE'
+        include 'NOTICE'
+      }
+    }
+
+    publishing {
+      publications {
+        apache(MavenPublication) {
+          if (tasks.matching({task -> task.name == 'shadowJar'}).isEmpty()) {
+            from components.java
+          } else {
+            project.shadow.component(it)
+          }
+
+          artifact sourceJar
+          artifact javadocJar
+          artifact testJar
+
+          versionMapping {
+            allVariants {
+              fromResolutionResult()
+            }
+          }
+
+          groupId = 'org.apache.spark'
+          pom {
+            name = 'Apache Spark'
+            description = 'A fast and general purpose engine for large-scale data processin'
+            url = 'https://spark.apache.org'
+            licenses {
+              license {
+                name = 'The Apache Software License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+              }
+            }
+            mailingLists {
+              mailingList {
+                name = 'Dev Mailing List'
+                post = 'dev@spark.apache.org'
+                subscribe = 'dev-subscribe@spark.apache.org'
+                unsubscribe = 'dev-unsubscribe@spark.apache.org'
+              }
+            }
+            issueManagement {
+              system = 'JIRA'
+              url = 'https://issues.apache.org/jira/browse/SPARK'
+            }
+          }
+        }
+      }
+
+      repositories {
+        maven {
+          credentials {
+            username project.hasProperty('mavenUser') ? "$mavenUser" : ""
+            password project.hasProperty('mavenPassword') ? "$mavenPassword" : ""
+          }
+          // upload to the releases repository using ./gradlew -Prelease publish
+          def apacheSnapshotsRepoUrl = 'https://repository.apache.org/content/repositories/snapshots'
+          def apacheReleasesRepoUrl = 'https://repository.apache.org/service/local/staging/deploy/maven2'
+          def snapshotsRepoUrl = project.hasProperty('mavenSnapshotsRepo') ? "$mavenSnapshotsRepo" : "$apacheSnapshotsRepoUrl"
+          def releasesRepoUrl = project.hasProperty('mavenReleasesRepo') ? "$mavenReleasesRepo" : "$apacheReleasesRepoUrl"
+          url = project.hasProperty('release') ? releasesRepoUrl : snapshotsRepoUrl
+        }
+      }
+    }
+
+    if (project.hasProperty('release')) {
+      signing {
+        useGpgCmd()
+        sign publishing.publications.apache
+      }
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,6 @@
 # limitations under the License.
 #
 
-group=org.apache.spark.k8s.operator
-version=0.1.0
-
 # Gradle
 org.gradle.jvmargs=-Xmx4g
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `deploy.gradle` to support publish-related tasks.

Note that the current `spark-operator-0.1.0.jar` is a fat uber jar shading many things which we don't want to publish even to the snapshot repository.

### Why are the changes needed?

We can use like the following.
```
$ rm -rf ~/.m2/repository/org/apache/spark
```

```
$ gradle publishToMavenLocal

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD

BUILD SUCCESSFUL in 612ms
32 actionable tasks: 8 executed, 24 up-to-date
```

```
$ tree ~/.m2/repository/org/apache/spark
/Users/dongjoon/.m2/repository/org/apache/spark
├── spark-operator
│   ├── 0.1.0
│   │   ├── spark-operator-0.1.0-javadoc.jar
│   │   ├── spark-operator-0.1.0-sources.jar
│   │   ├── spark-operator-0.1.0-tests.jar
│   │   ├── spark-operator-0.1.0.jar
│   │   └── spark-operator-0.1.0.pom
│   └── maven-metadata-local.xml
├── spark-operator-api
│   ├── 0.1.0
│   │   ├── spark-operator-api-0.1.0-javadoc.jar
│   │   ├── spark-operator-api-0.1.0-sources.jar
│   │   ├── spark-operator-api-0.1.0-tests.jar
│   │   ├── spark-operator-api-0.1.0.jar
│   │   ├── spark-operator-api-0.1.0.module
│   │   └── spark-operator-api-0.1.0.pom
│   └── maven-metadata-local.xml
└── spark-submission-worker
    ├── 0.1.0
    │   ├── spark-submission-worker-0.1.0-javadoc.jar
    │   ├── spark-submission-worker-0.1.0-sources.jar
    │   ├── spark-submission-worker-0.1.0-tests.jar
    │   ├── spark-submission-worker-0.1.0.jar
    │   ├── spark-submission-worker-0.1.0.module
    │   └── spark-submission-worker-0.1.0.pom
    └── maven-metadata-local.xml

7 directories, 20 files
```

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change and additional build step.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.