### PR TITLE
[MINOR] Use `IOException` in `SparkOperatorConfManager`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
@@ -20,6 +20,7 @@
 package org.apache.spark.k8s.operator.config;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
@@ -93,7 +94,7 @@ public class SparkOperatorConfManager {
     Properties properties = new Properties();
     try (InputStream inputStream = new FileInputStream(filePath)) {
       properties.load(inputStream);
-    } catch (Exception e) {
+    } catch (IOException e) {
       log.error("Failed to load properties from {}.", filePath, e);
     }
     return properties;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to catch `IOException` instead of `Exception` in `SparkOperatorConfManager`.

### Why are the changes needed?

There are five instances of `catch` statement with a general `Exception` class, and four instances look okay based on their context. For `SparkOperatorConfManager`, we had better use a specific one, `IOException`, because it only throws  `IOException` and its derived class, `FileNotFoundException`.
```
$ git grep 'catch (Exception'
spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java:    } catch (Exception e) {
spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetrics.java:    } catch (Exception e) {
spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppCleanUpStep.java:      } catch (Exception e) {
spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppInitStep.java:    } catch (Exception e) {
spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetricsTest.java:    } catch (Exception e) {
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.