### PR TITLE
[SPARK-49298] Reduce `spark-operator` fat jar size by excluding dependencies

### DIFF
--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -25,7 +25,6 @@ dependencies {
   annotationProcessor("io.fabric8:crd-generator-apt:$fabric8Version")
 
   // utils
-  implementation("commons-io:commons-io:$commonsIOVersion")
   implementation("org.projectlombok:lombok:$lombokVersion")
   annotationProcessor("org.projectlombok:lombok:$lombokVersion")
 

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -43,10 +43,17 @@ dependencies {
   implementation("io.dropwizard.metrics:metrics-core:$dropwizardMetricsVersion")
   implementation("io.dropwizard.metrics:metrics-jvm:$dropwizardMetricsVersion")
   compileOnly("org.apache.spark:spark-core_$scalaVersion:$sparkVersion") {
-    exclude group: 'com.squareup.okio'
-    exclude group: 'com.squareup.okhttp3'
+    exclude group: "com.github.luben"
+    exclude group: "io.netty", module: "netty-tcnative-boringssl-static"
+    exclude group: "io.netty", module: "netty-tcnative-classes"
     exclude group: "org.apache.logging.log4j"
+    exclude group: "org.fusesource.leveldbjni"
+    exclude group: "org.lz4"
+    exclude group: "org.rocksdb"
     exclude group: "org.slf4j"
+    exclude group: "org.xerial.snappy"
+    exclude group: 'com.squareup.okhttp3'
+    exclude group: 'com.squareup.okio'
   }
   compileOnly("org.projectlombok:lombok:$lombokVersion")
 

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -20,6 +20,13 @@ dependencies {
   implementation project(":spark-operator-api")
 
   implementation("org.apache.spark:spark-kubernetes_$scalaVersion:$sparkVersion") {
+    exclude group: "com.github.luben"
+    exclude group: "io.netty", module: "netty-tcnative-boringssl-static"
+    exclude group: "io.netty", module: "netty-tcnative-classes"
+    exclude group: "org.fusesource.leveldbjni"
+    exclude group: "org.lz4"
+    exclude group: "org.rocksdb"
+    exclude group: "org.xerial.snappy"
     exclude group: 'commons-collections', module: 'commons-collections'
   }
 
@@ -29,7 +36,6 @@ dependencies {
   testImplementation platform("org.junit:junit-bom:$junitVersion")
   testImplementation "org.mockito:mockito-core:$mockitoVersion"
   testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-  testImplementation "io.fabric8:kubernetes-server-mock:$fabric8Version"
   testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce `spark-operator` module's fat jar size by excluding dependencies

### Why are the changes needed?

This PR reduces the size from `227M` to `148M`. It's `35%` reduction.

**BEFORE**
```
$ ls -alh spark-operator/build/libs/spark-kubernetes-operator-0.1.0-all.jar
-rw-r--r--  1 dongjoon  staff   227M Aug 18 23:09 spark-operator/build/libs/spark-kubernetes-operator-0.1.0-all.jar
```

**AFTER**
```
$ ls -alh spark-operator/build/libs/spark-kubernetes-operator-0.1.0-all.jar
-rw-r--r--  1 dongjoon  staff   148M Aug 18 23:03 spark-operator/build/libs/spark-kubernetes-operator-0.1.0-all.jar
```

Please note that we reduced docker image from `892MB` to `654MB` by removing redundant `chown` commands before. After this PR, we have `571MB`.
- #33

```
$ docker images | head -n3
REPOSITORY                            TAG               IMAGE ID       CREATED              SIZE
spark-kubernetes-operator             0.1.0             657fadd103c9   About a minute ago   571MB
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

After passing the CIs, this should be tested manually.

### Was this patch authored or co-authored using generative AI tooling?

No.