### PR TITLE
[SPARK-49299] Add `buildDockerImage` Gradle Task

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Operator Image
         run: |
-          docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
+          ./gradlew buildDockerImage
           docker run spark-kubernetes-operator:0.1.0
   k8s-integration-tests:
     name: "K8s Integration Tests"
@@ -82,7 +82,7 @@ jobs:
         run: |
           kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
           eval $(minikube docker-env)
-          docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
+          ./gradlew buildDockerImage
           kubectl run spark-kubernetes-operator --image=spark-kubernetes-operator:0.1.0 --restart=Never
           sleep 5
           kubectl get pods -A

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,6 +50,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'adopt'
+          cache: 'gradle'
       - name: Build Operator Image
         run: |
           ./gradlew buildDockerImage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ ./gradlew build
 ## Build Docker Image
 
 ```bash
-$ docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile  .
+$ ./gradlew buildDockerImage
 ```
 
 ## Install Helm Chart

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ allprojects {
   version = "0.1.0"
 }
 
+tasks.register('buildDockerImage', Exec) {
+  String cmd = "docker build --build-arg APP_VERSION=${version} -t spark-kubernetes-operator:${version} -f build-tools/docker/Dockerfile ."
+  println "Build Docker Image: $cmd"
+  commandLine "sh", "-c", "$cmd"
+}
+
 subprojects {
   apply plugin: 'idea'
   apply plugin: 'eclipse'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `buildDockerImage` Gradle Task and update `README.md` and `GitHub Action CIs` accordingly.

### Why are the changes needed?

To provide an easy way to build the image without knowing the current version number.

**BEFORE**
```
$ docker build --build-arg APP_VERSION=0.1.0 -t spark-kubernetes-operator:0.1.0 -f build-tools/docker/Dockerfile .
```

**AFTER**
```
./gradlew buildDockerImage
```

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change.

### How was this patch tested?

Pass the CIs with the newly updated CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.