### PR TITLE
[SPARK-49304] Add `-SNAPSHOT` postfix to `Spark Operator` version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build Operator Image
         run: |
           ./gradlew buildDockerImage
-          docker run spark-kubernetes-operator:0.1.0
+          docker run spark-kubernetes-operator:$(./gradlew properties | grep '^version:' | awk '{print $2}')
   k8s-integration-tests:
     name: "K8s Integration Tests"
     runs-on: ubuntu-latest
@@ -89,12 +89,6 @@ jobs:
           kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
           eval $(minikube docker-env)
           ./gradlew buildDockerImage
-          kubectl run spark-kubernetes-operator --image=spark-kubernetes-operator:0.1.0 --restart=Never
-          sleep 5
-          kubectl get pods -A
-          kubectl logs spark-kubernetes-operator
-          kubectl delete pod spark-kubernetes-operator
-          # helm
           ./gradlew spark-operator-api:relocateGeneratedCRD
           helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
           helm test spark-kubernetes-operator

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -16,7 +16,7 @@
 image:
   repository: spark-kubernetes-operator
   pullPolicy: IfNotPresent
-  tag: 0.1.0
+  tag: 0.1.0-SNAPSHOT
   # If image digest is set then it takes precedence and the image tag will be ignored
   # digest: ""
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17): "Java 17 
 
 allprojects {
   group = "org.apache.spark.k8s.operator"
-  version = "0.1.0"
+  version = "0.1.0-SNAPSHOT"
 }
 
 tasks.register('buildDockerImage', Exec) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `-SNAPSHOT` postfix to `Spark Kubernetes Operator` version as a part of preparation of official release.

### Why are the changes needed?

To distinguish the dev version from the future official release.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.