### PR TITLE
[SPARK-49305] Revise `Spark Operator` docker image

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -30,15 +30,14 @@ LABEL org.opencontainers.image.version="${APP_VERSION}"
 
 ENV SPARK_OPERATOR_HOME=/opt/spark-operator
 ENV SPARK_OPERATOR_WORK_DIR=/opt/spark-operator/operator
-ENV APP_VERSION=$APP_VERSION
-ENV OPERATOR_JAR=spark-kubernetes-operator-$APP_VERSION-all.jar
+ENV SPARK_OPERATOR_JAR=spark-kubernetes-operator.jar
 
 WORKDIR $SPARK_OPERATOR_WORK_DIR
 RUN groupadd --system --gid=$SPARK_UID spark && \
     useradd --system --home-dir $SPARK_OPERATOR_HOME --uid=$SPARK_UID --gid=spark spark && \
     chown -R spark:spark $SPARK_OPERATOR_HOME
 
-COPY --from=builder --chown=spark:spark /app/spark-operator/build/libs/$OPERATOR_JAR .
+COPY --from=builder --chown=spark:spark /app/spark-operator/build/libs/spark-kubernetes-operator-$APP_VERSION-all.jar $SPARK_OPERATOR_JAR
 COPY --from=builder --chown=spark:spark /app/build-tools/docker/docker-entrypoint.sh .
 
 

--- a/build-tools/docker/docker-entrypoint.sh
+++ b/build-tools/docker/docker-entrypoint.sh
@@ -26,7 +26,7 @@ if [ "$1" = "help" ]; then
 elif [ "$1" = "operator" ]; then
   echo "Starting Operator..."
 
-  exec java -cp "./$OPERATOR_JAR" "$LOG_CONFIG" "$OPERATOR_JAVA_OPTS" org.apache.spark.k8s.operator.SparkOperator
+  exec java -cp "./$SPARK_OPERATOR_JAR" "$LOG_CONFIG" "$OPERATOR_JAVA_OPTS" org.apache.spark.k8s.operator.SparkOperator
 fi
 
 args=("${args[@]}")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revise `Spark Operator` docker image.

### Why are the changes needed?

- Environment Variables.
  - Remove `APP_VERSION` because image tag and metadata contain the version information already.
  - Rename `OPERATOR_JAR` to `SPARK_OPERATOR_JAR` like `SPARK_OPERATOR_HOME` and `SPARK_OPERATOR_WORK_DIR`.

- Remove version string from jar name to simplify.

**BEFORE**
```
$ docker run -it --rm spark-kubernetes-operator:0.1.0-SNAPSHOT ls -al | tail -n1
-rw-r--r-- 1 spark spark 154955452 Aug 19 19:29 spark-kubernetes-operator-0.1.0-SNAPSHOT-all.jar
```

**AFTER**
```
$ docker run -it --rm spark-kubernetes-operator:0.1.0-SNAPSHOT ls -al | tail -n1
-rw-r--r-- 1 spark spark 154955452 Aug 19 19:18 spark-kubernetes-operator.jar
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.