### PR TITLE
[SPARK-49309] Use `HTTP_*` constant variables instead of magic numbers

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/PrometheusPullModelHandler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/PrometheusPullModelHandler.java
@@ -19,6 +19,7 @@
 
 package org.apache.spark.k8s.operator.metrics;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.spark.k8s.operator.utils.ProbeUtil.sendMessage;
 
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class PrometheusPullModelHandler extends PrometheusServlet implements Htt
   public void handle(HttpExchange exchange) throws IOException {
     HttpServletRequest httpServletRequest = null;
     String value = getMetricsSnapshot(httpServletRequest);
-    sendMessage(exchange, 200, String.join("\n", filterNonEmptyRecords(value)));
+    sendMessage(exchange, HTTP_OK, String.join("\n", filterNonEmptyRecords(value)));
   }
 
   protected List<String> filterNonEmptyRecords(String metricsSnapshot) {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/probe/HealthProbe.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/probe/HealthProbe.java
@@ -19,6 +19,8 @@
 
 package org.apache.spark.k8s.operator.probe;
 
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.spark.k8s.operator.utils.ProbeUtil.areOperatorsStarted;
 import static org.apache.spark.k8s.operator.utils.ProbeUtil.sendMessage;
 
@@ -76,9 +78,9 @@ public class HealthProbe implements HttpHandler {
   @Override
   public void handle(HttpExchange exchange) throws IOException {
     if (isHealthy()) {
-      sendMessage(exchange, 200, "healthy");
+      sendMessage(exchange, HTTP_OK, "healthy");
     } else {
-      sendMessage(exchange, 500, "unhealthy");
+      sendMessage(exchange, HTTP_INTERNAL_ERROR, "unhealthy");
     }
   }
 

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/probe/ReadinessProbe.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/probe/ReadinessProbe.java
@@ -19,6 +19,7 @@
 
 package org.apache.spark.k8s.operator.probe;
 
+import static java.net.HttpURLConnection.*;
 import static org.apache.spark.k8s.operator.utils.ProbeUtil.areOperatorsStarted;
 import static org.apache.spark.k8s.operator.utils.ProbeUtil.sendMessage;
 
@@ -43,14 +44,15 @@ public class ReadinessProbe implements HttpHandler {
   public void handle(HttpExchange httpExchange) throws IOException {
     Optional<Boolean> operatorsAreReady = areOperatorsStarted(operators);
     if (operatorsAreReady.isEmpty() || !operatorsAreReady.get()) {
-      sendMessage(httpExchange, 400, "spark operators are not ready yet");
+      sendMessage(httpExchange, HTTP_BAD_REQUEST, "spark operators are not ready yet");
     }
 
     if (!passRbacCheck()) {
-      sendMessage(httpExchange, 403, "required rbac test failed, operators are not ready");
+      sendMessage(
+          httpExchange, HTTP_FORBIDDEN, "required rbac test failed, operators are not ready");
     }
 
-    sendMessage(httpExchange, 200, "started");
+    sendMessage(httpExchange, HTTP_OK, "started");
   }
 
   public boolean passRbacCheck() {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/ProbeUtil.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/ProbeUtil.java
@@ -30,11 +30,20 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.RuntimeInfo;
 import lombok.extern.slf4j.Slf4j;
 
+/** A utility class to provide common functionalities for probe services. */
 @Slf4j
 public final class ProbeUtil {
 
   private ProbeUtil() {}
 
+  /**
+   * Send an HTTP response message with the given response header HTTP status code and message.
+   *
+   * @param httpExchange The handler for this HTTP response.
+   * @param code A response header HTTP status code defined in java.net.HttpURLConnection.HTTP_*
+   * @param message A message to send as a body
+   * @throws IOException Failed to send a response.
+   */
   public static void sendMessage(HttpExchange httpExchange, int code, String message)
       throws IOException {
     try (OutputStream outputStream = httpExchange.getResponseBody()) {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/SparkExceptionUtils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/SparkExceptionUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.spark.k8s.operator.utils;
 
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -29,7 +31,7 @@ public final class SparkExceptionUtils {
 
   public static boolean isConflictForExistingResource(KubernetesClientException e) {
     return e != null
-        && e.getCode() == 409
+        && e.getCode() == HTTP_CONFLICT
         && e.getStatus() != null
         && StringUtils.isNotEmpty(e.getStatus().toString())
         && e.getStatus().toString().toLowerCase().contains("alreadyexists");

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ProbeServiceTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ProbeServiceTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.spark.k8s.operator.probe;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.OPERATOR_PROBE_PORT;
 import static org.apache.spark.k8s.operator.probe.ProbeService.HEALTHZ;
 import static org.apache.spark.k8s.operator.probe.ProbeService.READYZ;
@@ -121,7 +122,7 @@ class ProbeServiceTest {
     HttpURLConnection connection = (HttpURLConnection) u.openConnection();
     connection.setConnectTimeout(100000);
     connection.connect();
-    assertEquals(connection.getResponseCode(), 200, "Health Probe should return 200");
+    assertEquals(connection.getResponseCode(), HTTP_OK, "Health Probe should return HTTP_OK");
   }
 
   private void hitStartedUpEndpoint() throws IOException, MalformedURLException {
@@ -129,6 +130,6 @@ class ProbeServiceTest {
     HttpURLConnection connection = (HttpURLConnection) u.openConnection();
     connection.setConnectTimeout(100000);
     connection.connect();
-    assertEquals(connection.getResponseCode(), 200, "operators are not ready");
+    assertEquals(connection.getResponseCode(), HTTP_OK, "operators are not ready");
   }
 }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.spark.k8s.operator.probe;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,7 +64,7 @@ class ReadinessProbeTest {
     ReadinessProbe readinessProbe = new ReadinessProbe(Arrays.asList(operator));
     try (var mockedStatic = Mockito.mockStatic(ProbeUtil.class)) {
       readinessProbe.handle(httpExchange);
-      mockedStatic.verify(() -> ProbeUtil.sendMessage(httpExchange, 200, "started"));
+      mockedStatic.verify(() -> ProbeUtil.sendMessage(httpExchange, HTTP_OK, "started"));
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `java.net.HttpURLConnection.HTTP_*` constant variables instead of magic numbers in the code.

### Why are the changes needed?

Variable names provide semantics.

```
- if (e.getCode() == 409) {
+ if (e.getCode() == HTTP_CONFLICT) {
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.