### PR TITLE
[SPARK-49315] Generalize `relocateGeneratedCRD` Gradle Task to handle `*.spark.apache.org-v1.yml`

### DIFF
--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -52,7 +52,8 @@ tasks.register('finalizeGeneratedCRD', Exec) {
 // Copy generated yaml to Helm charts
 tasks.register('relocateGeneratedCRD', Copy) {
   dependsOn finalizeGeneratedCRD
-  from "build/classes/java/main/META-INF/fabric8/sparkapplications.spark.apache.org-v1.yml"
+  from "build/classes/java/main/META-INF/fabric8/"
+  include "*.spark.apache.org-v1.yml"
   into "../build-tools/helm/spark-kubernetes-operator/crds"
   rename '(.+).yml', '$1.yaml'
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to generalize `relocateGeneratedCRD` Gradle Task to handle `*.spark.apache.org-v1.yml`.

### Why are the changes needed?

To support the future CRDs generally.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs for now.

### Was this patch authored or co-authored using generative AI tooling?

No.