### PR TITLE
[SPARK-49316] Generalize `printer-columns.sh` to handle `*.spark.apache.org-v1.yml` files

### DIFF
--- a/spark-operator-api/src/main/resources/printer-columns.sh
+++ b/spark-operator-api/src/main/resources/printer-columns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -21,6 +21,7 @@
 # We do a yq to add printer columns
 
 SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
-CRD_PATH="${SCRIPT_PATH}/../../../build/classes/java/main/META-INF/fabric8/sparkapplications.spark.apache.org-v1.yml"
-yq -i '.spec.versions[0] += ({"additionalPrinterColumns": [{"jsonPath": ".status.currentState.currentStateSummary", "name": "Current State", "type": "string"}, {"jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date"}]})' ${CRD_PATH}
+for f in $(ls ${SCRIPT_PATH}/../../../build/classes/java/main/META-INF/fabric8/*.spark.apache.org-v1.yml); do
+  yq -i '.spec.versions[0] += ({"additionalPrinterColumns": [{"jsonPath": ".status.currentState.currentStateSummary", "name": "Current State", "type": "string"}, {"jsonPath": ".metadata.creationTimestamp", "name": "Age", "type": "date"}]})' $f
+done
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to generalize `printer-columns.sh` to handle `*.spark.apache.org-v1.yml` files

### Why are the changes needed?

To support the future CRDs generally.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs for now.

### Was this patch authored or co-authored using generative AI tooling?

No.