### PR TITLE
[SPARK-49317] Add `pi-on-yunikorn.yaml` example and update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ pi     ResourceReleased   4m10s
 $ kubectl delete sparkapp/pi
 ```
 
+## Run Spark Pi App on Apache YuniKorn scheduler
+
+```bash
+$ helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.5.2 --create-namespace --set embedAdmissionController=false
+
+$ kubectl apply -f examples/pi-on-yunikorn.yaml
+
+$ kubectl describe pod pi-on-yunikorn-0-driver
+...
+Events:
+  Type    Reason             Age   From      Message
+  ----    ------             ----  ----      -------
+  Normal  Scheduling         14s   yunikorn  default/pi-on-yunikorn-0-driver is queued and waiting for allocation
+  Normal  Scheduled          14s   yunikorn  Successfully assigned default/pi-on-yunikorn-0-driver to node docker-desktop
+  Normal  PodBindSuccessful  14s   yunikorn  Pod default/pi-on-yunikorn-0-driver is successfully bound to node docker-desktop
+  Normal  TaskCompleted      6s    yunikorn  Task default/pi-on-yunikorn-0-driver is completed
+  Normal  Pulled             13s   kubelet   Container image "spark:4.0.0-preview1" already present on machine
+  Normal  Created            13s   kubelet   Created container spark-kubernetes-driver
+  Normal  Started            13s   kubelet   Started container spark-kubernetes-driver
+
+$ kubectl delete sparkapp pi-on-yunikorn
+sparkapplication.spark.apache.org "pi-on-yunikorn" deleted
+```
+
 ## Contributing
 
 Please review the [Contribution to Spark guide](https://spark.apache.org/contributing.html)

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: pi-on-yunikorn
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  driverArgs: [ "20000" ]
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.log.structuredLogging.enabled: "false"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.scheduler.name: "yunikorn"
+    spark.kubernetes.driver.label.queue: "root.default"
+    spark.kubernetes.executor.label.queue: "root.default"
+    spark.kubernetes.driver.annotation.yunikorn.apache.org/app-id: "{{APP_ID}}"
+    spark.kubernetes.executor.annotation.yunikorn.apache.org/app-id: "{{APP_ID}}"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    scalaVersion: "2.13"
+    sparkVersion: "4.0.0-preview1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi-on-yunikorn.yaml` example and updates `README.md` accordingly.

### Why are the changes needed?

To provide an explicit example for batch scheduler environments.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test with the newly added instructions at `README.md`.

```
$ helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.5.2 --create-namespace --set embedAdmissionController=false

$ kubectl apply -f examples/pi-on-yunikorn.yaml

$ kubectl delete sparkapp pi-on-yunikorn
```

### Was this patch authored or co-authored using generative AI tooling?

No.