### PR TITLE
[SPARK-49319] Add `SparkCluster` to `spark-operator-api` module and examples

### DIFF
--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkCluster
+metadata:
+  name: prod
+spec:
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview1"
+  initWorkers: 3
+  minWorkers: 3
+  maxWorkers: 3
+  sparkConf:
+    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.master.ui.title: "Prod Spark Cluster"

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkCluster
+metadata:
+  name: qa
+spec:
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview1"
+  initWorkers: 1
+  minWorkers: 1
+  maxWorkers: 1
+  sparkConf:
+    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.master.ui.title: "QA Spark Cluster"

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
@@ -89,7 +89,7 @@ public class Constants {
   public static final String CLUSTER_SCHEDULE_FAILURE_MESSAGE =
       "Failed to request Spark cluster from scheduler backend.";
   public static final String CLUSTER_SUBMITTED_STATE_MESSAGE =
-      "Spark cluster has been created on Kubernetes Cluster.";
+      "Spark cluster has been submitted to Kubernetes Cluster.";
   public static final String CLUSTER_READY_MESSAGE = "Cluster has reached ready state.";
   public static final String UNKNOWN_CLUSTER_STATE_MESSAGE = "Cannot process cluster status.";
 }

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
   public static final String API_GROUP = "spark.apache.org";
   public static final String API_VERSION = "v1alpha1";
   public static final String LABEL_SPARK_APPLICATION_NAME = "spark.operator/spark-app-name";
+  public static final String LABEL_SPARK_CLUSTER_NAME = "spark.operator/spark-cluster-name";
   public static final String LABEL_SPARK_OPERATOR_NAME = "spark.operator/name";
   public static final String LABEL_SENTINEL_RESOURCE = "spark.operator/sentinel";
   public static final String LABEL_RESOURCE_NAME = "app.kubernetes.io/name";
@@ -30,6 +31,9 @@ public class Constants {
   public static final String LABEL_SPARK_ROLE_NAME = "spark-role";
   public static final String LABEL_SPARK_ROLE_DRIVER_VALUE = "driver";
   public static final String LABEL_SPARK_ROLE_EXECUTOR_VALUE = "executor";
+  public static final String LABEL_SPARK_ROLE_CLUSTER_VALUE = "cluster";
+  public static final String LABEL_SPARK_ROLE_MASTER_VALUE = "master";
+  public static final String LABEL_SPARK_ROLE_WORKER_VALUE = "worker";
   public static final String SENTINEL_RESOURCE_DUMMY_FIELD = "sentinel.dummy.number";
 
   public static final String DRIVER_SPARK_CONTAINER_PROP_KEY =
@@ -80,4 +84,12 @@ public class Constants {
       "The Spark application is running with less than minimal number of requested executors.";
   public static final String EXECUTOR_LAUNCH_TIMEOUT_MESSAGE =
       "The Spark application failed to get enough executors in the given time threshold.";
+
+  // Spark Cluster Messages
+  public static final String CLUSTER_SCHEDULE_FAILURE_MESSAGE =
+      "Failed to request Spark cluster from scheduler backend.";
+  public static final String CLUSTER_SUBMITTED_STATE_MESSAGE =
+      "Spark cluster has been created on Kubernetes Cluster.";
+  public static final String CLUSTER_READY_MESSAGE = "Cluster has reached ready state.";
+  public static final String UNKNOWN_CLUSTER_STATE_MESSAGE = "Cannot process cluster status.";
 }

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/SparkCluster.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/SparkCluster.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+import org.apache.spark.k8s.operator.spec.ClusterSpec;
+import org.apache.spark.k8s.operator.status.ClusterAttemptSummary;
+import org.apache.spark.k8s.operator.status.ClusterState;
+import org.apache.spark.k8s.operator.status.ClusterStateSummary;
+import org.apache.spark.k8s.operator.status.ClusterStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize()
+@Group(Constants.API_GROUP)
+@Version(Constants.API_VERSION)
+@ShortNames({"sparkcluster"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SparkCluster
+    extends BaseResource<
+        ClusterStateSummary, ClusterAttemptSummary, ClusterState, ClusterSpec, ClusterStatus> {
+  @Override
+  public ClusterStatus initStatus() {
+    return new ClusterStatus();
+  }
+
+  @Override
+  public ClusterSpec initSpec() {
+    return new ClusterSpec();
+  }
+}

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/SparkClusterList.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/SparkClusterList.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator;
+
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class SparkClusterList extends DefaultKubernetesResourceList<SparkCluster> {}

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ClusterSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ClusterSpec.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.spec;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.generator.annotation.Required;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterSpec extends BaseSpec {
+  @Required protected RuntimeVersions runtimeVersions;
+  @Required protected int initWorkers;
+  @Required protected int minWorkers;
+  @Required protected int maxWorkers;
+}

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterAttemptSummary.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterAttemptSummary.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.status;
+
+import java.util.SortedMap;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterAttemptSummary extends BaseAttemptSummary {
+  protected final SortedMap<Long, ClusterState> stateTransitionHistory;
+
+  public ClusterAttemptSummary(
+      AttemptInfo attemptInfo, SortedMap<Long, ClusterState> stateTransitionHistory) {
+    super(attemptInfo);
+    this.stateTransitionHistory = stateTransitionHistory;
+  }
+
+  public ClusterAttemptSummary() {
+    this(new AttemptInfo(), null);
+  }
+
+  public ClusterAttemptSummary(AttemptInfo attemptInfo) {
+    this(attemptInfo, null);
+  }
+}

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterState.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterState.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.status;
+
+import static org.apache.spark.k8s.operator.Constants.CLUSTER_SUBMITTED_STATE_MESSAGE;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterState extends BaseState<ClusterStateSummary> implements Serializable {
+  public ClusterState() {
+    super(ClusterStateSummary.Submitted, Instant.now().toString(), CLUSTER_SUBMITTED_STATE_MESSAGE);
+  }
+
+  public ClusterState(ClusterStateSummary currentStateSummary, String message) {
+    super(currentStateSummary, Instant.now().toString(), message);
+  }
+}

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStateSummary.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStateSummary.java
@@ -32,13 +32,7 @@ public enum ClusterStateSummary implements BaseStateSummary {
   Failed,
 
   /** all resources (pods, services .etc have been cleaned up) */
-  ResourceReleased,
-
-  /**
-   * If configured, operator may mark app as terminated without releasing resources. While this can
-   * be helpful in dev phase, it shall not be enabled for prod use cases
-   */
-  TerminatedWithoutReleaseResources;
+  ResourceReleased;
 
   public boolean isInitializing() {
     return Submitted.equals(this);

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStateSummary.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStateSummary.java
@@ -23,6 +23,7 @@ public enum ClusterStateSummary implements BaseStateSummary {
   /** Spark cluster is submitted but yet scheduled */
   Submitted,
 
+  /** Spark cluster fails to schedule. */
   SchedulingFailure,
 
   /** Cluster is running healthy */

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStateSummary.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStateSummary.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.status;
+
+public enum ClusterStateSummary implements BaseStateSummary {
+  /** Spark cluster is submitted but yet scheduled */
+  Submitted,
+
+  SchedulingFailure,
+
+  /** Cluster is running healthy */
+  RunningHealthy,
+
+  /** Cluster failed */
+  Failed,
+
+  /** all resources (pods, services .etc have been cleaned up) */
+  ResourceReleased,
+
+  /**
+   * If configured, operator may mark app as terminated without releasing resources. While this can
+   * be helpful in dev phase, it shall not be enabled for prod use cases
+   */
+  TerminatedWithoutReleaseResources;
+
+  public boolean isInitializing() {
+    return Submitted.equals(this);
+  }
+
+  public boolean isStarting() {
+    return RunningHealthy.ordinal() > this.ordinal();
+  }
+
+  /**
+   * A state is 'terminated' if and only if no further actions are needed to reconcile it.
+   *
+   * @return true if the state indicates the cluster has terminated
+   */
+  public boolean isTerminated() {
+    return ResourceReleased.equals(this);
+  }
+
+  @Override
+  public boolean isFailure() {
+    return SchedulingFailure.equals(this) || Failed.equals(this);
+  }
+
+  @Override
+  public boolean isInfrastructureFailure() {
+    return SchedulingFailure.equals(this);
+  }
+}

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStatus.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/status/ClusterStatus.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.status;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterStatus
+    extends BaseStatus<ClusterStateSummary, ClusterState, ClusterAttemptSummary> {
+
+  public ClusterStatus() {
+    super(new ClusterState(), new ClusterAttemptSummary());
+  }
+
+  public ClusterStatus(
+      ClusterState currentState,
+      Map<Long, ClusterState> stateTransitionHistory,
+      ClusterAttemptSummary previousAttemptSummary,
+      ClusterAttemptSummary currentAttemptSummary) {
+    super(currentState, stateTransitionHistory, previousAttemptSummary, currentAttemptSummary);
+  }
+
+  /** Create a new ClusterStatus, set the given latest state as current and update state history */
+  public ClusterStatus appendNewState(ClusterState state) {
+    return new ClusterStatus(
+        state,
+        createUpdatedHistoryWithNewState(state),
+        previousAttemptSummary,
+        currentAttemptSummary);
+  }
+
+  private Map<Long, ClusterState> createUpdatedHistoryWithNewState(ClusterState state) {
+    TreeMap<Long, ClusterState> updatedHistory = new TreeMap<>(stateTransitionHistory);
+    updatedHistory.put(updatedHistory.lastKey() + 1L, state);
+    return updatedHistory;
+  }
+}

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ClusterSpecTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ClusterSpecTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.spec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class ClusterSpecTest {
+  @Test
+  void testBuilder() {
+    ClusterSpec spec1 = new ClusterSpec();
+    ClusterSpec spec2 = new ClusterSpec.ClusterSpecBuilder().build();
+    assertEquals(spec1, spec2);
+  }
+
+  @Test
+  void testInitSpecWithDefaults() {
+    ClusterSpec spec1 = new ClusterSpec();
+    assertNull(spec1.runtimeVersions);
+    assertEquals(0, spec1.initWorkers);
+    assertEquals(0, spec1.minWorkers);
+    assertEquals(0, spec1.maxWorkers);
+  }
+}

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/status/ClusterStatusTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/status/ClusterStatusTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.status;
+
+import static org.apache.spark.k8s.operator.status.ClusterStateSummary.Submitted;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ClusterStatusTest {
+  @Test
+  void testInitStatus() {
+    ClusterStatus status = new ClusterStatus();
+    assertEquals(Submitted, status.currentState.currentStateSummary);
+    assertEquals(1, status.getStateTransitionHistory().size());
+    assertEquals(status.currentState, status.getStateTransitionHistory().get(0L));
+  }
+
+  @Test
+  void testAppendNewState() {
+    ClusterStatus status = new ClusterStatus();
+    ClusterState newState = new ClusterState(ClusterStateSummary.RunningHealthy, "foo");
+    ClusterStatus newStatus = status.appendNewState(newState);
+    assertEquals(2, newStatus.getStateTransitionHistory().size());
+    assertEquals(newState, newStatus.getStateTransitionHistory().get(1L));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims the following.
- Extend `spark-operator-api` module by adding `SparkCluster` in addition to `SparkApplication`.
- Provide target examples

Most `SparkCluster` API changes are a straight-forward extension from `SparkApplication`.

### Why are the changes needed?

To make `Apache Spark K8s Operator` support `Spark Cluster` on K8s environment in the same way.

### Does this PR introduce _any_ user-facing change?

No. This is a new feature which is not released yet.

### How was this patch tested?

This only added API layer.

### Was this patch authored or co-authored using generative AI tooling?

No.