### PR TITLE
[SPARK-49325] Add `SparkCluster` to `spark-operator` module

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConf.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConf.java
@@ -143,6 +143,15 @@ public final class SparkOperatorConf {
           .defaultValue("")
           .build();
 
+  public static final ConfigOption<String> SPARK_CLUSTER_STATUS_LISTENER_CLASS_NAMES =
+      ConfigOption.<String>builder()
+          .key("spark.kubernetes.operator.reconciler.clusterStatusListenerClassNames")
+          .enableDynamicOverride(false)
+          .description("Comma-separated names of SparkClusterStatusListener class implementations")
+          .typeParameterClass(String.class)
+          .defaultValue("")
+          .build();
+
   public static final ConfigOption<Boolean> DYNAMIC_CONFIG_ENABLED =
       ConfigOption.<Boolean>builder()
           .key("spark.kubernetes.operator.dynamicConfig.enabled")

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.context;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import lombok.RequiredArgsConstructor;
+
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.SparkClusterResourceSpec;
+import org.apache.spark.k8s.operator.SparkClusterSubmissionWorker;
+import org.apache.spark.k8s.operator.reconciler.SparkClusterResourceSpecFactory;
+
+/**
+ * Context for {@link SparkCluster} resource, including secondary resource(s) and desired secondary
+ * resource spec
+ */
+@RequiredArgsConstructor
+public class SparkClusterContext extends BaseContext<SparkCluster> {
+  private final SparkCluster sparkCluster;
+  private final Context<?> josdkContext;
+  private final SparkClusterSubmissionWorker submissionWorker;
+
+  /** secondaryResourceSpec is initialized in a lazy fashion - built upon the first attempt */
+  private SparkClusterResourceSpec secondaryResourceSpec;
+
+  private SparkClusterResourceSpec getSecondaryResourceSpec() {
+    synchronized (this) {
+      if (secondaryResourceSpec == null) {
+        secondaryResourceSpec =
+            SparkClusterResourceSpecFactory.buildResourceSpec(sparkCluster, submissionWorker);
+      }
+      return secondaryResourceSpec;
+    }
+  }
+
+  @Override
+  public SparkCluster getResource() {
+    return sparkCluster;
+  }
+
+  public Service getMasterServiceSpec() {
+    return getSecondaryResourceSpec().getMasterService();
+  }
+
+  public StatefulSet getMasterStatefulSetSpec() {
+    return getSecondaryResourceSpec().getMasterStatefulSet();
+  }
+
+  public StatefulSet getWorkerStatefulSetSpec() {
+    return getSecondaryResourceSpec().getWorkerStatefulSet();
+  }
+
+  @Override
+  public KubernetesClient getClient() {
+    return josdkContext.getClient();
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/decorators/ClusterDecorator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/decorators/ClusterDecorator.java
@@ -35,7 +35,7 @@ public class ClusterDecorator implements ResourceDecorator {
 
   private final SparkCluster cluster;
 
-  /** Add labels and owner references to the app for all secondary resources */
+  /** Add labels and owner references to the cluster for all secondary resources */
   @Override
   public <T extends HasMetadata> T decorate(T resource) {
     ObjectMeta metaData =

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/decorators/ClusterDecorator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/decorators/ClusterDecorator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.decorators;
+
+import static org.apache.spark.k8s.operator.utils.ModelUtils.buildOwnerReferenceTo;
+import static org.apache.spark.k8s.operator.utils.Utils.sparkClusterResourceLabels;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import lombok.RequiredArgsConstructor;
+
+import org.apache.spark.k8s.operator.SparkCluster;
+
+/** Decorates Spark cluster resources like statefulsets. */
+@RequiredArgsConstructor
+public class ClusterDecorator implements ResourceDecorator {
+
+  private final SparkCluster cluster;
+
+  /** Add labels and owner references to the app for all secondary resources */
+  @Override
+  public <T extends HasMetadata> T decorate(T resource) {
+    ObjectMeta metaData =
+        new ObjectMetaBuilder(resource.getMetadata())
+            .addToOwnerReferences(buildOwnerReferenceTo(cluster))
+            .addToLabels(sparkClusterResourceLabels(cluster))
+            .withNamespace(cluster.getMetadata().getNamespace())
+            .build();
+    resource.setMetadata(metaData);
+    return resource;
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/listeners/SparkClusterStatusListener.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/listeners/SparkClusterStatusListener.java
@@ -21,6 +21,6 @@ package org.apache.spark.k8s.operator.listeners;
 import org.apache.spark.k8s.operator.SparkCluster;
 import org.apache.spark.k8s.operator.status.ClusterStatus;
 
-/** Custom listeners, if added, would be listening to Spark App status change */
+/** Custom listeners, if added, would be listening to Spark Cluster status change */
 public abstract class SparkClusterStatusListener
     extends BaseStatusListener<ClusterStatus, SparkCluster> {}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/listeners/SparkClusterStatusListener.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/listeners/SparkClusterStatusListener.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.spark.k8s.operator.listeners;
+
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.status.ClusterStatus;
+
+/** Custom listeners, if added, would be listening to Spark App status change */
+public abstract class SparkClusterStatusListener
+    extends BaseStatusListener<ClusterStatus, SparkCluster> {}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterReconciler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterReconciler.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler;
+
+import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.completeAndDefaultRequeue;
+import static org.apache.spark.k8s.operator.utils.Utils.commonResourceLabelsStr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.spark.k8s.operator.Constants;
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.SparkClusterSubmissionWorker;
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.metrics.healthcheck.SentinelManager;
+import org.apache.spark.k8s.operator.reconciler.reconcilesteps.*;
+import org.apache.spark.k8s.operator.utils.LoggingUtils;
+import org.apache.spark.k8s.operator.utils.ReconcilerUtils;
+import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
+
+/**
+ * Reconciler for Spark Cluster. Performs sanity check on the cluster, identify the reconcile steps
+ * based on status and execute the steps.
+ */
+@ControllerConfiguration
+@Slf4j
+@RequiredArgsConstructor
+public class SparkClusterReconciler
+    implements Reconciler<SparkCluster>,
+        ErrorStatusHandler<SparkCluster>,
+        EventSourceInitializer<SparkCluster>,
+        Cleaner<SparkCluster> {
+  private final SparkClusterSubmissionWorker submissionWorker;
+  private final SparkClusterStatusRecorder sparkClusterStatusRecorder;
+  private final SentinelManager<SparkCluster> sentinelManager;
+
+  @Override
+  public UpdateControl<SparkCluster> reconcile(
+      SparkCluster sparkCluster, Context<SparkCluster> context) throws Exception {
+    LoggingUtils.TrackedMDC trackedMDC = new LoggingUtils.TrackedMDC();
+    try {
+      if (sentinelManager.handleSentinelResourceReconciliation(sparkCluster, context.getClient())) {
+        return UpdateControl.noUpdate();
+      }
+      log.error("Start SparkClusterReconciler.");
+      sparkClusterStatusRecorder.updateStatusFromCache(sparkCluster);
+      SparkClusterContext ctx = new SparkClusterContext(sparkCluster, context, submissionWorker);
+      List<ClusterReconcileStep> reconcileSteps = getReconcileSteps(sparkCluster);
+      for (ClusterReconcileStep step : reconcileSteps) {
+        ReconcileProgress progress = step.reconcile(ctx, sparkClusterStatusRecorder);
+        if (progress.isCompleted()) {
+          return ReconcilerUtils.toUpdateControl(sparkCluster, progress);
+        }
+      }
+      return ReconcilerUtils.toUpdateControl(sparkCluster, completeAndDefaultRequeue());
+    } finally {
+      log.error("Reconciliation completed.");
+      trackedMDC.reset();
+    }
+  }
+
+  @Override
+  public ErrorStatusUpdateControl<SparkCluster> updateErrorStatus(
+      SparkCluster sparkCluster, Context<SparkCluster> context, Exception e) {
+    LoggingUtils.TrackedMDC trackedMDC = new LoggingUtils.TrackedMDC();
+    try {
+      context
+          .getRetryInfo()
+          .ifPresent(
+              retryInfo -> {
+                if (log.isErrorEnabled()) {
+                  log.error(
+                      "Failed attempt: {}, last attempt: {}",
+                      retryInfo.getAttemptCount(),
+                      retryInfo.isLastAttempt());
+                }
+              });
+      return ErrorStatusUpdateControl.noStatusUpdate();
+    } finally {
+      trackedMDC.reset();
+    }
+  }
+
+  @Override
+  public Map<String, EventSource> prepareEventSources(EventSourceContext<SparkCluster> context) {
+    EventSource podEventSource =
+        new InformerEventSource<>(
+            InformerConfiguration.from(Pod.class, context)
+                .withSecondaryToPrimaryMapper(
+                    Mappers.fromLabel(Constants.LABEL_SPARK_APPLICATION_NAME))
+                .withLabelSelector(commonResourceLabelsStr())
+                .build(),
+            context);
+    return EventSourceInitializer.nameEventSources(podEventSource);
+  }
+
+  protected List<ClusterReconcileStep> getReconcileSteps(final SparkCluster cluster) {
+    List<ClusterReconcileStep> steps = new ArrayList<>();
+    steps.add(new ClusterValidateStep());
+    steps.add(new ClusterTerminatedStep());
+    switch (cluster.getStatus().getCurrentState().getCurrentStateSummary()) {
+      case Submitted -> steps.add(new ClusterInitStep());
+      case RunningHealthy -> {
+        // There is nothing to do because Spark Cluster is supposed to run infinitely.
+      }
+      default -> steps.add(new ClusterUnknownStateStep());
+    }
+    return steps;
+  }
+
+  /**
+   * Best-effort graceful termination upon delete.
+   *
+   * @param sparkCluster the resource that is marked for deletion
+   * @param context the context with which the operation is executed
+   * @return DeleteControl, with requeue if needed
+   */
+  @Override
+  public DeleteControl cleanup(SparkCluster sparkCluster, Context<SparkCluster> context) {
+    LoggingUtils.TrackedMDC trackedMDC = new LoggingUtils.TrackedMDC();
+    try {
+      log.info("Cleaning up resources for SparkCluster.");
+      SparkClusterContext ctx = new SparkClusterContext(sparkCluster, context, submissionWorker);
+      List<ClusterReconcileStep> cleanupSteps = new ArrayList<>();
+      cleanupSteps.add(new ClusterValidateStep());
+      cleanupSteps.add(new ClusterTerminatedStep());
+      for (ClusterReconcileStep step : cleanupSteps) {
+        ReconcileProgress progress = step.reconcile(ctx, sparkClusterStatusRecorder);
+        if (progress.isCompleted()) {
+          if (progress.isRequeue()) {
+            return DeleteControl.noFinalizerRemoval()
+                .rescheduleAfter(progress.getRequeueAfterDuration());
+          } else {
+            break;
+          }
+        }
+      }
+    } finally {
+      log.info("Cleanup completed");
+      trackedMDC.reset();
+    }
+    sparkClusterStatusRecorder.removeCachedStatus(sparkCluster);
+    return DeleteControl.defaultDelete();
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.SparkClusterResourceSpec;
+import org.apache.spark.k8s.operator.SparkClusterSubmissionWorker;
+import org.apache.spark.k8s.operator.decorators.ClusterDecorator;
+
+@Slf4j
+public final class SparkClusterResourceSpecFactory {
+
+  private SparkClusterResourceSpecFactory() {}
+
+  public static SparkClusterResourceSpec buildResourceSpec(
+      final SparkCluster cluster, final SparkClusterSubmissionWorker worker) {
+    Map<String, String> confOverrides = new HashMap<>();
+    SparkClusterResourceSpec spec = worker.getResourceSpec(cluster, confOverrides);
+    ClusterDecorator decorator = new ClusterDecorator(cluster);
+    decorator.decorate(spec.getMasterService());
+    decorator.decorate(spec.getMasterStatefulSet());
+    decorator.decorate(spec.getWorkerStatefulSet());
+    return spec;
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
+
+import static org.apache.spark.k8s.operator.Constants.CLUSTER_READY_MESSAGE;
+import static org.apache.spark.k8s.operator.Constants.CLUSTER_SCHEDULE_FAILURE_MESSAGE;
+import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.*;
+import static org.apache.spark.k8s.operator.status.ClusterStateSummary.RunningHealthy;
+import static org.apache.spark.k8s.operator.status.ClusterStateSummary.SchedulingFailure;
+import static org.apache.spark.k8s.operator.utils.SparkExceptionUtils.buildGeneralErrorMessage;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
+import org.apache.spark.k8s.operator.status.ClusterState;
+import org.apache.spark.k8s.operator.status.ClusterStatus;
+import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
+
+/** Request cluster master and its resources when starting an attempt */
+@Slf4j
+public class ClusterInitStep extends ClusterReconcileStep {
+  @Override
+  public ReconcileProgress reconcile(
+      SparkClusterContext context, SparkClusterStatusRecorder statusRecorder) {
+    ClusterState currentState = context.getResource().getStatus().getCurrentState();
+    if (!currentState.getCurrentStateSummary().isInitializing()) {
+      return proceed();
+    }
+    SparkCluster cluster = context.getResource();
+    if (cluster.getStatus().getPreviousAttemptSummary() != null) {
+      Instant lastTransitionTime = Instant.parse(currentState.getLastTransitionTime());
+      Instant restartTime = lastTransitionTime.plusMillis(300 * 1000);
+      Instant now = Instant.now();
+      if (restartTime.isAfter(now)) {
+        return completeAndRequeueAfter(Duration.between(now, restartTime));
+      }
+    }
+    try {
+      Service masterService = context.getMasterServiceSpec();
+      context.getClient().services().resource(masterService).create();
+      StatefulSet masterStatefulSet = context.getMasterStatefulSetSpec();
+      context.getClient().apps().statefulSets().resource(masterStatefulSet).create();
+      StatefulSet workerStatefulSet = context.getWorkerStatefulSetSpec();
+      context.getClient().apps().statefulSets().resource(workerStatefulSet).create();
+
+      ClusterStatus updatedStatus =
+          context
+              .getResource()
+              .getStatus()
+              .appendNewState(new ClusterState(RunningHealthy, CLUSTER_READY_MESSAGE));
+      statusRecorder.persistStatus(context, updatedStatus);
+      return completeAndDefaultRequeue();
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("Failed to request master resource.", e);
+      }
+      String msg = CLUSTER_SCHEDULE_FAILURE_MESSAGE + " StackTrace: " + buildGeneralErrorMessage(e);
+      statusRecorder.persistStatus(
+          context,
+          context
+              .getResource()
+              .getStatus()
+              .appendNewState(new ClusterState(SchedulingFailure, msg)));
+      return completeAndImmediateRequeue();
+    }
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterReconcileStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterReconcileStep.java
@@ -27,7 +27,7 @@ import org.apache.spark.k8s.operator.status.ClusterState;
 import org.apache.spark.k8s.operator.status.ClusterStatus;
 import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
 
-/** Basic reconcile step for application */
+/** Basic reconcile step for cluster */
 public abstract class ClusterReconcileStep {
   public abstract ReconcileProgress reconcile(
       SparkClusterContext context, SparkClusterStatusRecorder statusRecorder);

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterReconcileStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterReconcileStep.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
+
+import java.time.Duration;
+
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
+import org.apache.spark.k8s.operator.status.ClusterState;
+import org.apache.spark.k8s.operator.status.ClusterStatus;
+import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
+
+/** Basic reconcile step for application */
+public abstract class ClusterReconcileStep {
+  public abstract ReconcileProgress reconcile(
+      SparkClusterContext context, SparkClusterStatusRecorder statusRecorder);
+
+  protected ReconcileProgress updateStatusAndRequeueAfter(
+      SparkClusterContext context,
+      SparkClusterStatusRecorder statusRecorder,
+      ClusterStatus updatedStatus,
+      Duration requeueAfter) {
+    statusRecorder.persistStatus(context, updatedStatus);
+    return ReconcileProgress.completeAndRequeueAfter(requeueAfter);
+  }
+
+  protected ReconcileProgress appendStateAndRequeueAfter(
+      SparkClusterContext context,
+      SparkClusterStatusRecorder statusRecorder,
+      ClusterState newState,
+      Duration requeueAfter) {
+    statusRecorder.appendNewStateAndPersist(context, newState);
+    return ReconcileProgress.completeAndRequeueAfter(requeueAfter);
+  }
+
+  protected ReconcileProgress appendStateAndImmediateRequeue(
+      SparkClusterContext context,
+      SparkClusterStatusRecorder statusRecorder,
+      ClusterState newState) {
+    return appendStateAndRequeueAfter(context, statusRecorder, newState, Duration.ZERO);
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterTerminatedStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterTerminatedStep.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
+
+import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.proceed;
+
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
+import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
+
+/** Observes whether cluster is already terminated. If so, end the reconcile. */
+public class ClusterTerminatedStep extends ClusterReconcileStep {
+  @Override
+  public ReconcileProgress reconcile(
+      SparkClusterContext context, SparkClusterStatusRecorder statusRecorder) {
+    if (context
+        .getResource()
+        .getStatus()
+        .getCurrentState()
+        .getCurrentStateSummary()
+        .isTerminated()) {
+      statusRecorder.removeCachedStatus(context.getResource());
+      return ReconcileProgress.completeAndNoRequeue();
+    }
+    return proceed();
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterUnknownStateStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterUnknownStateStep.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
+
+import org.apache.spark.k8s.operator.Constants;
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
+import org.apache.spark.k8s.operator.status.ClusterState;
+import org.apache.spark.k8s.operator.status.ClusterStateSummary;
+import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
+
+/** Abnormal state handler */
+public class ClusterUnknownStateStep extends ClusterReconcileStep {
+  @Override
+  public ReconcileProgress reconcile(
+      SparkClusterContext context, SparkClusterStatusRecorder statusRecorder) {
+    ClusterState state =
+        new ClusterState(ClusterStateSummary.Failed, Constants.UNKNOWN_CLUSTER_STATE_MESSAGE);
+    statusRecorder.persistStatus(context, context.getResource().getStatus().appendNewState(state));
+    return ReconcileProgress.completeAndImmediateRequeue();
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterValidateStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterValidateStep.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler.reconcilesteps;
+
+import static org.apache.spark.k8s.operator.reconciler.ReconcileProgress.proceed;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
+import org.apache.spark.k8s.operator.utils.SparkClusterStatusRecorder;
+
+/** Validates the submitted cluster. This can be re-factored into webhook in the future. */
+@Slf4j
+public class ClusterValidateStep extends ClusterReconcileStep {
+  @Override
+  public ReconcileProgress reconcile(
+      SparkClusterContext context, SparkClusterStatusRecorder statusRecorder) {
+    return proceed();
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/SparkClusterStatusRecorder.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/SparkClusterStatusRecorder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import java.util.List;
+
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.context.SparkClusterContext;
+import org.apache.spark.k8s.operator.listeners.SparkClusterStatusListener;
+import org.apache.spark.k8s.operator.status.ClusterState;
+import org.apache.spark.k8s.operator.status.ClusterStatus;
+
+public class SparkClusterStatusRecorder
+    extends StatusRecorder<ClusterStatus, SparkCluster, SparkClusterStatusListener> {
+  public SparkClusterStatusRecorder(List<SparkClusterStatusListener> statusListeners) {
+    super(statusListeners, ClusterStatus.class, SparkCluster.class);
+  }
+
+  public void appendNewStateAndPersist(SparkClusterContext context, ClusterState newState) {
+    ClusterStatus updatedStatus = context.getResource().getStatus().appendNewState(newState);
+    persistStatus(context, updatedStatus);
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java
@@ -21,11 +21,13 @@ package org.apache.spark.k8s.operator.utils;
 
 import static org.apache.spark.k8s.operator.Constants.LABEL_RESOURCE_NAME;
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_OPERATOR_NAME;
+import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_ROLE_CLUSTER_VALUE;
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_ROLE_DRIVER_VALUE;
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_ROLE_EXECUTOR_VALUE;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.OPERATOR_APP_NAME;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.OPERATOR_WATCHED_NAMESPACES;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.SPARK_APP_STATUS_LISTENER_CLASS_NAMES;
+import static org.apache.spark.k8s.operator.config.SparkOperatorConf.SPARK_CLUSTER_STATUS_LISTENER_CLASS_NAMES;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +41,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.apache.spark.k8s.operator.Constants;
 import org.apache.spark.k8s.operator.SparkApplication;
+import org.apache.spark.k8s.operator.SparkCluster;
 import org.apache.spark.k8s.operator.listeners.SparkAppStatusListener;
+import org.apache.spark.k8s.operator.listeners.SparkClusterStatusListener;
 
 public final class Utils {
 
@@ -104,6 +108,18 @@ public final class Utils {
     return labels;
   }
 
+  public static Map<String, String> sparkClusterResourceLabels(final SparkCluster master) {
+    Map<String, String> labels = commonManagedResourceLabels();
+    labels.put(Constants.LABEL_SPARK_CLUSTER_NAME, master.getMetadata().getName());
+    return labels;
+  }
+
+  public static Map<String, String> clusterLabels(final SparkCluster sparkCluster) {
+    Map<String, String> labels = sparkClusterResourceLabels(sparkCluster);
+    labels.put(Constants.LABEL_SPARK_ROLE_NAME, LABEL_SPARK_ROLE_CLUSTER_VALUE);
+    return labels;
+  }
+
   public static Set<String> getWatchedNamespaces() {
     return Utils.sanitizeCommaSeparatedStrAsSet(OPERATOR_WATCHED_NAMESPACES.getValue());
   }
@@ -111,6 +127,11 @@ public final class Utils {
   public static List<SparkAppStatusListener> getAppStatusListener() {
     return ClassLoadingUtils.getStatusListener(
         SparkAppStatusListener.class, SPARK_APP_STATUS_LISTENER_CLASS_NAMES.getValue());
+  }
+
+  public static List<SparkClusterStatusListener> getClusterStatusListener() {
+    return ClassLoadingUtils.getStatusListener(
+        SparkClusterStatusListener.class, SPARK_CLUSTER_STATUS_LISTENER_CLASS_NAMES.getValue());
   }
 
   /**

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/SparkOperatorTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/SparkOperatorTest.java
@@ -50,6 +50,7 @@ import org.apache.spark.k8s.operator.metrics.MetricsSystemFactory;
 import org.apache.spark.k8s.operator.metrics.source.KubernetesMetricsInterceptor;
 import org.apache.spark.k8s.operator.probe.ProbeService;
 import org.apache.spark.k8s.operator.reconciler.SparkAppReconciler;
+import org.apache.spark.k8s.operator.reconciler.SparkClusterReconciler;
 import org.apache.spark.k8s.operator.utils.Utils;
 
 class SparkOperatorTest {
@@ -159,6 +160,8 @@ class SparkOperatorTest {
                 Operator.class,
                 (mock, context) -> {
                   when(mock.register(any(SparkAppReconciler.class), any(Consumer.class)))
+                      .thenReturn(registeredController);
+                  when(mock.register(any(SparkClusterReconciler.class), any(Consumer.class)))
                       .thenReturn(registeredController);
                 });
         MockedConstruction<SparkAppReconciler> sparkAppReconcilerConstruction =

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactoryTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.reconciler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.SparkClusterResourceSpec;
+import org.apache.spark.k8s.operator.SparkClusterSubmissionWorker;
+
+class SparkClusterResourceSpecFactoryTest {
+
+  @Test
+  void testNamespace() {
+    SparkCluster cluster = new SparkCluster();
+    String namespace = "test-namespace";
+    cluster.setMetadata(
+        new ObjectMetaBuilder().withNamespace(namespace).withName("bar-cluster").build());
+    SparkClusterSubmissionWorker mockWorker = mock(SparkClusterSubmissionWorker.class);
+    when(mockWorker.getResourceSpec(any(), any()))
+        .thenReturn(new SparkClusterResourceSpec(cluster, new SparkConf()));
+    SparkClusterResourceSpec spec =
+        SparkClusterResourceSpecFactory.buildResourceSpec(cluster, mockWorker);
+    verify(mockWorker).getResourceSpec(eq(cluster), any());
+    assertEquals(namespace, spec.getMasterService().getMetadata().getNamespace());
+    assertEquals(namespace, spec.getMasterStatefulSet().getMetadata().getNamespace());
+    assertEquals(namespace, spec.getWorkerStatefulSet().getMetadata().getNamespace());
+  }
+
+  @Test
+  void testOwnerReference() {
+    SparkCluster cluster = new SparkCluster();
+    cluster.setMetadata(
+        new ObjectMetaBuilder().withNamespace("test-namespace").withName("my-cluster").build());
+    SparkClusterSubmissionWorker mockWorker = mock(SparkClusterSubmissionWorker.class);
+    when(mockWorker.getResourceSpec(any(), any()))
+        .thenReturn(new SparkClusterResourceSpec(cluster, new SparkConf()));
+    SparkClusterResourceSpec spec =
+        SparkClusterResourceSpecFactory.buildResourceSpec(cluster, mockWorker);
+    verify(mockWorker).getResourceSpec(eq(cluster), any());
+    assertEquals(1, spec.getMasterService().getMetadata().getOwnerReferences().size());
+    OwnerReference owner = spec.getMasterService().getMetadata().getOwnerReferences().get(0);
+    assertEquals("SparkCluster", owner.getKind());
+    assertEquals("my-cluster", owner.getName());
+
+    // All resources share the same owner
+    assertEquals(owner, spec.getMasterStatefulSet().getMetadata().getOwnerReferences().get(0));
+    assertEquals(owner, spec.getWorkerStatefulSet().getMetadata().getOwnerReferences().get(0));
+  }
+}

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -153,7 +153,7 @@ public class SparkClusterResourceSpec {
         .withValue("1")
         .endEnv()
         .addToCommand("bash")
-        .addToArgs("/opt/spark/sbin/start-worker.sh", "spark://master:7077")
+        .addToArgs("/opt/spark/sbin/start-worker.sh", "spark://" + name + "-svc:7077")
         .endContainer()
         .endSpec()
         .endTemplate()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `SparkCluster` to `spark-operator` module. This also fixed service name issue during testing.

### Why are the changes needed?

To support `SparkCluster` like `SparkApplication`.

```
$ ./gradlew build buildDockerImage spark-operator-api:relocateGeneratedCR -x check

$ helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/

$ kubectl apply -f examples/qa-cluster-with-one-worker.yaml
$ kubectl apply -f examples/qa-cluster-with-one-worker.yaml
sparkcluster.spark.apache.org/qa created

$ k get sparkcluster
NAME   CURRENT STATE    AGE
qa     RunningHealthy   2s

$ k get pod
NAME                                        READY   STATUS    RESTARTS   AGE
qa-master-0                                 1/1     Running   0          17s
qa-worker-0                                 1/1     Running   0          17s
spark-kubernetes-operator-546b54d5c-mdljw   1/1     Running   0          22s
```

### Does this PR introduce _any_ user-facing change?

No because Spark K8s operator is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.