### PR TITLE
[SPARK-49328] Propagate Spark configurations to `SparkCluster`

### DIFF
--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -25,3 +25,6 @@ spec:
   sparkConf:
     spark.kubernetes.container.image: "spark:4.0.0-preview1"
     spark.master.ui.title: "Prod Spark Cluster"
+    spark.master.rest.enabled: "true"
+    spark.master.rest.host: "0.0.0.0"
+    spark.ui.reverseProxy: "true"

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -25,3 +25,6 @@ spec:
   sparkConf:
     spark.kubernetes.container.image: "spark:4.0.0-preview1"
     spark.master.ui.title: "QA Spark Cluster"
+    spark.master.rest.enabled: "true"
+    spark.master.rest.host: "0.0.0.0"
+    spark.ui.reverseProxy: "true"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to propagate Spark configurations to Spark Master and Worker via `SPARK_MASTER_OPTS` and `SPARK_WORKER_OPTS`.

### Why are the changes needed?

To control `SparkCluster`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

```
$ kubectl apply -f examples/qa-cluster-with-one-worker.yaml
sparkcluster.spark.apache.org/qa created

$ kubectl port-forward qa-master-0 8080
```

![Screenshot 2024-08-20 at 18 39 19](https://github.com/user-attachments/assets/e5561c6e-67fe-40f2-bd46-856f62fdeb17)


### Was this patch authored or co-authored using generative AI tooling?

No.