### PR TITLE
[SPARK-49329] Support user provided spec for SparkCluster

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/MasterSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/MasterSpec.java
@@ -19,28 +19,23 @@
 
 package org.apache.spark.k8s.operator.spec;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.fabric8.generator.annotation.Required;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class ClusterSpec extends BaseSpec {
-  @Required protected RuntimeVersions runtimeVersions;
-
-  @Required @Builder.Default
-  protected ClusterTolerations clusterTolerations = new ClusterTolerations();
-
-  @Builder.Default protected MasterSpec masterSpec = new MasterSpec.MasterSpecBuilder().build();
-  @Builder.Default protected WorkerSpec workerSpec = new WorkerSpec.WorkerSpecBuilder().build();
+public class MasterSpec {
+  protected StatefulSetSpec masterStatefulSetSpec;
+  protected ObjectMeta masterStatefulSetMetadata;
+  protected ServiceSpec masterServiceSpec;
+  protected ObjectMeta masterServiceMetadata;
 }

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/WorkerSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/WorkerSpec.java
@@ -19,28 +19,23 @@
 
 package org.apache.spark.k8s.operator.spec;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.fabric8.generator.annotation.Required;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class ClusterSpec extends BaseSpec {
-  @Required protected RuntimeVersions runtimeVersions;
-
-  @Required @Builder.Default
-  protected ClusterTolerations clusterTolerations = new ClusterTolerations();
-
-  @Builder.Default protected MasterSpec masterSpec = new MasterSpec.MasterSpecBuilder().build();
-  @Builder.Default protected WorkerSpec workerSpec = new WorkerSpec.WorkerSpecBuilder().build();
+public class WorkerSpec {
+  protected StatefulSetSpec workerStatefulSetSpec;
+  protected ObjectMeta workerStatefulSetMetadata;
+  protected ServiceSpec workerServiceSpec;
+  protected ObjectMeta workerServiceMetadata;
 }

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterResourceSpecTest.java
@@ -24,19 +24,30 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpecBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.k8s.operator.spec.ClusterSpec;
 import org.apache.spark.k8s.operator.spec.ClusterTolerations;
+import org.apache.spark.k8s.operator.spec.MasterSpec;
+import org.apache.spark.k8s.operator.spec.WorkerSpec;
 
 class SparkClusterResourceSpecTest {
   SparkCluster cluster;
   ObjectMeta objectMeta;
   ClusterSpec clusterSpec;
+  StatefulSetSpec statefulSetSpec;
+  ServiceSpec serviceSpec;
+  MasterSpec masterSpec;
+  WorkerSpec workerSpec;
   SparkConf sparkConf = new SparkConf().set("spark.kubernetes.namespace", "other-namespace");
   ClusterTolerations clusterTolerations = new ClusterTolerations();
 
@@ -45,11 +56,25 @@ class SparkClusterResourceSpecTest {
     cluster = mock(SparkCluster.class);
     objectMeta = mock(ObjectMeta.class);
     clusterSpec = mock(ClusterSpec.class);
+    serviceSpec = mock(ServiceSpec.class);
+    masterSpec = mock(MasterSpec.class);
+    workerSpec = mock(WorkerSpec.class);
+    statefulSetSpec = mock(StatefulSetSpec.class);
     when(cluster.getMetadata()).thenReturn(objectMeta);
     when(cluster.getSpec()).thenReturn(clusterSpec);
     when(objectMeta.getNamespace()).thenReturn("my-namespace");
     when(objectMeta.getName()).thenReturn("cluster-name");
     when(clusterSpec.getClusterTolerations()).thenReturn(clusterTolerations);
+    when(clusterSpec.getMasterSpec()).thenReturn(masterSpec);
+    when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec);
+    when(masterSpec.getMasterStatefulSetSpec()).thenReturn(statefulSetSpec);
+    when(masterSpec.getMasterStatefulSetMetadata()).thenReturn(objectMeta);
+    when(masterSpec.getMasterServiceSpec()).thenReturn(serviceSpec);
+    when(masterSpec.getMasterServiceMetadata()).thenReturn(objectMeta);
+    when(workerSpec.getWorkerStatefulSetSpec()).thenReturn(statefulSetSpec);
+    when(workerSpec.getWorkerStatefulSetMetadata()).thenReturn(objectMeta);
+    when(workerSpec.getWorkerServiceSpec()).thenReturn(serviceSpec);
+    when(workerSpec.getWorkerServiceMetadata()).thenReturn(objectMeta);
   }
 
   @Test
@@ -73,6 +98,48 @@ class SparkClusterResourceSpecTest {
   }
 
   @Test
+  void testWorkerServiceWithTemplate() {
+    ObjectMeta objectMeta1 =
+        new ObjectMetaBuilder()
+            .withNamespace("foo")
+            .withName("bar")
+            .addToLabels("foo", "bar")
+            .build();
+    ServiceSpec serviceSpec1 = new ServiceSpecBuilder().withExternalName("foo").build();
+    WorkerSpec workerSpec1 = mock(WorkerSpec.class);
+    when(workerSpec1.getWorkerServiceSpec()).thenReturn(serviceSpec1);
+    when(workerSpec1.getWorkerServiceMetadata()).thenReturn(objectMeta1);
+    when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec1);
+
+    Service service1 = new SparkClusterResourceSpec(cluster, new SparkConf()).getWorkerService();
+    assertEquals("my-namespace", service1.getMetadata().getNamespace());
+    assertEquals("cluster-name-worker-svc", service1.getMetadata().getName());
+    assertEquals("bar", service1.getMetadata().getLabels().get("foo"));
+    assertEquals("foo", service1.getSpec().getExternalName());
+  }
+
+  @Test
+  void testMasterServiceWithTemplate() {
+    ObjectMeta objectMeta1 =
+        new ObjectMetaBuilder()
+            .withNamespace("foo")
+            .withName("bar")
+            .addToLabels("foo", "bar")
+            .build();
+    ServiceSpec serviceSpec1 = new ServiceSpecBuilder().withExternalName("foo").build();
+    MasterSpec masterSpec1 = mock(MasterSpec.class);
+    when(masterSpec1.getMasterServiceSpec()).thenReturn(serviceSpec1);
+    when(masterSpec1.getMasterServiceMetadata()).thenReturn(objectMeta1);
+    when(clusterSpec.getMasterSpec()).thenReturn(masterSpec1);
+
+    Service service1 = new SparkClusterResourceSpec(cluster, new SparkConf()).getMasterService();
+    assertEquals("my-namespace", service1.getMetadata().getNamespace());
+    assertEquals("cluster-name-master-svc", service1.getMetadata().getName());
+    assertEquals("bar", service1.getMetadata().getLabels().get("foo"));
+    assertEquals("foo", service1.getSpec().getExternalName());
+  }
+
+  @Test
   void testMasterStatefulSet() {
     SparkClusterResourceSpec spec1 = new SparkClusterResourceSpec(cluster, new SparkConf());
     StatefulSet statefulSet1 = spec1.getMasterStatefulSet();
@@ -85,6 +152,40 @@ class SparkClusterResourceSpecTest {
   }
 
   @Test
+  void testMasterStatefulSetWithTemplate() {
+    ObjectMeta objectMeta1 =
+        new ObjectMetaBuilder()
+            .withNamespace("foo")
+            .withName("bar")
+            .addToLabels("foo", "bar")
+            .build();
+    StatefulSetSpec statefulSetSpec1 =
+        new StatefulSetSpecBuilder()
+            .withNewTemplate()
+            .withNewSpec()
+            .addNewInitContainer()
+            .withName("init-foo")
+            .endInitContainer()
+            .addNewContainer()
+            .withName("sidecar-foo")
+            .endContainer()
+            .endSpec()
+            .endTemplate()
+            .build();
+    MasterSpec masterSpec1 = mock(MasterSpec.class);
+    when(masterSpec1.getMasterStatefulSetMetadata()).thenReturn(objectMeta1);
+    when(masterSpec1.getMasterStatefulSetSpec()).thenReturn(statefulSetSpec1);
+    when(clusterSpec.getMasterSpec()).thenReturn(masterSpec1);
+    SparkClusterResourceSpec spec1 = new SparkClusterResourceSpec(cluster, new SparkConf());
+    StatefulSet statefulSet1 = spec1.getMasterStatefulSet();
+    assertEquals("my-namespace", statefulSet1.getMetadata().getNamespace());
+    assertEquals("cluster-name-master", statefulSet1.getMetadata().getName());
+    assertEquals("bar", statefulSet1.getMetadata().getLabels().get("foo"));
+    assertEquals(1, statefulSet1.getSpec().getTemplate().getSpec().getInitContainers().size());
+    assertEquals(2, statefulSet1.getSpec().getTemplate().getSpec().getContainers().size());
+  }
+
+  @Test
   void testWorkerStatefulSet() {
     SparkClusterResourceSpec spec = new SparkClusterResourceSpec(cluster, new SparkConf());
     StatefulSet statefulSet = spec.getWorkerStatefulSet();
@@ -94,5 +195,36 @@ class SparkClusterResourceSpecTest {
     SparkClusterResourceSpec spec2 = new SparkClusterResourceSpec(cluster, sparkConf);
     StatefulSet statefulSet2 = spec2.getWorkerStatefulSet();
     assertEquals("other-namespace", statefulSet2.getMetadata().getNamespace());
+  }
+
+  @Test
+  void testWorkerStatefulSetWithTemplate() {
+    ObjectMeta objectMeta1 =
+        new ObjectMetaBuilder()
+            .withNamespace("foo")
+            .withName("bar")
+            .addToLabels("foo", "bar")
+            .build();
+    StatefulSetSpec statefulSetSpec1 =
+        new StatefulSetSpecBuilder()
+            .withNewTemplate()
+            .withNewSpec()
+            .addNewInitContainer()
+            .withName("init-foo")
+            .endInitContainer()
+            .addNewContainer()
+            .withName("sidecar-foo")
+            .endContainer()
+            .endSpec()
+            .endTemplate()
+            .build();
+    WorkerSpec workerSpec1 = mock(WorkerSpec.class);
+    when(workerSpec1.getWorkerStatefulSetMetadata()).thenReturn(objectMeta1);
+    when(workerSpec1.getWorkerStatefulSetSpec()).thenReturn(statefulSetSpec1);
+    when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec1);
+    SparkClusterResourceSpec spec = new SparkClusterResourceSpec(cluster, new SparkConf());
+    StatefulSet statefulSet = spec.getWorkerStatefulSet();
+    assertEquals("my-namespace", statefulSet.getMetadata().getNamespace());
+    assertEquals("cluster-name-worker", statefulSet.getMetadata().getName());
   }
 }

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterSubmissionWorkerTest.java
@@ -30,23 +30,31 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.spark.k8s.operator.spec.ClusterSpec;
 import org.apache.spark.k8s.operator.spec.ClusterTolerations;
+import org.apache.spark.k8s.operator.spec.MasterSpec;
+import org.apache.spark.k8s.operator.spec.WorkerSpec;
 
 class SparkClusterSubmissionWorkerTest {
   SparkCluster cluster;
   ObjectMeta objectMeta;
   ClusterSpec clusterSpec;
   ClusterTolerations clusterTolerations = new ClusterTolerations();
+  MasterSpec masterSpec;
+  WorkerSpec workerSpec;
 
   @BeforeEach
   void setUp() {
     cluster = mock(SparkCluster.class);
     objectMeta = mock(ObjectMeta.class);
     clusterSpec = mock(ClusterSpec.class);
+    masterSpec = mock(MasterSpec.class);
+    workerSpec = mock(WorkerSpec.class);
     when(cluster.getMetadata()).thenReturn(objectMeta);
     when(cluster.getSpec()).thenReturn(clusterSpec);
     when(objectMeta.getNamespace()).thenReturn("my-namespace");
     when(objectMeta.getName()).thenReturn("cluster-name");
     when(clusterSpec.getClusterTolerations()).thenReturn(clusterTolerations);
+    when(clusterSpec.getMasterSpec()).thenReturn(masterSpec);
+    when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec);
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

This PR introduces the feature to enable user-provided metadata & spec for Spark Clusters.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Similar to pod template spec support for Apps, this is desired when user would like to introduce customization for Cluster master + worker spec.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No - not released yet

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit tests and integration test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
