### PR TITLE
[SPARK-49330] Revise `InstanceConfig` to `ExecutorInstanceConfig` class

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ApplicationTolerations.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ApplicationTolerations.java
@@ -39,7 +39,7 @@ public class ApplicationTolerations {
   protected ApplicationTimeoutConfig applicationTimeoutConfig = new ApplicationTimeoutConfig();
 
   /** Determine the toleration behavior for executor / worker instances. */
-  @Builder.Default protected InstanceConfig instanceConfig = new InstanceConfig();
+  @Builder.Default protected ExecutorInstanceConfig instanceConfig = new ExecutorInstanceConfig();
 
   @Builder.Default protected ResourceRetainPolicy resourceRetainPolicy = ResourceRetainPolicy.Never;
 }

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ExecutorInstanceConfig.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ExecutorInstanceConfig.java
@@ -35,9 +35,10 @@ import lombok.NoArgsConstructor;
  * <pre>{@code
  * spec:
  *   applicationTolerations:
- *     instanceConfig: minExecutors: 3
- *     initExecutors: 5
- *     maxExecutors: 10
+ *     instanceConfig:
+ *       minExecutors: 3
+ *       initExecutors: 5
+ *       maxExecutors: 10
  *   sparkConf:
  *     spark.executor.instances: "10"
  * }</pre>
@@ -61,8 +62,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class InstanceConfig {
-  @Builder.Default protected long initExecutors = 0L;
-  @Builder.Default protected long minExecutors = 0L;
-  @Builder.Default protected long maxExecutors = 0L;
+public class ExecutorInstanceConfig {
+  @Builder.Default protected int initExecutors = 0;
+  @Builder.Default protected int minExecutors = 0;
+  @Builder.Default protected int maxExecutors = 0;
 }

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
@@ -19,24 +19,31 @@
 
 package org.apache.spark.k8s.operator.spec;
 
-import org.junit.jupiter.api.Assertions;
+import static org.apache.spark.k8s.operator.spec.DeploymentMode.ClusterMode;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 
 class ApplicationSpecTest {
   @Test
+  void testBuilder() {
+    ApplicationSpec spec1 = new ApplicationSpec();
+    ApplicationSpec spec2 = new ApplicationSpec.ApplicationSpecBuilder().build();
+    assertEquals(spec1, spec2);
+  }
+
+  @Test
   void testInitSpecWithDefaults() {
-    ApplicationSpec applicationSpec1 = new ApplicationSpec();
-    ApplicationSpec applicationSpec2 = new ApplicationSpec.ApplicationSpecBuilder().build();
-    Assertions.assertEquals(applicationSpec1, applicationSpec2);
-    Assertions.assertEquals(DeploymentMode.ClusterMode, applicationSpec1.getDeploymentMode());
-    Assertions.assertNull(applicationSpec1.getDriverSpec());
-    Assertions.assertNull(applicationSpec1.getExecutorSpec());
-    Assertions.assertNotNull(applicationSpec1.getApplicationTolerations());
-    Assertions.assertEquals(
-        RestartPolicy.Never,
-        applicationSpec1.getApplicationTolerations().getRestartConfig().getRestartPolicy());
-    Assertions.assertEquals(
-        ResourceRetainPolicy.Never,
-        applicationSpec1.getApplicationTolerations().getResourceRetainPolicy());
+    ApplicationSpec spec = new ApplicationSpec();
+    assertEquals(ClusterMode, spec.getDeploymentMode());
+    assertNull(spec.getDriverSpec());
+    assertNull(spec.getExecutorSpec());
+    ApplicationTolerations tolerations = spec.getApplicationTolerations();
+    assertNotNull(tolerations);
+    assertEquals(RestartPolicy.Never, tolerations.getRestartConfig().getRestartPolicy());
+    assertEquals(ResourceRetainPolicy.Never, tolerations.getResourceRetainPolicy());
+    assertEquals(0, tolerations.instanceConfig.initExecutors);
+    assertEquals(0, tolerations.instanceConfig.minExecutors);
+    assertEquals(0, tolerations.instanceConfig.maxExecutors);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to revise the followings.

- Rename `InstanceConfig` to `ExecutorInstanceConfig` because we will add `WorkerInstanceConfig`
- Fix malformed Java docs
- Fix `long` type to `int` for `(init|min|max)Executors` because `spark.executor.instances` is `Int` config.
- Refactor `ApplicastionSpecTest` by splitting test cases like `ClusterSpecTest`.

### Why are the changes needed?

To fix bugs and improve codes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.