### PR TITLE
[SPARK-49332] Add K8s service for `Workers` to `SparkClusterResourceSpec`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
@@ -62,6 +62,10 @@ public class SparkClusterContext extends BaseContext<SparkCluster> {
     return getSecondaryResourceSpec().getMasterService();
   }
 
+  public Service getWorkerServiceSpec() {
+    return getSecondaryResourceSpec().getWorkerService();
+  }
+
   public StatefulSet getMasterStatefulSetSpec() {
     return getSecondaryResourceSpec().getMasterStatefulSet();
   }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
@@ -40,6 +40,7 @@ public final class SparkClusterResourceSpecFactory {
     SparkClusterResourceSpec spec = worker.getResourceSpec(cluster, confOverrides);
     ClusterDecorator decorator = new ClusterDecorator(cluster);
     decorator.decorate(spec.getMasterService());
+    decorator.decorate(spec.getWorkerService());
     decorator.decorate(spec.getMasterStatefulSet());
     decorator.decorate(spec.getWorkerStatefulSet());
     return spec;

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
@@ -62,6 +62,8 @@ public class ClusterInitStep extends ClusterReconcileStep {
     try {
       Service masterService = context.getMasterServiceSpec();
       context.getClient().services().resource(masterService).create();
+      Service workerService = context.getWorkerServiceSpec();
+      context.getClient().services().resource(workerService).create();
       StatefulSet masterStatefulSet = context.getMasterStatefulSetSpec();
       context.getClient().apps().statefulSets().resource(masterStatefulSet).create();
       StatefulSet workerStatefulSet = context.getWorkerStatefulSetSpec();

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactoryTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactoryTest.java
@@ -48,6 +48,7 @@ class SparkClusterResourceSpecFactoryTest {
         SparkClusterResourceSpecFactory.buildResourceSpec(cluster, mockWorker);
     verify(mockWorker).getResourceSpec(eq(cluster), any());
     assertEquals(namespace, spec.getMasterService().getMetadata().getNamespace());
+    assertEquals(namespace, spec.getWorkerService().getMetadata().getNamespace());
     assertEquals(namespace, spec.getMasterStatefulSet().getMetadata().getNamespace());
     assertEquals(namespace, spec.getWorkerStatefulSet().getMetadata().getNamespace());
   }
@@ -69,6 +70,7 @@ class SparkClusterResourceSpecFactoryTest {
     assertEquals("my-cluster", owner.getName());
 
     // All resources share the same owner
+    assertEquals(owner, spec.getWorkerService().getMetadata().getOwnerReferences().get(0));
     assertEquals(owner, spec.getMasterStatefulSet().getMetadata().getOwnerReferences().get(0));
     assertEquals(owner, spec.getWorkerStatefulSet().getMetadata().getOwnerReferences().get(0));
   }

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterResourceSpecTest.java
@@ -53,7 +53,17 @@ class SparkClusterResourceSpecTest {
   void testMasterService() {
     Service service1 = new SparkClusterResourceSpec(cluster, new SparkConf()).getMasterService();
     assertEquals("my-namespace", service1.getMetadata().getNamespace());
-    assertEquals("cluster-name-svc", service1.getMetadata().getName());
+    assertEquals("cluster-name-master-svc", service1.getMetadata().getName());
+
+    Service service2 = new SparkClusterResourceSpec(cluster, sparkConf).getMasterService();
+    assertEquals("other-namespace", service2.getMetadata().getNamespace());
+  }
+
+  @Test
+  void testWorkerService() {
+    Service service1 = new SparkClusterResourceSpec(cluster, new SparkConf()).getWorkerService();
+    assertEquals("my-namespace", service1.getMetadata().getNamespace());
+    assertEquals("cluster-name-worker-svc", service1.getMetadata().getName());
 
     Service service2 = new SparkClusterResourceSpec(cluster, sparkConf).getMasterService();
     assertEquals("other-namespace", service2.getMetadata().getNamespace());


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `K8s` Service for `Workers` to `SparkClusterResourceSpec`.

### Why are the changes needed?

To communicate to worker pods with DNS.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.