### PR TITLE
[SPARK-49340] Document `SparkCluster` and add `submit-pi-to-prod.sh` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,41 @@ pi     ResourceReleased   4m10s
 $ kubectl delete sparkapp/pi
 ```
 
+## Run Spark Cluster
+
+```bash
+$ kubectl apply -f examples/prod-cluster-with-three-workers.yaml
+
+$ kubectl get sparkcluster
+NAME   CURRENT STATE    AGE
+prod   RunningHealthy   10s
+
+$ kubectl port-forward prod-master-0 6066 &
+
+$ ./examples/submit-pi-to-prod.sh
+{
+  "action" : "CreateSubmissionResponse",
+  "message" : "Driver successfully submitted as driver-20240821181327-0000",
+  "serverSparkVersion" : "4.0.0-preview1",
+  "submissionId" : "driver-20240821181327-0000",
+  "success" : true
+}
+
+$ curl http://localhost:6066/v1/submissions/status/driver-20240821181327-0000/
+{
+  "action" : "SubmissionStatusResponse",
+  "driverState" : "FINISHED",
+  "serverSparkVersion" : "4.0.0-preview1",
+  "submissionId" : "driver-20240821181327-0000",
+  "success" : true,
+  "workerHostPort" : "10.1.5.188:42099",
+  "workerId" : "worker-20240821181236-10.1.5.188-42099"
+}
+
+$ kubectl delete sparkcluster prod
+sparkcluster.spark.apache.org "prod" deleted
+```
+
 ## Run Spark Pi App on Apache YuniKorn scheduler
 
 ```bash

--- a/examples/submit-pi-to-prod.sh
+++ b/examples/submit-pi-to-prod.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+curl -XPOST http://localhost:6066/v1/submissions/create \
+--data '{
+  "appResource": "",
+  "sparkProperties": {
+    "spark.master": "spark://prod-master-svc:7077",
+    "spark.submit.deployMode": "cluster",
+    "spark.app.name": "SparkPi",
+    "spark.driver.cores": "1",
+    "spark.driver.memory": "1g",
+    "spark.executor.cores": "1",
+    "spark.executor.memory": "1g",
+    "spark.cores.max": "2",
+    "spark.ui.reverseProxy": "true",
+    "spark.jars": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  },
+  "clientSparkVersion": "",
+  "mainClass": "org.apache.spark.examples.SparkPi",
+  "environmentVariables": { },
+  "action": "CreateSubmissionRequest",
+  "appArgs": [ "2000" ]
+}'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR documents `SparkCluster` in `README.md` and add `submit-pi-to-prod.sh` example.

### Why are the changes needed?

To provide examples about how to use `SparkCluster` feature.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review the docs.

### Was this patch authored or co-authored using generative AI tooling?

No.