### PR TITLE
[SPARK-49343] Document nightly versions of operator image and Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ $ kubectl delete sparkapp pi-on-yunikorn
 sparkapplication.spark.apache.org "pi-on-yunikorn" deleted
 ```
 
+## Try nightly build for testing
+
+As of now, you can try `spark-kubernetes-operator` nightly version in the following way.
+
+```
+$ helm install spark-kubernetes-operator https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz --set image.repository=dongjoon/spark-kubernetes-operator
+```
+
 ## Contributing
 
 Please review the [Contribution to Spark guide](https://spark.apache.org/contributing.html)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ sparkapplication.spark.apache.org "pi-on-yunikorn" deleted
 As of now, you can try `spark-kubernetes-operator` nightly version in the following way.
 
 ```
-$ helm install spark-kubernetes-operator https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz --set image.repository=dongjoon/spark-kubernetes-operator
+$ helm install spark-kubernetes-operator \
+https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz \
+--set image.repository=dongjoon/spark-kubernetes-operator
 ```
 
 ## Contributing

--- a/build-tools/helm/spark-kubernetes-operator/Chart.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/Chart.yaml
@@ -17,5 +17,5 @@ name: spark-kubernetes-operator
 description: A Helm chart for the Apache Spark Kubernetes Operator
 type: application
 version: 0.1.0-SNAPSHOT
-appVersion: 0.1.0
+appVersion: 0.1.0-SNAPSHOT
 icon: https://spark.apache.org/favicon.ico


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to document how to use nightly versions of operator image and Helm Chart.

### Why are the changes needed?

Note that we are working on the official DockerHub repository seperately.

- [INFRA-26059 Add `apache/spark-kubernetes-operator` DockerHub repo](https://issues.apache.org/jira/browse/INFRA-26059)

This only aims to use `nightlies.apache.org` as a helm chart snapshot location.
- https://infra.apache.org/nightlies.html

For dev image, temporarily location is provided but it will be also reloaded to the Apache dev image location.

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change.

### How was this patch tested?

Manually test like the following. 
- We don't need to clone or build from GitHub source code repository.
```
helm install spark-kubernetes-operator \
https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz \
--set image.repository=dongjoon/spark-kubernetes-operator
```
- If you have your own image, you can use it for `image.repository`.

### Was this patch authored or co-authored using generative AI tooling?

No.