### PR TITLE
[SPARK-49346] Add `publish_snapshot_dockerhub.yml` Daily GitHub Action job

### DIFF
--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 name: Publish Snapshot Image
 
 on:

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Publish Snapshot Image
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'list of branches to publish (JSON)'
+        required: true
+        # keep in sync with default value of strategy matrix 'branch'
+        default: '["main"]'
+
+jobs:
+  publish-snapshot-image:
+    if: ${{ startsWith(github.repository, 'apache/') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # keep in sync with default value of workflow_dispatch input 'branch'
+        branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.branch }}
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        context: .
+        file: build-tools/docker/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: apache/spark-kubernetes-operator:main-snapshot

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
 
 name: Publish Snapshot Image
 

--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM gradle:8.9.0-jdk17-jammy AS builder
-ARG APP_VERSION
+FROM gradle:8.10.0-jdk17-jammy AS builder
+ARG APP_VERSION=0.1.0-SNAPSHOT
 WORKDIR /app
 COPY . .
 RUN ./gradlew clean build -x check


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `publish_snapshot_dockerhub.yml` Daily GitHub Action job.

### Why are the changes needed?

To provide an official snapshot image after [INFRA-26059](https://issues.apache.org/jira/browse/INFRA-26059) is resolved.

Mostly, I borrowed Apache Kyuubi CI template.
- https://github.com/apache/kyuubi/blob/master/.github/workflows/publish-snapshot-docker.yml

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a daily CI.

### Was this patch authored or co-authored using generative AI tooling?

No.