### PR TITLE
[SPARK-49348] Support `schedulerName` for SparkCluster

### DIFF
--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkCluster
+metadata:
+  name: cluster-on-yunikorn
+spec:
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview1"
+  initWorkers: 1
+  minWorkers: 1
+  maxWorkers: 1
+  sparkConf:
+    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.scheduler.name: "yunikorn"
+    spark.master.ui.title: "Spark Cluster on YuniKorn Scheduler"
+    spark.master.rest.enabled: "true"
+    spark.master.rest.host: "0.0.0.0"
+    spark.ui.reverseProxy: "true"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support K8s Scheduler for SparkCluster via `spark.kubernetes.scheduler.name`.

### Why are the changes needed?

To support a submission to a custom scheduler like Apache YuniKorn.

### Does this PR introduce _any_ user-facing change?

No. This is a new feature.

### How was this patch tested?

Pass the CIs and manual testing. Without installing `YuniKorn` scheduler, the pod of SparkCluster will be in Pending status.
```
$ gradle build buildDockerImage spark-operator-api:relocateGeneratedCRD -x check
$ kubectl apply -f examples/cluster-on-yunikorn.yaml
```

### Was this patch authored or co-authored using generative AI tooling?

No.