### PR TITLE
[SPARK-49351] Add `publish_snapshot_chart.yml` GitHub Action job

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -1,0 +1,47 @@
+name: Publish Snapshot Chart
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'list of branches to publish (JSON)'
+        required: true
+        # keep in sync with default value of strategy matrix 'branch'
+        default: '["main"]'
+
+jobs:
+  publish-snapshot-chart:
+    if: ${{ startsWith(github.repository, 'apache/') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # keep in sync with default value of workflow_dispatch input 'branch'
+        branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.branch }}
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'adopt'
+        cache: 'gradle'
+    - name: Build Operator
+      run: |
+        ./gradlew build spark-operator-api:relocateGeneratedCRD -x check --no-daemon
+    - name: Build Chart
+      run: |
+        cd build-tools/helm
+        mkdir charts
+        tar cvfz charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz spark-kubernetes-operator
+        helm repo index charts --url https://nightlies.apache.org/spark/charts
+    - name: Upload
+      run: |
+        curl -u ${{ secrets.NIGHTLIES_USER }}:${{ secrets.NIGHTLIES_TOKEN }} -T charts/index.yaml 'https://nightlies.apache.org/spark/charts/'
+        curl -u ${{ secrets.NIGHTLIES_USER }}:${{ secrets.NIGHTLIES_TOKEN }} -T charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz 'https://nightlies.apache.org/spark/charts/'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `publish_snapshot_chart.yml` GitHub Action job.

ASF INFRA Reference.
- https://github.com/apache/infrastructure-test/blob/master/.github/workflows/nightlies.yml

### Why are the changes needed?

To provide a daily snapshot of HelmChart.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. We need to merge and test because the credentials work only inside commit environment.

### Was this patch authored or co-authored using generative AI tooling?

No.