### PR TITLE
[SPARK-49331][FOLLOWUP] Fix `cpu` to `cpus` in `setup-minikube` setting

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           cache: true
           kubernetes-version: ${{ matrix.kube-version }}
-          cpu: 2
+          cpus: 2
           memory: 6144m
       - name: Set Up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of the following PR to fix `cpu` to `cpus` in `setup-minikube` setting.
- #82

### Why are the changes needed?

This was a typo and CI complains like the following.

- https://github.com/apache/spark-kubernetes-operator/actions/runs/10503328332/job/29096477836
```
Warning: Unexpected input(s) 'cpu', valid inputs are ['start', 'cache', 'minikube-version', 'driver', 'container-runtime', 'kubernetes-version', 'cpus', 'memory', 'network-plugin', 'cni', 'addons', 'extra-config', 'feature-gates', 'listen-address', 'mount-path', 'install-path', 'wait', 'insecure-registry', 'start-args']
```

### Does this PR introduce _any_ user-facing change?

No, this is an infra bug fix.

### How was this patch tested?

Manually check the CI logs.

### Was this patch authored or co-authored using generative AI tooling?

No.