### PR TITLE
[SPARK-49360] Use `rsync` to upload to `nightlies`

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -42,6 +42,12 @@ jobs:
         tar cvfz charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz spark-kubernetes-operator
         helm repo index charts --url https://nightlies.apache.org/spark/charts
     - name: Upload
-      run: |
-        curl -u ${{ secrets.NIGHTLIES_USER }}:${{ secrets.NIGHTLIES_TOKEN }} -T charts/index.yaml 'https://nightlies.apache.org/spark/charts/'
-        curl -u ${{ secrets.NIGHTLIES_USER }}:${{ secrets.NIGHTLIES_TOKEN }} -T charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz 'https://nightlies.apache.org/spark/charts/'
+      uses: burnett01/rsync-deployments@5.2
+      with:
+        switches: -avzr
+        path: build-tools/helm/charts
+        remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/spark/charts
+        remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
+        remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+        remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+        remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `rsync` to upload to `nightlies`.

- https://github.com/apache/infrastructure-test/blob/master/.github/workflows/nightlies-rsync.yml

### Why are the changes needed?

According to INFRA-26062, we asked explicitly the following example, but they refuse to provide it.
- https://github.com/apache/infrastructure-test/blob/master/.github/workflows/nightlies.yml

Maybe, there are some unknown reasons.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.