### PR TITLE
[SPARK-49360][FOLLOWUP] Use `/*` for path

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -45,8 +45,8 @@ jobs:
       uses: burnett01/rsync-deployments@5.2
       with:
         switches: -avzr
-        path: build-tools/helm/charts
-        remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/spark/charts
+        path: build-tools/helm/*
+        remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/spark
         remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
         remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
         remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the following.
- #92 

### Why are the changes needed?

Currently, it fails.
- https://github.com/apache/spark-kubernetes-operator/actions/runs/10514479628/job/29132402746

This PR follows the same pattern like INFRA example
```
path: docs/*
remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/infrastructure
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

After merging, we can test.

### Was this patch authored or co-authored using generative AI tooling?

No.