### PR TITLE
[SPARK-49361] Fix `Dockerfile` by removing unused `ARG` from builder and moving default value

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -15,13 +15,12 @@
 # limitations under the License.
 #
 FROM gradle:8.10.0-jdk17-jammy AS builder
-ARG APP_VERSION=0.1.0-SNAPSHOT
 WORKDIR /app
 COPY . .
 RUN ./gradlew clean build -x check
 
 FROM azul/zulu-openjdk:21
-ARG APP_VERSION
+ARG APP_VERSION=0.1.0-SNAPSHOT
 ARG SPARK_UID=185
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Dockerfile` by removing unused `ARG` from builder and moving default value.

### Why are the changes needed?

To publish snapshot image correctly.
- https://github.com/apache/spark-kubernetes-operator/actions/workflows/publish_snapshot_dockerhub.yml

### Does this PR introduce _any_ user-facing change?

No. This is not released yet.

### How was this patch tested?

In `build.gradle`, we always use `--build-arg`.

https://github.com/apache/spark-kubernetes-operator/blob/5bdb8394e9383836d712cfb94364f742df01b1e8/build.gradle#L41

For testing, we need to test manually without `--build-arg`.
```
$ docker build -t spark-kubernetes-operator:main-snapshot -f build-tools/docker/Dockerfile  .
```

### Was this patch authored or co-authored using generative AI tooling?

No.