### PR TITLE
[SPARK-49362] Simplify snapshot HelmChart to use `apache/spark-kubernetes-operator:main-snapshot` by default

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -38,14 +38,17 @@ jobs:
     - name: Build Chart
       run: |
         cd build-tools/helm
-        mkdir charts
-        tar cvfz charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz spark-kubernetes-operator
-        helm repo index charts --url https://nightlies.apache.org/spark/charts
+        sed -i 's/repository: /repository: apache\//' build-tools/helm/spark-kubernetes-operator/values.yaml
+        sed -i 's/tag: .*$/tag: main-snapshot/' spark-kubernetes-operator/values.yaml
+        mkdir -p tmp/charts
+        helm package spark-kubernetes-operator -d tmp/charts --app-version main-snapshot
+        helm repo index tmp/charts --url https://nightlies.apache.org/spark/charts
+        helm show chart tmp/charts/spark-kubernetes-operator-*.tgz
     - name: Upload
       uses: burnett01/rsync-deployments@5.2
       with:
         switches: -avzr
-        path: build-tools/helm/*
+        path: build-tools/helm/tmp/*
         remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/spark
         remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
         remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}

--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ As of now, you can try `spark-kubernetes-operator` nightly version in the follow
 
 ```
 $ helm install spark-kubernetes-operator \
-https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz \
---set image.repository=dongjoon/spark-kubernetes-operator
+https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz
 ```
 
 ## Contributing


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify snapshot HelmChart to use `apache/spark-kubernetes-operator:main-snapshot` by default.

### Why are the changes needed?

To help users use it without overriding via `--set`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.