### PR TITLE
[SPARK-49362][FOLLOWUP] Remove `build-tools/helm/` from the path

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Build Chart
       run: |
         cd build-tools/helm
-        sed -i 's/repository: /repository: apache\//' build-tools/helm/spark-kubernetes-operator/values.yaml
+        sed -i 's/repository: /repository: apache\//' spark-kubernetes-operator/values.yaml
         sed -i 's/tag: .*$/tag: main-snapshot/' spark-kubernetes-operator/values.yaml
         mkdir -p tmp/charts
         helm package spark-kubernetes-operator -d tmp/charts --app-version main-snapshot


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to fix the HelmChart snapshot CI by removing `build-tools/helm/` prefix.

### Why are the changes needed?

The prefix is not required since we changed the directory.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.