### PR TITLE
[SPARK-49324] Add `SparkApplication` state transition e2e test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -72,6 +72,7 @@ jobs:
         test_group:
           - spark-versions
           - python
+          - state-transition
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/tests/e2e/assertions/spark-application/spark-state-transition.yaml
+++ b/tests/e2e/assertions/spark-application/spark-state-transition.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-job-succeeded-test
+  namespace: default
+status:
+  stateTransitionHistory:
+    (*.currentStateSummary):
+      - "Submitted"
+      - "DriverRequested"
+      - "DriverStarted"
+      - "DriverReady"
+      - "RunningHealthy"
+      - "Succeeded"
+      - "ResourceReleased"

--- a/tests/e2e/state-transition/chainsaw-test.yaml
+++ b/tests/e2e/state-transition/chainsaw-test.yaml
@@ -48,5 +48,6 @@ spec:
         env:
           - name: SPARK_APPLICATION_NAME
             value: ($SPARK_APPLICATION_NAME)
+        timeout: 30s
         content: |
           kubectl delete sparkapplication $SPARK_APPLICATION_NAME

--- a/tests/e2e/state-transition/chainsaw-test.yaml
+++ b/tests/e2e/state-transition/chainsaw-test.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: spark-operator-spark-application-state-transition-validation
+spec:
+  scenarios:
+  - bindings:
+      - name: TEST_NAME
+        value: succeeded
+      - name: FILE_NAME
+        value: spark-example-succeeded.yaml
+      - name: SPARK_APPLICATION_NAME
+        value: spark-job-succeeded-test
+  steps:
+  - try:
+    - script:
+        env:
+          - name: FILE_NAME
+            value: ($FILE_NAME)
+        content: kubectl apply -f $FILE_NAME
+    - assert:
+        timeout: 30s
+        file: "../assertions/spark-application/spark-state-transition.yaml"
+    catch:
+    - describe:
+        apiVersion: spark.apache.org/v1alpha1
+        kind: SparkApplication
+        namespace: default
+    finally:
+    - script:
+        env:
+          - name: SPARK_APPLICATION_NAME
+            value: ($SPARK_APPLICATION_NAME)
+        content: |
+          kubectl delete sparkapplication $SPARK_APPLICATION_NAME

--- a/tests/e2e/state-transition/chainsaw-test.yaml
+++ b/tests/e2e/state-transition/chainsaw-test.yaml
@@ -36,7 +36,7 @@ spec:
             value: ($FILE_NAME)
         content: kubectl apply -f $FILE_NAME
     - assert:
-        timeout: 30s
+        timeout: 60s
         file: "../assertions/spark-application/spark-state-transition.yaml"
     catch:
     - describe:

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-job-succeeded-test
+  namespace: default
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  sparkConf:
+    spark.executor.instances: "1"
+    spark.kubernetes.container.image: "spark:4.0.0-preview1-scala2.13-java17-ubuntu"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+  runtimeVersions:
+    sparkVersion: 4.0.0-preview1
+    scalaVersion: "2.13"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add one state transition test for Spark Applications


### Why are the changes needed?
For stablitiy.


### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
Test from personal GitHub workflow actions


### Was this patch authored or co-authored using generative AI tooling?
n/a
