### PR TITLE
[SPARK-49377] Fix e2e catch step application not found

### DIFF
--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
         - events:
             namespace: default
         - describe:
-            apiVersion: v1
+            apiVersion: spark.apache.org/v1alpha1
             kind: SparkApplication
             namespace: default
         - describe:

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -83,7 +83,7 @@ spec:
         - events:
             namespace: default
         - describe:
-            apiVersion: v1
+            apiVersion: spark.apache.org/v1alpha1
             kind: SparkApplication
             namespace: default
         - describe:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change version in e2e step catch step


### Why are the changes needed?
After the change, in the catch step, the applications can be "described" instead of not found

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
test locally

### Was this patch authored or co-authored using generative AI tooling?
n/a
