### PR TITLE
[SPARK-49395] Add `8081` port to Worker resource spec

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -261,6 +261,10 @@ public class SparkClusterResourceSpec {
                 + name
                 + "-master-svc:7077 && while /opt/spark/sbin/spark-daemon.sh status "
                 + "org.apache.spark.deploy.worker.Worker 1; do sleep 1; done")
+        .addNewPort()
+        .withName("web")
+        .withContainerPort(8081)
+        .endPort()
         .endContainer()
         .endSpec()
         .endTemplate()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `8081` port to Worker resource spec.

### Why are the changes needed?

Like `Master`'s `8080` port, we can expose it for users.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.
```
$ gradle build buildDockerImage spark-operator-api:relocateGeneratedCRD -x check
$ helm install spark-kubernetes-operator -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
$ kubectl apply -f examples/qa-cluster-with-one-worker.yaml
$ kubectl get pod -l spark-role=worker -oyaml | yq '.items[0].spec.containers[0].ports'
- containerPort: 8081
  name: web
  protocol: TCP
```

### Was this patch authored or co-authored using generative AI tooling?

No.