### PR TITLE
[MINOR] Remove unused versions from `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,6 @@ org.gradle.jvmargs=-Xmx4g
 
 # Caution: fabric8 version should be aligned with Spark dependency
 fabric8Version=6.13.3
-commonsLang3Version=3.16.0
-commonsIOVersion=2.16.1
 lombokVersion=1.18.32
 operatorSDKVersion=4.9.0
 okHttpVersion=4.12.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unused versions from `gradle.properties`.

### Why are the changes needed?

To clean up the misleading unused versions. We can see that there is no usage like the following.

```
$ git grep commonsLang3Version
gradle.properties:commonsLang3Version=3.16.0

$ git grep commonsIOVersion
gradle.properties:commonsIOVersion=2.16.1
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.