### PR TITLE
[SPARK-49400] Use Gradle Version Catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ buildscript {
     }
   }
   dependencies {
-    classpath "com.github.spotbugs.snom:spotbugs-gradle-plugin:${spotBugsGradlePluginVersion}"
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:${spotlessPluginVersion}"
-    classpath "com.github.johnrengelman:shadow:${shadowJarPluginVersion}"
+    classpath "${libs.spotbugs.gradle.plugin.get()}"
+    classpath "${libs.spotless.plugin.gradle.get()}"
+    classpath "${libs.shadow.get()}"
   }
 }
 
@@ -59,7 +59,7 @@ subprojects {
 
   apply plugin: 'checkstyle'
   checkstyle {
-    toolVersion = checkstyleVersion
+    toolVersion = libs.versions.checkstyle.get()
     configFile = file("$rootDir/config/checkstyle/checkstyle.xml")
     ignoreFailures = false
     showViolations = true
@@ -68,14 +68,14 @@ subprojects {
   apply plugin: 'pmd'
   pmd {
     ruleSetFiles = files("$rootDir/config/pmd/ruleset.xml")
-    toolVersion = pmdVersion
+    toolVersion = libs.versions.pmd.get()
     consoleOutput = true
     ignoreFailures = false
   }
 
   apply plugin: 'com.github.spotbugs'
   spotbugs {
-    toolVersion = spotBugsVersion
+    toolVersion = libs.versions.spotbugs.tool.get()
     afterEvaluate {
       reportsDir = file("${project.reporting.baseDir}/findbugs")
     }
@@ -85,7 +85,7 @@ subprojects {
 
   apply plugin: 'jacoco'
   jacoco {
-    toolVersion = jacocoVersion
+    toolVersion = libs.versions.jacoco.get()
   }
   jacocoTestReport {
     dependsOn test

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,35 +17,3 @@
 
 # Gradle
 org.gradle.jvmargs=-Xmx4g
-
-# Caution: fabric8 version should be aligned with Spark dependency
-fabric8Version=6.13.3
-commonsLang3Version=3.16.0
-commonsIOVersion=2.16.1
-lombokVersion=1.18.32
-operatorSDKVersion=4.9.0
-okHttpVersion=4.12.0
-dropwizardMetricsVersion=4.2.25
-
-# Spark
-scalaVersion=2.13
-sparkVersion=4.0.0-preview1
-
-# Logging
-log4jVersion=2.22.1
-
-# Test
-junitVersion=5.10.2
-jacocoVersion=0.8.12
-mockitoVersion=5.11.0
-powerMockVersion=2.0.9
-
-# Build Analysis
-checkstyleVersion=10.17.0
-pmdVersion=6.55.0
-spotBugsGradlePluginVersion=6.0.17
-spotBugsVersion=4.8.6
-spotlessPluginVersion=6.25.0
-
-# Packaging
-shadowJarPluginVersion=8.1.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+[versions]
+fabric8 = "6.13.3"
+lombok = "1.18.32"
+operator-sdk = "4.9.0"
+okhttp = "4.12.0"
+dropwizard-metrics = "4.2.25"
+spark = "4.0.0-preview1"
+log4j = "2.22.1"
+
+# Test
+junit = "5.10.2"
+jacoco = "0.8.12"
+mockito = "5.11.0"
+powermock = "2.0.9"
+
+# Build Analysis
+checkstyle = "10.17.0"
+pmd = "6.55.0"
+spotbugs-tool = "4.8.6"
+spotbugs-plugin = "6.0.17"
+spotless-plugin = "6.25.0"
+
+# Packaging
+shadow-jar-plugin = "8.1.1"
+
+[libraries]
+kubernetes-client = { group = "io.fabric8", name = "kubernetes-client", version.ref = "fabric8" }
+kubernetes-httpclient-okhttp = { group = "io.fabric8", name = "kubernetes-httpclient-okhttp", version.ref = "fabric8" }
+kubernetes-server-mock = { group = "io.fabric8", name = "kubernetes-server-mock", version.ref = "fabric8" }
+crd-generator-apt = { group = "io.fabric8", name = "crd-generator-apt", version.ref = "fabric8" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
+log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
+log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
+log4j-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version.ref = "log4j" }
+log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
+log4j-layout-template-json = { group = "org.apache.logging.log4j", name = "log4j-layout-template-json", version.ref = "log4j" }
+operator-framework = { group = "io.javaoperatorsdk", name = "operator-framework", version.ref = "operator-sdk"}
+operator-framework-junit5 = { group = "io.javaoperatorsdk", name = "operator-framework-junit-5", version.ref = "operator-sdk"}
+spotbugs-annotations = { group = "com.github.spotbugs", name = "spotbugs-annotations", version.ref = "spotbugs-tool"}
+metrics-core = { group = "io.dropwizard.metrics", name = "metrics-core", version.ref = "dropwizard-metrics"}
+metrics-jvm = { group = "io.dropwizard.metrics", name = "metrics-jvm", version.ref = "dropwizard-metrics"}
+spark-core = { group = "org.apache.spark", name = "spark-core_2.13", version.ref = "spark"}
+spark-kubernetes = { group = "org.apache.spark", name = "spark-kubernetes_2.13", version.ref = "spark"}
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito"}
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit"}
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit"}
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher"}
+powermock-core = { group = "org.powermock", name = "powermock-core", version.ref = "powermock"}
+spotbugs-gradle-plugin = { group = "com.github.spotbugs.snom", name = "spotbugs-gradle-plugin", version.ref = "spotbugs-plugin" }
+spotless-plugin-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless-plugin" }
+shadow = { group = "com.github.johnrengelman", name = "shadow", version.ref = "shadow-jar-plugin"}

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -18,23 +18,23 @@
  */
 dependencies {
   // fabric8
-  implementation("io.fabric8:kubernetes-client:$fabric8Version") {
+  implementation(libs.kubernetes.client) {
     exclude group: 'com.squareup.okhttp3'
   }
-  compileOnly("io.fabric8:crd-generator-apt:$fabric8Version")
-  annotationProcessor("io.fabric8:crd-generator-apt:$fabric8Version")
+  compileOnly(libs.crd.generator.apt)
+  annotationProcessor(libs.crd.generator.apt)
 
   // utils
-  implementation("org.projectlombok:lombok:$lombokVersion")
-  annotationProcessor("org.projectlombok:lombok:$lombokVersion")
+  implementation(libs.lombok)
+  annotationProcessor(libs.lombok)
 
   // logging
-  implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
-  implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
+  implementation(libs.log4j.slf4j.impl)
+  implementation(libs.log4j.core)
 
-  testImplementation platform("org.junit:junit-bom:$junitVersion")
-  testImplementation 'org.junit.jupiter:junit-jupiter'
-  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 test {

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -22,27 +22,27 @@ dependencies {
   implementation project(":spark-operator-api")
   implementation project(":spark-submission-worker")
 
-  implementation("io.javaoperatorsdk:operator-framework:$operatorSDKVersion") {
+  implementation(libs.operator.framework) {
     exclude group: 'com.squareup.okio'
     exclude group: 'io.fabric8'
   }
-  implementation("io.fabric8:kubernetes-httpclient-okhttp:$fabric8Version") {
+  implementation(libs.kubernetes.httpclient.okhttp) {
     exclude group: 'com.squareup.okhttp3'
   }
-  implementation("com.squareup.okhttp3:okhttp:$okHttpVersion")
-  implementation("com.squareup.okhttp3:logging-interceptor:$okHttpVersion")
-  implementation("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
+  implementation(libs.okhttp)
+  implementation(libs.logging.interceptor)
+  implementation(libs.spotbugs.annotations)
   // logging
-  implementation("org.apache.logging.log4j:log4j-api:$log4jVersion")
-  implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-  implementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
-  implementation("org.apache.logging.log4j:log4j-1.2-api:$log4jVersion")
-  implementation("org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion")
+  implementation(libs.log4j.api)
+  implementation(libs.log4j.core)
+  implementation(libs.log4j.slf4j.impl)
+  implementation(libs.log4j.api12)
+  implementation(libs.log4j.layout.template.json)
 
   // metrics
-  implementation("io.dropwizard.metrics:metrics-core:$dropwizardMetricsVersion")
-  implementation("io.dropwizard.metrics:metrics-jvm:$dropwizardMetricsVersion")
-  compileOnly("org.apache.spark:spark-core_$scalaVersion:$sparkVersion") {
+  implementation(libs.metrics.core)
+  implementation(libs.metrics.jvm)
+  compileOnly(libs.spark.core) {
     exclude group: "com.github.luben"
     exclude group: "io.netty", module: "netty-tcnative-boringssl-static"
     exclude group: "io.netty", module: "netty-tcnative-classes"
@@ -55,32 +55,32 @@ dependencies {
     exclude group: 'com.squareup.okhttp3'
     exclude group: 'com.squareup.okio'
   }
-  compileOnly("org.projectlombok:lombok:$lombokVersion")
+  compileOnly(libs.lombok)
 
-  annotationProcessor("org.projectlombok:lombok:$lombokVersion")
-  annotationProcessor("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
+  annotationProcessor(libs.lombok)
+  annotationProcessor(libs.spotbugs.annotations)
 
-  testImplementation("io.javaoperatorsdk:operator-framework-junit-5:$operatorSDKVersion") {
+  testImplementation(libs.operator.framework.junit5) {
     exclude group: 'com.squareup.okio'
     exclude group: 'io.fabric8'
   }
-  testImplementation("io.fabric8:kubernetes-server-mock:$fabric8Version") {
+  testImplementation(libs.kubernetes.server.mock) {
     exclude group: 'junit'
     exclude group: 'com.squareup.okhttp3'
   }
-  testImplementation("org.apache.spark:spark-core_$scalaVersion:$sparkVersion") {
+  testImplementation(libs.spark.core) {
     exclude group: 'com.squareup.okio'
     exclude group: 'com.squareup.okhttp3'
     exclude group: "org.apache.logging.log4j"
     exclude group: "org.slf4j"
   }
-  testImplementation("com.squareup.okhttp3:mockwebserver:$okHttpVersion")
-  testImplementation platform("org.junit:junit-bom:$junitVersion")
-  testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
-  testImplementation("org.powermock:powermock-core:$powerMockVersion")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+  testImplementation(libs.mockwebserver)
+  testImplementation platform(libs.junit.bom)
+  testImplementation(libs.junit.jupiter)
+  testImplementation(libs.powermock.core)
+  testRuntimeOnly(libs.junit.platform.launcher)
 
-  testImplementation("org.mockito:mockito-core:$mockitoVersion")
+  testImplementation(libs.mockito.core)
 }
 
 test {

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -19,7 +19,7 @@
 dependencies {
   implementation project(":spark-operator-api")
 
-  implementation("org.apache.spark:spark-kubernetes_$scalaVersion:$sparkVersion") {
+  implementation(libs.spark.kubernetes) {
     exclude group: "com.github.luben"
     exclude group: "io.netty", module: "netty-tcnative-boringssl-static"
     exclude group: "io.netty", module: "netty-tcnative-classes"
@@ -30,13 +30,13 @@ dependencies {
     exclude group: 'commons-collections', module: 'commons-collections'
   }
 
-  compileOnly("org.projectlombok:lombok:$lombokVersion")
-  annotationProcessor("org.projectlombok:lombok:$lombokVersion")
+  compileOnly(libs.lombok)
+  annotationProcessor(libs.lombok)
 
-  testImplementation platform("org.junit:junit-bom:$junitVersion")
-  testImplementation "org.mockito:mockito-core:$mockitoVersion"
-  testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 test {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use a standard `Gradle Version Catalog`.
- https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml

### Why are the changes needed?

Currently, `gradle.properties` has all predefined versions, but it's not a good place.

Gradle provides a standard way, `Gradle Version Catalog`, via `libs.versions.toml`, which is supported by CIs and other tools. We had better follow the standard in order to simplify the code and reduce the maintenance burden.

```
- implementation("org.apache.spark:spark-kubernetes_$scalaVersion:$sparkVersion") {
+ implementation(libs.spark.kubernetes) {
```

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.