### PR TITLE
[SPARK-49403] Add `log4j2` default setting to `values.yaml`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -167,7 +167,13 @@ operatorConfiguration:
   append: true
   log4j2.properties: |+
     # Logging Overrides
-    # rootLogger.level=DEBUG
+    rootLogger.level=INFO
+    rootLogger.appenderRef.stdout.ref = console
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.target = SYSTEM_ERR
+    appender.console.layout.type = PatternLayout
+    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
   spark-operator.properties: |+
     # Property Overrides. e.g.
     # spark.kubernetes.operator.reconciler.intervalSeconds=60


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `log4j2` default setting to `values.yaml`.

### Why are the changes needed?

To show INFO log by default and allow users override this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

```
$ kubectl logs -f spark-kubernetes-operator-546b54d5c-d5b49
Starting Operator...
WARNING: Runtime environment or build system does not support multi-release JARs. This will impact location-based features.
24/08/27 07:09:02 INFO SparkOperator: Configuring operator with 50 reconciliation threads.
24/08/27 07:09:02 INFO SparkOperator: Adding Operator JosdkMetrics to metrics system.
...
```

### Was this patch authored or co-authored using generative AI tooling?

No.