### PR TITLE
[SPARK-49453] Add quotes for number

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -188,4 +188,4 @@ operatorConfiguration:
       "helm.sh/resource-policy": keep
     data:
       # Spark Operator Config Runtime Properties Overrides. e.g.
-      spark.kubernetes.operator.reconciler.intervalSeconds: 60
+      spark.kubernetes.operator.reconciler.intervalSeconds: "60"


### PR DESCRIPTION
### What changes were proposed in this pull request?
[SPARK-49453] Add quotes for number in values.yaml


### Why are the changes needed?
I have another value.yaml as below:
``` yaml
operatorConfiguration:
  dynamicConfig:
  enable: true
  create: true
  data:
    spark.kubernetes.operator.watchedNamespaces: "default, spark-1"
```
After running below with two values.yaml:
helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml -f tests/e2e/helm/dynamic-config-values.yaml build-tools/helm/spark-kubernetes-operator/
The generated configmap data field does not contains the line spark.kubernetes.operator.watchedNamespaces: "default, spark-1". Note that if you run helm install --dry-run, the record exist

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
test locally


### Was this patch authored or co-authored using generative AI tooling?
no