### PR TITLE
[SPARK-49514] Fix K8s version in GitHub Action CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_versions:
+        kubernetes_version:
           - "1.27.0"
           - "1.31.0"
         test_group:
@@ -88,7 +88,7 @@ jobs:
         uses: medyagh/setup-minikube@v0.0.18
         with:
           cache: true
-          kubernetes-version: ${{ matrix.kube-version }}
+          kubernetes-version: ${{ matrix.kubernetes_version }}
           cpus: 2
           memory: 6144m
       - name: Set Up Go


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `K8s` version in GitHub Action CI.

### Why are the changes needed?

Currently, K8s Integration tests always use K8s 1.30 because matrix value is not used correctly. The last line of screenshot shows it.

- https://github.com/apache/spark-kubernetes-operator/actions/runs/10647518766/job/29515540136

![Screenshot 2024-09-04 at 10 40 01](https://github.com/user-attachments/assets/ca7b9aa4-4c58-47b0-9639-1ed38f99327d)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Check the CI log in this PR.

- https://github.com/apache/spark-kubernetes-operator/actions/runs/10706755380/job/29685195043?pr=116

![Screenshot 2024-09-04 at 10 41 46](https://github.com/user-attachments/assets/d48b46f9-52ce-4b6a-97fd-b167c2887c9a)


### Was this patch authored or co-authored using generative AI tooling?

No.