### PR TITLE
[SPARK-49590] Fix `javaVersion` to `jdkVersion` in E2E `spark-versions` test template

### DIFF
--- a/tests/e2e/spark-versions/spark-example.yaml
+++ b/tests/e2e/spark-versions/spark-example.yaml
@@ -31,4 +31,4 @@ spec:
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
     sparkVersion: ($V_SPARK_VERSION)
-    javaVersion: ($V_JAVA_VERSION)
+    jdkVersion: ($V_JAVA_VERSION)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR corrects an invalid spec in e2e test template - `javaVersion` -> `jdkVersion` .

https://github.com/apache/spark-kubernetes-operator/blob/bc422fd4524f8139e934123cfe78d1833009026c/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/RuntimeVersions.java#L39

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The invalid test template causes e2e to fail e.g. https://github.com/apache/spark-kubernetes-operator/actions/runs/10745816799/job/29942467715?pr=118

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CIs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No