### PR TITLE
[SPARK-49645] Update `e2e/python/chainsaw-test.yaml` to use non-R image

### DIFF
--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -27,7 +27,7 @@ spec:
         - name: "SCALA_VERSION"
           value: "2.12"
         - name: "IMAGE"
-          value: 'spark:3.5.2-scala2.12-java17-python3-r-ubuntu'
+          value: 'spark:3.5.2-scala2.12-java17-python3-ubuntu'
   steps:
     - name: install-spark-application
       try:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `e2e/python/chainsaw-test.yaml` to use non-R image.

This is the only instance we have.
```
$ git grep '\-r-'
tests/e2e/python/chainsaw-test.yaml:          value: 'spark:3.5.2-scala2.12-java17-python3-r-ubuntu'
```

### Why are the changes needed?

New image is 36% smaller.
```
$ docker images | grep 3.5.2
spark  3.5.2-scala2.12-java17-python3-r-ubuntu   16362acf4adb   4 weeks ago     1.52GB
spark  3.5.2-scala2.12-java17-python3-ubuntu     a79b6b6ef9a4   4 weeks ago     985MB
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.