### PR TITLE
[SPARK-49658] Refactor e2e tests pipelines

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -112,11 +112,8 @@ jobs:
           kubectl get pods -A
           kubectl describe node
       - name: Run Spark K8s Operator on K8S with Dynamic Configuration Disabled
+        if: matrix.mode == 'static'
         run: |
-          if [[ "${{ matrix.mode }}" != "static" ]]; then
-            echo "Skip installation of the operator when mode is not static"
-            exit 0
-          fi
           eval $(minikube docker-env)
           ./gradlew buildDockerImage
           ./gradlew spark-operator-api:relocateGeneratedCRD
@@ -125,18 +122,12 @@ jobs:
           # Use remote host' s docker image
           minikube docker-env --unset
       - name: Run E2E Test with Dynamic Configuration Disabled
-        run: |
-          if [[ "${{ matrix.mode }}" != "static" ]]; then
-            echo "Skip e2e tests when mode is not static"
-            exit 0
-          fi          
+        if: matrix.mode == 'static'
+        run: |        
           chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
       - name: Run Spark K8s Operator on K8S with Dynamic Configuration Enabled
+        if: matrix.mode == 'dynamic'
         run: |
-          if [[ "${{ matrix.mode }}" != "dynamic" ]]; then
-            echo "Skip installation of the operator when mode is not dynamic"
-            exit 0
-          fi
           eval $(minikube docker-env)
           ./gradlew buildDockerImage
           ./gradlew spark-operator-api:relocateGeneratedCRD
@@ -146,11 +137,8 @@ jobs:
           build-tools/helm/spark-kubernetes-operator/
           minikube docker-env --unset
       - name: Run E2E Test with Dynamic Configuration Enabled
+        if: matrix.mode == 'dynamic'
         run: |
-          if [[ "${{ matrix.mode }}" != "dynamic" ]]; then
-            echo "Skip e2e tests when mode is not dynamic"
-            exit 0
-          fi
           chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
 
   lint:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,12 +69,23 @@ jobs:
         kubernetes-version:
           - "1.28.0"
           - "1.31.0"
+        mode:
+          - dynamic
+          - static
         test-group:
           - spark-versions
           - python
           - state-transition
-        dynamic-config-test-group:
           - watched-namespaces
+        exclude:
+          - mode: dynamic
+            test-group: spark-versions
+          - mode: dynamic
+            test-group: python
+          - mode: dynamic
+            test-group: state-transition
+          - mode: static
+            test-group: watched-namespaces
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -102,7 +113,10 @@ jobs:
           kubectl describe node
       - name: Run Spark K8s Operator on K8S with Dynamic Configuration Disabled
         run: |
-          kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
+          if [[ "${{ matrix.mode }}" != "static" ]]; then
+            echo "Skip installation of the operator when mode is not static"
+            exit 0
+          fi
           eval $(minikube docker-env)
           ./gradlew buildDockerImage
           ./gradlew spark-operator-api:relocateGeneratedCRD
@@ -112,11 +126,20 @@ jobs:
           minikube docker-env --unset
       - name: Run E2E Test with Dynamic Configuration Disabled
         run: |
+          if [[ "${{ matrix.mode }}" != "static" ]]; then
+            echo "Skip e2e tests when mode is not static"
+            exit 0
+          fi          
           chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
       - name: Run Spark K8s Operator on K8S with Dynamic Configuration Enabled
         run: |
-          helm uninstall spark-kubernetes-operator
+          if [[ "${{ matrix.mode }}" != "dynamic" ]]; then
+            echo "Skip installation of the operator when mode is not dynamic"
+            exit 0
+          fi
           eval $(minikube docker-env)
+          ./gradlew buildDockerImage
+          ./gradlew spark-operator-api:relocateGeneratedCRD
           helm install spark-kubernetes-operator --create-namespace -f \
           build-tools/helm/spark-kubernetes-operator/values.yaml -f \
           tests/e2e/helm/dynamic-config-values.yaml \
@@ -124,7 +147,11 @@ jobs:
           minikube docker-env --unset
       - name: Run E2E Test with Dynamic Configuration Enabled
         run: |
-          chainsaw test --test-dir ./tests/e2e/${{ matrix.dynamic-config-test-group }} --parallel 2
+          if [[ "${{ matrix.mode }}" != "dynamic" ]]; then
+            echo "Skip e2e tests when mode is not dynamic"
+            exit 0
+          fi
+          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
 
   lint:
     name: "Linter and documentation"


### PR DESCRIPTION
### What changes were proposed in this pull request?
e2e pipelines refactor


### Why are the changes needed?
* Current helm installation does not require creation of additional clusterrolebinding, serviceacount etc. Remove it.
* Current e2e pipeline run 3 times(because of the dimension of test-group) run of dynamic operator installation and watched-namespaces tests for one k8s version. Reduce it to 1 run only per k8s version.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
test locally

### Was this patch authored or co-authored using generative AI tooling?
no