### PR TITLE
[SPARK-49705] Use `spark-examples.jar` instead of `spark-examples_2.13-4.0.0-preview1.jar`

### DIFF
--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -18,7 +18,7 @@ metadata:
   name: pi-on-yunikorn
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   driverArgs: [ "20000" ]
   sparkConf:
     spark.dynamicAllocation.enabled: "true"

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -18,7 +18,7 @@ metadata:
   name: pi-scala
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -18,7 +18,7 @@ metadata:
   name: pi-with-one-pod
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.kubernetes.driver.master: "local[10]"
     spark.kubernetes.driver.request.cores: "5"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -18,7 +18,7 @@ metadata:
   name: pi
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -18,7 +18,7 @@ metadata:
   name: sql
 spec:
   mainClass: "org.apache.spark.examples.sql.JavaSparkSQLCli"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   driverArgs: [ "SHOW DATABASES", "SHOW TABLES", "SELECT VERSION()"  ]
   sparkConf:
     spark.dynamicAllocation.enabled: "true"

--- a/examples/submit-pi-to-prod.sh
+++ b/examples/submit-pi-to-prod.sh
@@ -30,7 +30,7 @@ curl -XPOST http://localhost:6066/v1/submissions/create \
     "spark.executor.memory": "1g",
     "spark.cores.max": "2",
     "spark.ui.reverseProxy": "true",
-    "spark.jars": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+    "spark.jars": "local:///opt/spark/examples/jars/spark-examples.jar"
   },
   "clientSparkVersion": "",
   "mainClass": "org.apache.spark.examples.SparkPi",

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: default
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.executor.instances: "1"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: ($SPARK_APP_NAMESPACE)
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
-  jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.executor.instances: "1"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `spark-examples.jar` instead of `spark-examples_2.13-4.0.0-preview1.jar`.

### Why are the changes needed?

To simplify the examples for Apache Spark 4+ via SPARK-45497.
- https://github.com/apache/spark/pull/43324

### Does this PR introduce _any_ user-facing change?

Yes, but only example images.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.