### PR TITLE
[SPARK-49706] Use `apache/spark` images instead of `spark`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Events:
   Normal  Scheduled          14s   yunikorn  Successfully assigned default/pi-on-yunikorn-0-driver to node docker-desktop
   Normal  PodBindSuccessful  14s   yunikorn  Pod default/pi-on-yunikorn-0-driver is successfully bound to node docker-desktop
   Normal  TaskCompleted      6s    yunikorn  Task default/pi-on-yunikorn-0-driver is completed
-  Normal  Pulled             13s   kubelet   Container image "spark:4.0.0-preview1" already present on machine
+  Normal  Pulled             13s   kubelet   Container image "apache/spark:4.0.0-preview1" already present on machine
   Normal  Created            13s   kubelet   Created container spark-kubernetes-driver
   Normal  Started            13s   kubelet   Started container spark-kubernetes-driver
 

--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -25,7 +25,7 @@ spec:
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
     spark.kubernetes.scheduler.name: "yunikorn"
     spark.master.ui.title: "Spark Cluster on YuniKorn Scheduler"
     spark.master.rest.enabled: "true"

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -87,7 +87,7 @@ spec:
       annotations:
         customAnnotation: "annotation"
   sparkConf:
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
     spark.master.ui.title: "Spark Cluster with Template"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -26,7 +26,7 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
     spark.kubernetes.scheduler.name: "yunikorn"
     spark.kubernetes.driver.label.queue: "root.default"
     spark.kubernetes.executor.label.queue: "root.default"

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -25,7 +25,7 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -25,6 +25,6 @@ spec:
     spark.kubernetes.driver.limit.cores: "5"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
   runtimeVersions:
     sparkVersion: "4.0.0-preview1"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -25,7 +25,7 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:

--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -25,7 +25,7 @@ spec:
       minWorkers: 3
       maxWorkers: 3
   sparkConf:
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
     spark.master.ui.title: "Prod Spark Cluster"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/pyspark-pi.yaml
+++ b/examples/pyspark-pi.yaml
@@ -24,7 +24,7 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -25,7 +25,7 @@ spec:
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
     spark.master.ui.title: "QA Spark Cluster"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -26,6 +26,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
   runtimeVersions:
     sparkVersion: "4.0.0-preview1"

--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -27,7 +27,7 @@ spec:
         - name: "SCALA_VERSION"
           value: "2.12"
         - name: "IMAGE"
-          value: 'spark:3.5.2-scala2.12-java17-python3-ubuntu'
+          value: "apache/spark:3.5.2-scala2.12-java17-python3-ubuntu"
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -29,7 +29,7 @@ spec:
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: 'spark:4.0.0-preview1-scala2.13-java17-ubuntu'
+        value: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"
   - bindings:
       - name: "SPARK_VERSION"
         value: "3.5.2"

--- a/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
@@ -26,7 +26,7 @@ spec:
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
     spark.master.ui.title: "Spark Cluster E2E Test"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -25,7 +25,7 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
   sparkConf:
     spark.executor.instances: "1"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1-scala2.13-java17-ubuntu"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
     sparkVersion: 4.0.0-preview1

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -25,7 +25,7 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.0-preview1.jar"
   sparkConf:
     spark.executor.instances: "1"
-    spark.kubernetes.container.image: "spark:4.0.0-preview1-scala2.13-java17-ubuntu"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.driver.request.cores: "0.5"
     spark.kubernetes.executor.request.cores: "0.5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to propose to use `apache/spark` images instead of `spark` because `apache/spark` images are published first. For example, the following are only available in `apache/spark` as of now.
- https://github.com/apache/spark-docker/pull/66
- https://github.com/apache/spark-docker/pull/67
- https://github.com/apache/spark-docker/pull/68

### Why are the changes needed?

To apply the latest bits earlier.

### Does this PR introduce _any_ user-facing change?

There is no change from `Apache Spark K8s Operator`.
Only the underlying images are changed.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.