### PR TITLE
[SPARK-45923]Add java21 to the e2e tests

### DIFF
--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -38,7 +38,7 @@ spec:
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: 'spark:3.5.2-scala2.12-java17-ubuntu'
+        value: 'apache/spark:3.5.2-scala2.12-java17-ubuntu'
   - bindings:
       - name: "SPARK_VERSION"
         value: "3.4.3"
@@ -47,7 +47,16 @@ spec:
       - name: "JAVA_VERSION"
         value: "11"
       - name: "IMAGE"
-        value: 'spark:3.4.3-scala2.12-java11-ubuntu'
+        value: 'apache/spark:3.4.3-scala2.12-java11-ubuntu'
+  - bindings:
+      - name: "SPARK_VERSION"
+        value: "4.0.0-preview1"
+      - name: "SCALA_VERSION"
+        value: "2.13"
+      - name: "JAVA_VERSION"
+        value: "21"
+      - name: "IMAGE"
+        value: 'apache/spark:4.0.0-preview1-java21-scala'
   steps:
     - name: install-spark-application
       try:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add java 21 e2e teste


### Why are the changes needed?
E2E coverage on java version

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
e2e workflow should cover this

### Was this patch authored or co-authored using generative AI tooling?
no