### PR TITLE
[SPARK-49742] Upgrade `README`, examples, tests to use `preview2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ ./examples/submit-pi-to-prod.sh
 {
   "action" : "CreateSubmissionResponse",
   "message" : "Driver successfully submitted as driver-20240821181327-0000",
-  "serverSparkVersion" : "4.0.0-preview1",
+  "serverSparkVersion" : "4.0.0-preview2",
   "submissionId" : "driver-20240821181327-0000",
   "success" : true
 }
@@ -73,7 +73,7 @@ $ curl http://localhost:6066/v1/submissions/status/driver-20240821181327-0000/
 {
   "action" : "SubmissionStatusResponse",
   "driverState" : "FINISHED",
-  "serverSparkVersion" : "4.0.0-preview1",
+  "serverSparkVersion" : "4.0.0-preview2",
   "submissionId" : "driver-20240821181327-0000",
   "success" : true,
   "workerHostPort" : "10.1.5.188:42099",
@@ -100,7 +100,7 @@ Events:
   Normal  Scheduled          14s   yunikorn  Successfully assigned default/pi-on-yunikorn-0-driver to node docker-desktop
   Normal  PodBindSuccessful  14s   yunikorn  Pod default/pi-on-yunikorn-0-driver is successfully bound to node docker-desktop
   Normal  TaskCompleted      6s    yunikorn  Task default/pi-on-yunikorn-0-driver is completed
-  Normal  Pulled             13s   kubelet   Container image "apache/spark:4.0.0-preview1" already present on machine
+  Normal  Pulled             13s   kubelet   Container image "apache/spark:4.0.0-preview2" already present on machine
   Normal  Created            13s   kubelet   Created container spark-kubernetes-driver
   Normal  Started            13s   kubelet   Started container spark-kubernetes-driver
 

--- a/examples/cluster-java21.yaml
+++ b/examples/cluster-java21.yaml
@@ -18,14 +18,14 @@ metadata:
   name: cluster-java21
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3
       minWorkers: 3
       maxWorkers: 3
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-java21"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21"
     spark.master.ui.title: "Prod Spark Cluster (Java 21)"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -18,14 +18,14 @@ metadata:
   name: cluster-on-yunikorn
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.kubernetes.scheduler.name: "yunikorn"
     spark.master.ui.title: "Spark Cluster on YuniKorn Scheduler"
     spark.master.rest.enabled: "true"

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
@@ -87,7 +87,7 @@ spec:
       annotations:
         customAnnotation: "annotation"
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.master.ui.title: "Spark Cluster with Template"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/pi-java21.yaml
+++ b/examples/pi-java21.yaml
@@ -25,9 +25,9 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -26,7 +26,7 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.kubernetes.scheduler.name: "yunikorn"
     spark.kubernetes.driver.label.queue: "root.default"
     spark.kubernetes.executor.label.queue: "root.default"
@@ -36,4 +36,4 @@ spec:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -25,9 +25,9 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -25,6 +25,6 @@ spec:
     spark.kubernetes.driver.limit.cores: "5"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -25,9 +25,9 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -18,14 +18,14 @@ metadata:
   name: prod
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3
       minWorkers: 3
       maxWorkers: 3
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.master.ui.title: "Prod Spark Cluster"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/pyspark-pi.yaml
+++ b/examples/pyspark-pi.yaml
@@ -24,8 +24,8 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -18,14 +18,14 @@ metadata:
   name: qa
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.master.ui.title: "QA Spark Cluster"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -26,6 +26,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -52,7 +52,7 @@ public class SparkClusterResourceSpec {
     String clusterName = cluster.getMetadata().getName();
     String scheduler = conf.get(Config.KUBERNETES_SCHEDULER_NAME().key(), "default-scheduler");
     String namespace = conf.get(Config.KUBERNETES_NAMESPACE().key(), clusterNamespace);
-    String image = conf.get(Config.CONTAINER_IMAGE().key(), "spark:4.0.0-preview1");
+    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.0.0-preview2");
     ClusterSpec spec = cluster.getSpec();
     StringBuilder options = new StringBuilder();
     for (Tuple2<String, String> t : conf.getAll()) {

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -23,13 +23,13 @@ spec:
   scenarios:
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.0.0-preview1"
+        value: "4.0.0-preview2"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"
+        value: "apache/spark:4.0.0-preview2-scala2.13-java17-ubuntu"
   - bindings:
       - name: "SPARK_VERSION"
         value: "3.5.2"
@@ -50,13 +50,13 @@ spec:
         value: 'apache/spark:3.4.3-scala2.12-java11-ubuntu'
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.0.0-preview1"
+        value: "4.0.0-preview2"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "21"
       - name: "IMAGE"
-        value: 'apache/spark:4.0.0-preview1-java21-scala'
+        value: 'apache/spark:4.0.0-preview2-java21-scala'
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
@@ -19,14 +19,14 @@ metadata:
   namespace: default
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview1"
+    sparkVersion: "4.0.0-preview2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.master.ui.title: "Spark Cluster E2E Test"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -25,8 +25,8 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.executor.instances: "1"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala2.13-java17-ubuntu"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: 4.0.0-preview1
+    sparkVersion: 4.0.0-preview2
     scalaVersion: "2.13"

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -25,10 +25,10 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.executor.instances: "1"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview1-scala2.13-java17-ubuntu"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala2.13-java17-ubuntu"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.driver.request.cores: "0.5"
     spark.kubernetes.executor.request.cores: "0.5"
   runtimeVersions:
-    sparkVersion: 4.0.0-preview1
+    sparkVersion: 4.0.0-preview2
     scalaVersion: "2.13"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update README, examples, tests to use `Apache Spark 4.0.0-preview2`.

### Why are the changes needed?

We can use the launched `SparkApp`s and `SparkCluster`s.
- Spark K8s Operator is built with `4.0.0-preview2` already via #133 
- Apache Spark 4.0.0-preview2 images are ready via
    - https://github.com/apache/spark-docker/pull/70
    - https://github.com/apache/spark-docker/pull/71

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.