### PR TITLE
[SPARK-49754] Support HPA for `SparkCluster`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
@@ -36,6 +36,12 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - "autoscaling"
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - '*'
+  - apiGroups:
       - "spark.apache.org"
     resources:
       - '*'

--- a/examples/cluster-with-hpa.yaml
+++ b/examples/cluster-with-hpa.yaml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkCluster
+metadata:
+  name: cluster-with-hpa
+spec:
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview2"
+  clusterTolerations:
+    instanceConfig:
+      initWorkers: 3
+      minWorkers: 1
+      maxWorkers: 3
+  workerSpec:
+    workerStatefulSetSpec:
+      template:
+        spec:
+          containers:
+          - name: worker
+            resources:
+              requests:
+                cpu: "3"
+                memory: "3Gi"
+              limits:
+                cpu: "3"
+                memory: "3Gi"
+  sparkConf:
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21"
+    spark.master.ui.title: "Cluster with HorizontalPodAutoscaler"
+    spark.master.rest.enabled: "true"
+    spark.master.rest.host: "0.0.0.0"
+    spark.ui.reverseProxy: "true"

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
@@ -19,8 +19,11 @@
 
 package org.apache.spark.k8s.operator.context;
 
+import java.util.Optional;
+
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.RequiredArgsConstructor;
@@ -72,6 +75,10 @@ public class SparkClusterContext extends BaseContext<SparkCluster> {
 
   public StatefulSet getWorkerStatefulSetSpec() {
     return getSecondaryResourceSpec().getWorkerStatefulSet();
+  }
+
+  public Optional<HorizontalPodAutoscaler> getHorizontalPodAutoscalerSpec() {
+    return getSecondaryResourceSpec().getHorizontalPodAutoscaler();
   }
 
   @Override

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
@@ -43,6 +43,9 @@ public final class SparkClusterResourceSpecFactory {
     decorator.decorate(spec.getWorkerService());
     decorator.decorate(spec.getMasterStatefulSet());
     decorator.decorate(spec.getWorkerStatefulSet());
+    if (spec.getHorizontalPodAutoscaler().isPresent()) {
+      decorator.decorate(spec.getHorizontalPodAutoscaler().get());
+    }
     return spec;
   }
 }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
@@ -68,6 +68,16 @@ public class ClusterInitStep extends ClusterReconcileStep {
       context.getClient().apps().statefulSets().resource(masterStatefulSet).create();
       StatefulSet workerStatefulSet = context.getWorkerStatefulSetSpec();
       context.getClient().apps().statefulSets().resource(workerStatefulSet).create();
+      var horizontalPodAutoscaler = context.getHorizontalPodAutoscalerSpec();
+      if (horizontalPodAutoscaler.isPresent()) {
+        context
+            .getClient()
+            .autoscaling()
+            .v2()
+            .horizontalPodAutoscalers()
+            .resource(horizontalPodAutoscaler.get())
+            .create();
+      }
 
       ClusterStatus updatedStatus =
           context

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterSubmissionWorkerTest.java
@@ -65,5 +65,6 @@ class SparkClusterSubmissionWorkerTest {
     assertNotNull(spec.getMasterService());
     assertNotNull(spec.getMasterStatefulSet());
     assertNotNull(spec.getWorkerStatefulSet());
+    assertNotNull(spec.getHorizontalPodAutoscaler());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support K8s [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale) for `SparkCluster`.

### Why are the changes needed?

To allow users more flexible installation on top of static SparkClusters.

### Does this PR introduce _any_ user-facing change?

No. This is a new feature and HPA is not created if the minimum number of workers is equal to the maximum number of workers.

### How was this patch tested?

Pass the CIs. And, manually create an example cluster and wait until it scales down to the minimum number of workers.
```
$ gradle build buildDockerImage spark-operator-api:relocateGeneratedCRD
$ kubectl apply -f examples/cluster-with-hpa.yaml
```

```
Conditions:                                                                                                                                                          │
│   Type            Status  Reason            Message                                                                                                                  │
│   ----            ------  ------            -------                                                                                                                  │
│   AbleToScale     True    ReadyForNewScale  recommended size matches current size                                                                                    │
│   ScalingActive   True    ValidMetricFound  the HPA was able to successfully calculate a replica count from cpu resource utilization (percentage of request)         │
│   ScalingLimited  True    TooFewReplicas    the desired replica count is less than the minimum replica count                                                         │
│ Events:                                                                                                                                                              │
│   Type    Reason             Age    From                       Message                                                                                               │
│   ----    ------             ----   ----                       -------                                                                                               │
│   Normal  SuccessfulRescale  2m31s  horizontal-pod-autoscaler  New size: 2; reason: All metrics below target                                                         │
│   Normal  SuccessfulRescale  91s    horizontal-pod-autoscaler  New size: 1; reason: All metrics below target
```

### Was this patch authored or co-authored using generative AI tooling?

No.