### PR TITLE
[SPARK-49778] Remove (master|worker) prefix from field names of `(Master|Worker)Spec`

### DIFF
--- a/examples/cluster-with-hpa.yaml
+++ b/examples/cluster-with-hpa.yaml
@@ -25,7 +25,7 @@ spec:
       minWorkers: 1
       maxWorkers: 3
   workerSpec:
-    workerStatefulSetSpec:
+    statefulSetSpec:
       template:
         spec:
           containers:

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -56,10 +56,10 @@ spec:
       annotations:
         customAnnotation: "svc1"
   workerSpec:
-    workerStatefulSetMetadata:
+    statefulSetMetadata:
       annotations:
         customAnnotation: "annotation"
-    workerStatefulSetSpec:
+    statefulSetSpec:
       template:
         spec:
           priorityClassName: system-cluster-critical
@@ -83,7 +83,7 @@ spec:
               limits:
                 cpu: "0.1"
                 memory: "10Mi"
-    workerServiceMetadata:
+    serviceMetadata:
       annotations:
         customAnnotation: "annotation"
   sparkConf:

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/MasterSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/MasterSpec.java
@@ -34,8 +34,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MasterSpec {
-  protected StatefulSetSpec masterStatefulSetSpec;
-  protected ObjectMeta masterStatefulSetMetadata;
-  protected ServiceSpec masterServiceSpec;
-  protected ObjectMeta masterServiceMetadata;
+  protected StatefulSetSpec statefulSetSpec;
+  protected ObjectMeta statefulSetMetadata;
+  protected ServiceSpec serviceSpec;
+  protected ObjectMeta serviceMetadata;
 }

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/WorkerSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/WorkerSpec.java
@@ -34,8 +34,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkerSpec {
-  protected StatefulSetSpec workerStatefulSetSpec;
-  protected ObjectMeta workerStatefulSetMetadata;
-  protected ServiceSpec workerServiceSpec;
-  protected ObjectMeta workerServiceMetadata;
+  protected StatefulSetSpec statefulSetSpec;
+  protected ObjectMeta statefulSetMetadata;
+  protected ServiceSpec serviceSpec;
+  protected ObjectMeta serviceMetadata;
 }

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -67,16 +67,10 @@ public class SparkClusterResourceSpec {
     WorkerSpec workerSpec = spec.getWorkerSpec();
     masterService =
         buildMasterService(
-            clusterName,
-            namespace,
-            masterSpec.getMasterServiceMetadata(),
-            masterSpec.getMasterServiceSpec());
+            clusterName, namespace, masterSpec.getServiceMetadata(), masterSpec.getServiceSpec());
     workerService =
         buildWorkerService(
-            clusterName,
-            namespace,
-            workerSpec.getWorkerServiceMetadata(),
-            workerSpec.getWorkerServiceSpec());
+            clusterName, namespace, workerSpec.getServiceMetadata(), workerSpec.getServiceSpec());
     masterStatefulSet =
         buildMasterStatefulSet(
             scheduler,
@@ -84,8 +78,8 @@ public class SparkClusterResourceSpec {
             namespace,
             image,
             options.toString(),
-            masterSpec.getMasterStatefulSetMetadata(),
-            masterSpec.getMasterStatefulSetSpec());
+            masterSpec.getStatefulSetMetadata(),
+            masterSpec.getStatefulSetSpec());
     workerStatefulSet =
         buildWorkerStatefulSet(
             scheduler,
@@ -94,8 +88,8 @@ public class SparkClusterResourceSpec {
             image,
             spec.getClusterTolerations().getInstanceConfig().getInitWorkers(),
             options.toString(),
-            workerSpec.getWorkerStatefulSetMetadata(),
-            workerSpec.getWorkerStatefulSetSpec());
+            workerSpec.getStatefulSetMetadata(),
+            workerSpec.getStatefulSetSpec());
     horizontalPodAutoscaler = buildHorizontalPodAutoscaler(clusterName, namespace, spec);
   }
 

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterResourceSpecTest.java
@@ -71,14 +71,14 @@ class SparkClusterResourceSpecTest {
     when(clusterSpec.getClusterTolerations()).thenReturn(clusterTolerations);
     when(clusterSpec.getMasterSpec()).thenReturn(masterSpec);
     when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec);
-    when(masterSpec.getMasterStatefulSetSpec()).thenReturn(statefulSetSpec);
-    when(masterSpec.getMasterStatefulSetMetadata()).thenReturn(objectMeta);
-    when(masterSpec.getMasterServiceSpec()).thenReturn(serviceSpec);
-    when(masterSpec.getMasterServiceMetadata()).thenReturn(objectMeta);
-    when(workerSpec.getWorkerStatefulSetSpec()).thenReturn(statefulSetSpec);
-    when(workerSpec.getWorkerStatefulSetMetadata()).thenReturn(objectMeta);
-    when(workerSpec.getWorkerServiceSpec()).thenReturn(serviceSpec);
-    when(workerSpec.getWorkerServiceMetadata()).thenReturn(objectMeta);
+    when(masterSpec.getStatefulSetSpec()).thenReturn(statefulSetSpec);
+    when(masterSpec.getStatefulSetMetadata()).thenReturn(objectMeta);
+    when(masterSpec.getServiceSpec()).thenReturn(serviceSpec);
+    when(masterSpec.getServiceMetadata()).thenReturn(objectMeta);
+    when(workerSpec.getStatefulSetSpec()).thenReturn(statefulSetSpec);
+    when(workerSpec.getStatefulSetMetadata()).thenReturn(objectMeta);
+    when(workerSpec.getServiceSpec()).thenReturn(serviceSpec);
+    when(workerSpec.getServiceMetadata()).thenReturn(objectMeta);
   }
 
   @Test
@@ -111,8 +111,8 @@ class SparkClusterResourceSpecTest {
             .build();
     ServiceSpec serviceSpec1 = new ServiceSpecBuilder().withExternalName("foo").build();
     WorkerSpec workerSpec1 = mock(WorkerSpec.class);
-    when(workerSpec1.getWorkerServiceSpec()).thenReturn(serviceSpec1);
-    when(workerSpec1.getWorkerServiceMetadata()).thenReturn(objectMeta1);
+    when(workerSpec1.getServiceSpec()).thenReturn(serviceSpec1);
+    when(workerSpec1.getServiceMetadata()).thenReturn(objectMeta1);
     when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec1);
 
     Service service1 = new SparkClusterResourceSpec(cluster, new SparkConf()).getWorkerService();
@@ -132,8 +132,8 @@ class SparkClusterResourceSpecTest {
             .build();
     ServiceSpec serviceSpec1 = new ServiceSpecBuilder().withExternalName("foo").build();
     MasterSpec masterSpec1 = mock(MasterSpec.class);
-    when(masterSpec1.getMasterServiceSpec()).thenReturn(serviceSpec1);
-    when(masterSpec1.getMasterServiceMetadata()).thenReturn(objectMeta1);
+    when(masterSpec1.getServiceSpec()).thenReturn(serviceSpec1);
+    when(masterSpec1.getServiceMetadata()).thenReturn(objectMeta1);
     when(clusterSpec.getMasterSpec()).thenReturn(masterSpec1);
 
     Service service1 = new SparkClusterResourceSpec(cluster, new SparkConf()).getMasterService();
@@ -177,8 +177,8 @@ class SparkClusterResourceSpecTest {
             .endTemplate()
             .build();
     MasterSpec masterSpec1 = mock(MasterSpec.class);
-    when(masterSpec1.getMasterStatefulSetMetadata()).thenReturn(objectMeta1);
-    when(masterSpec1.getMasterStatefulSetSpec()).thenReturn(statefulSetSpec1);
+    when(masterSpec1.getStatefulSetMetadata()).thenReturn(objectMeta1);
+    when(masterSpec1.getStatefulSetSpec()).thenReturn(statefulSetSpec1);
     when(clusterSpec.getMasterSpec()).thenReturn(masterSpec1);
     SparkClusterResourceSpec spec1 = new SparkClusterResourceSpec(cluster, new SparkConf());
     StatefulSet statefulSet1 = spec1.getMasterStatefulSet();
@@ -223,8 +223,8 @@ class SparkClusterResourceSpecTest {
             .endTemplate()
             .build();
     WorkerSpec workerSpec1 = mock(WorkerSpec.class);
-    when(workerSpec1.getWorkerStatefulSetMetadata()).thenReturn(objectMeta1);
-    when(workerSpec1.getWorkerStatefulSetSpec()).thenReturn(statefulSetSpec1);
+    when(workerSpec1.getStatefulSetMetadata()).thenReturn(objectMeta1);
+    when(workerSpec1.getStatefulSetSpec()).thenReturn(statefulSetSpec1);
     when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec1);
     SparkClusterResourceSpec spec = new SparkClusterResourceSpec(cluster, new SparkConf());
     StatefulSet statefulSet = spec.getWorkerStatefulSet();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the redundant `master` or `worker` prefixes from field names of `MasterSpec` and `WorkerSpec`. For example,
```
- workerSpec.workerStatefulSetSpec
+ workerSpec.statefulSetSpec
```

### Why are the changes needed?

To simplify `MasterSpec` and `WorkerSpec` by removing repetitions.

### Does this PR introduce _any_ user-facing change?

No, this is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.