### PR TITLE
[SPARK-49830] Add required fields for sparkApplicationSentinel

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -171,6 +171,10 @@ metadata:
     {{- template "spark-operator.workloadLabels" $ }}
   annotations:
     {{- template "spark-operator.workloadAnnotations" $ }}
+spec:
+  runtimeVersions:
+    sparkVersion: 4.0.0-preview2
+    scalaVersion: "2.13"
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the required fields for sparkApplicationSentinel

### Why are the changes needed?
Without this, when enable sparkApplicationSentinel, the operator got ERROR

```
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PUT at: [https://10.96.0.1:443/apis/spark.apache.org/v1alpha1/namespaces/spark-4/sparkapplications/spark-app-sentinel](https://10.96.0.1/apis/spark.apache.org/v1alpha1/namespaces/spark-4/sparkapplications/spark-app-sentinel). Message: SparkApplication.spark.apache.org "spark-app-sentinel" is invalid: spec.runtimeVersions: Required value. Received status: Status(apiVersion=v1, code=422, details=StatusDetails(causes=[StatusCause(field=spec.runtimeVersions, message=Required value, reason=FieldValueRequired, additionalProperties={})], group=spark.apache.org, kind=SparkApplication, name=spark-app-sentinel, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=SparkApplication.spark.apache.org "spark-app-sentinel" is invalid: spec.runtimeVersions: Required value, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Invalid, status=Failure, additionalProperties={}).
```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
test locally, modify the values.yaml with sparkApplicationSentinel enabled

### Was this patch authored or co-authored using generative AI tooling?
no
