### PR TITLE
[SPARK-49831] Provide empty `RuntimeVersions` object to `ClusterSpec.runtimeVersions` by default

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ClusterSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ClusterSpec.java
@@ -36,7 +36,7 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ClusterSpec extends BaseSpec {
-  @Required protected RuntimeVersions runtimeVersions;
+  @Required @Builder.Default protected RuntimeVersions runtimeVersions = new RuntimeVersions();
 
   @Required @Builder.Default
   protected ClusterTolerations clusterTolerations = new ClusterTolerations();

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ClusterSpecTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ClusterSpecTest.java
@@ -20,7 +20,6 @@
 package org.apache.spark.k8s.operator.spec;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,9 @@ class ClusterSpecTest {
   @Test
   void testInitSpecWithDefaults() {
     ClusterSpec spec1 = new ClusterSpec();
-    assertNull(spec1.runtimeVersions);
+    assertEquals(null, spec1.runtimeVersions.jdkVersion);
+    assertEquals(null, spec1.runtimeVersions.scalaVersion);
+    assertEquals(null, spec1.runtimeVersions.sparkVersion);
     assertEquals(0, spec1.clusterTolerations.instanceConfig.initWorkers);
     assertEquals(0, spec1.clusterTolerations.instanceConfig.minWorkers);
     assertEquals(0, spec1.clusterTolerations.instanceConfig.maxWorkers);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like the other fields of `ClusterSpec`, this PR aims to provide at least empty `RuntimeVersions` object to `ClusterSpec.runtimeVersions` field by default.

### Why are the changes needed?

Although `ClusterSpec.runtimeVersions` field is a required field, it's `null` currently by default because this should be provided by the users. However, technically, we can create `RuntimeVersions` object with null fields when we don't know the values of `RuntimeVersion` class fields. By providing this intermediate object by default, we can write a test case more easily in other modules.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the updated test case.

### Was this patch authored or co-authored using generative AI tooling?

No.