### PR TITLE
[SPARK-49832] Make `o.a.s.k8s.operator.utils.Utils` argument naming consistent

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java
@@ -96,26 +96,26 @@ public final class Utils {
     return labels;
   }
 
-  public static Map<String, String> driverLabels(final SparkApplication sparkApplication) {
-    Map<String, String> labels = sparkAppResourceLabels(sparkApplication);
+  public static Map<String, String> driverLabels(final SparkApplication app) {
+    Map<String, String> labels = sparkAppResourceLabels(app);
     labels.put(Constants.LABEL_SPARK_ROLE_NAME, LABEL_SPARK_ROLE_DRIVER_VALUE);
     return labels;
   }
 
-  public static Map<String, String> executorLabels(final SparkApplication sparkApplication) {
-    Map<String, String> labels = sparkAppResourceLabels(sparkApplication);
+  public static Map<String, String> executorLabels(final SparkApplication app) {
+    Map<String, String> labels = sparkAppResourceLabels(app);
     labels.put(Constants.LABEL_SPARK_ROLE_NAME, LABEL_SPARK_ROLE_EXECUTOR_VALUE);
     return labels;
   }
 
-  public static Map<String, String> sparkClusterResourceLabels(final SparkCluster master) {
+  public static Map<String, String> sparkClusterResourceLabels(final SparkCluster cluster) {
     Map<String, String> labels = commonManagedResourceLabels();
-    labels.put(Constants.LABEL_SPARK_CLUSTER_NAME, master.getMetadata().getName());
+    labels.put(Constants.LABEL_SPARK_CLUSTER_NAME, cluster.getMetadata().getName());
     return labels;
   }
 
-  public static Map<String, String> clusterLabels(final SparkCluster sparkCluster) {
-    Map<String, String> labels = sparkClusterResourceLabels(sparkCluster);
+  public static Map<String, String> clusterLabels(final SparkCluster cluster) {
+    Map<String, String> labels = sparkClusterResourceLabels(cluster);
     labels.put(Constants.LABEL_SPARK_ROLE_NAME, LABEL_SPARK_ROLE_CLUSTER_VALUE);
     return labels;
   }


### PR DESCRIPTION
### Why are the changes needed?

This PR aims to make `o.a.s.k8s.operator.utils.Utils` argument naming consistent.

### Does this PR introduce _any_ user-facing change?

`Utils` has a mixed style for `SparkApplication` and `SparkCluster` argument. We had better be consistent.
- `SparkApplication` argument:

https://github.com/apache/spark-kubernetes-operator/blob/cdad512990f25dcd1a289627c70e541df5960f62/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java#L89

https://github.com/apache/spark-kubernetes-operator/blob/cdad512990f25dcd1a289627c70e541df5960f62/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java#L99

- `SparkCluster ` argument:

https://github.com/apache/spark-kubernetes-operator/blob/cdad512990f25dcd1a289627c70e541df5960f62/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java#L111

https://github.com/apache/spark-kubernetes-operator/blob/cdad512990f25dcd1a289627c70e541df5960f62/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java#L117

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.