### PR TITLE
[SPARK-49838] Add `spark-version` label to `Spark Cluster` resources

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
@@ -34,6 +34,7 @@ public class Constants {
   public static final String LABEL_SPARK_ROLE_CLUSTER_VALUE = "cluster";
   public static final String LABEL_SPARK_ROLE_MASTER_VALUE = "master";
   public static final String LABEL_SPARK_ROLE_WORKER_VALUE = "worker";
+  public static final String LABEL_SPARK_VERSION_NAME = "spark-version";
   public static final String SENTINEL_RESOURCE_DUMMY_FIELD = "sentinel.dummy.number";
 
   public static final String DRIVER_SPARK_CONTAINER_PROP_KEY =

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/Utils.java
@@ -24,6 +24,7 @@ import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_OPERATOR_NAME;
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_ROLE_CLUSTER_VALUE;
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_ROLE_DRIVER_VALUE;
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_ROLE_EXECUTOR_VALUE;
+import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_VERSION_NAME;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.OPERATOR_APP_NAME;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.OPERATOR_WATCHED_NAMESPACES;
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.SPARK_APP_STATUS_LISTENER_CLASS_NAMES;
@@ -111,6 +112,7 @@ public final class Utils {
   public static Map<String, String> sparkClusterResourceLabels(final SparkCluster cluster) {
     Map<String, String> labels = commonManagedResourceLabels();
     labels.put(Constants.LABEL_SPARK_CLUSTER_NAME, cluster.getMetadata().getName());
+    labels.put(LABEL_SPARK_VERSION_NAME, cluster.getSpec().getRuntimeVersions().getSparkVersion());
     return labels;
   }
 

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkClusterSubmissionWorkerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.spark.k8s.operator.spec.ClusterSpec;
 import org.apache.spark.k8s.operator.spec.ClusterTolerations;
 import org.apache.spark.k8s.operator.spec.MasterSpec;
+import org.apache.spark.k8s.operator.spec.RuntimeVersions;
 import org.apache.spark.k8s.operator.spec.WorkerSpec;
 
 class SparkClusterSubmissionWorkerTest {
@@ -40,6 +41,7 @@ class SparkClusterSubmissionWorkerTest {
   ClusterTolerations clusterTolerations = new ClusterTolerations();
   MasterSpec masterSpec;
   WorkerSpec workerSpec;
+  RuntimeVersions runtimeVersions = new RuntimeVersions();
 
   @BeforeEach
   void setUp() {
@@ -55,6 +57,7 @@ class SparkClusterSubmissionWorkerTest {
     when(clusterSpec.getClusterTolerations()).thenReturn(clusterTolerations);
     when(clusterSpec.getMasterSpec()).thenReturn(masterSpec);
     when(clusterSpec.getWorkerSpec()).thenReturn(workerSpec);
+    when(clusterSpec.getRuntimeVersions()).thenReturn(runtimeVersions);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `spark-version` label to `Spark Cluster` resources like `Spark Application`

### Why are the changes needed?

`spark-version` is an important label to distinguish and search in the production environment. This PR will add `spark-version` to the following resources.
- `Master Service`
- `Master Statefulset`
- `Master Pod`
- `Worker Service`
- `Worker Statefulset`
- `Worker HorizontalPodAutoscaler`
- `Worker Pod`

We can use `spark-version` as a selector like the following.
```
$ kubectl get svc
NAME                          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
cluster-with-hpa-master-svc   ClusterIP   None         <none>        8080/TCP,7077/TCP,6066/TCP   39s
cluster-with-hpa-worker-svc   ClusterIP   None         <none>        8081/TCP                     39s
kubernetes                    ClusterIP   10.96.0.1    <none>        443/TCP                      6d12h

$ kubectl get svc -l spark-version=4.0.0-preview2
NAME                          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
cluster-with-hpa-master-svc   ClusterIP   None         <none>        8080/TCP,7077/TCP,6066/TCP   89s
cluster-with-hpa-worker-svc   ClusterIP   None         <none>        8081/TCP                     89s

$ kubectl get pod -l spark-version=4.0.0-preview2
NAME                        READY   STATUS    RESTARTS   AGE
cluster-with-hpa-master-0   1/1     Running   0          17m
cluster-with-hpa-worker-0   1/1     Running   0          17m
```

### Does this PR introduce _any_ user-facing change?

No, this is not released yet.

### How was this patch tested?

Pass the CIs with the revised test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.