### PR TITLE
[SPARK-49778][FOLLOWUP] Fix `cluster-with-template.yaml` by removing `master` prefix

### DIFF
--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -25,10 +25,10 @@ spec:
       minWorkers: 1
       maxWorkers: 1
   masterSpec:
-    masterStatefulSetMetadata:
+    statefulSetMetadata:
       annotations:
         customAnnotation: "annotation"
-    masterStatefulSetSpec:
+    statefulSetSpec:
       template:
         spec:
           priorityClassName: system-cluster-critical
@@ -52,7 +52,7 @@ spec:
               limits:
                 cpu: "0.1"
                 memory: "10Mi"
-    masterServiceMetadata:
+    serviceMetadata:
       annotations:
         customAnnotation: "svc1"
   workerSpec:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the following to fix `cluster-with-template.yaml` by removing `master` prefix.
- #136 

### Why are the changes needed?

To make it valid.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests.

```
$ kubectl apply -f examples/cluster-with-template.yaml
sparkcluster.spark.apache.org/cluster-with-template created
```

### Was this patch authored or co-authored using generative AI tooling?

No.