### PR TITLE
[SPARK-49887] Update `cluster-with-template.yaml` example with pod annotation

### DIFF
--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -30,6 +30,9 @@ spec:
         customAnnotation: "annotation"
     masterStatefulSetSpec:
       template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           priorityClassName: system-cluster-critical
           securityContext:
@@ -61,6 +64,9 @@ spec:
         customAnnotation: "annotation"
     statefulSetSpec:
       template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
         spec:
           priorityClassName: system-cluster-critical
           securityContext:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `cluster-with-template.yaml` example with pod annotation.

### Why are the changes needed?

For `SparkCluster` CRD, `safe-to-evict` is frequently used. We had better provide it as an example.
```yaml
cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
```

### Does this PR introduce _any_ user-facing change?

No. This is only an example update.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.