### PR TITLE
[SPARK-49888] Use `registry.k8s.io/pause:3.9` to avoid failure deterministically

### DIFF
--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -44,7 +44,7 @@ spec:
                 cpu: "2"
                 memory: "2Gi"
           - name: sidecar
-            image: registry.k8s.io/pause
+            image: registry.k8s.io/pause:3.9
             resources:
               requests:
                 cpu: "0.1"
@@ -75,7 +75,7 @@ spec:
                 cpu: "2"
                 memory: "2Gi"
           - name: sidecar
-            image: registry.k8s.io/pause
+            image: registry.k8s.io/pause:3.9
             resources:
               requests:
                 cpu: "0.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `registry.k8s.io/pause:3.9` to avoid failure deterministically.

### Why are the changes needed?

`pause` image seems to support multi-arch since 3.1. In some K8s clusters, the example fails due to the architecture issues. To avoid architecture failure like the following, we had better specify the version.
```
$ kubectl logs -f cluster-with-template-master-0 -c sidecar
exec /pause: exec format error
```

### Does this PR introduce _any_ user-facing change?

No,

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.