### PR TITLE
[SPARK-50401] Upgrade `kubernetes-client` to 6.13.4 and `log4j` to 2.24.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 [versions]
-fabric8 = "6.13.3"
+fabric8 = "6.13.4"
 lombok = "1.18.32"
 operator-sdk = "4.9.0"
 okhttp = "4.12.0"
 dropwizard-metrics = "4.2.25"
 spark = "4.0.0-preview2"
-log4j = "2.22.1"
+log4j = "2.24.2"
 
 # Test
 junit = "5.10.2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `kubernetes-client` to 6.13.4 and `log4j` to 2.24.2.

### Why are the changes needed?

To catch up Apache Spark updates.
- https://github.com/apache/spark/pull/48268
- https://github.com/apache/spark/pull/48029
- https://github.com/apache/spark/pull/48945

### Does this PR introduce _any_ user-facing change?

No, this is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.