### PR TITLE
[SPARK-50723] Upgrade `kubernetes-client` to 7.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 [versions]
-fabric8 = "6.13.4"
+fabric8 = "7.0.1"
 lombok = "1.18.32"
 operator-sdk = "4.9.0"
 okhttp = "4.12.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `kubernetes-client` to 7.0.1 in line with Apache Spark 4.
- https://github.com/apache/spark/pull/49159

Please note that `spark-kubernetes-operator` still uses `okhttp3` because `KubernetesMetricsInterceptor` depends on `okhttp3` `Interceptor` class. This is the main difference from Apache Spark 4 which migrated from `okhttp3` to `vertex`.

### Why are the changes needed?

To bring the latest K8s client feature by matching with the latest Apache Spark 4 dependency,
- https://github.com/fabric8io/kubernetes-client/releases/tag/v7.0.1
- https://github.com/fabric8io/kubernetes-client/releases/tag/v7.0.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.