### PR TITLE
[SPARK-50725] Update CI to test K8s 1.32

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         kubernetes-version:
           - "1.28.0"
-          - "1.31.0"
+          - "1.32.0"
         mode:
           - dynamic
           - static


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the maximum K8s test version to 1.32 from 1.31.

### Why are the changes needed?

To improve the test coverage because K8s 1.32.0 was released on 2024-12-11.
- https://kubernetes.io/releases/#release-v1-32

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.