### PR TITLE
Update the image tag to main-snapshot

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 image:
-  repository: spark-kubernetes-operator
+  repository: apache/spark-kubernetes-operator
   pullPolicy: IfNotPresent
-  tag: 0.1.0-SNAPSHOT
+  tag: main-snapshot
   # If image digest is set then it takes precedence and the image tag will be ignored
   # digest: ""
 


### PR DESCRIPTION
The image tag 0.1.0-SNAPSHOT does not exist in the apache/spark-kubernetes-operator repository, causing the spark-kubernetes-operator to enter a CrashLoopBackOff state.


### What changes were proposed in this pull request?
Pod was resulting in :
bash-3.2$ kubectl get pods
NAME                                         READY   STATUS             RESTARTS         AGE
spark-kubernetes-operator-778b9bbdc6-ft75q   0/1     CrashLoopBackOff   13 (4m40s ago)   38m



### Why are the changes needed?
The changes are needed because the current image tag 0.1.0-SNAPSHOT doesn't exist in the apache/spark-kubernetes-operator repository. This missing image tag is causing the spark-kubernetes-operator to keep crashing and restarting, which prevents it from working properly. By updating the image tag to a valid version that actually exists, we can fix this issue and make sure the operator runs smoothly.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This was tested by updating the image tag in the spark-kubernetes-operator deployment. After that pod went to running state. 
bash-3.2$ kubectl get pods
NAME                                         READY   STATUS    RESTARTS         AGE
spark-kubernetes-operator-778b9bbdc6-ft75q   1/1     Running   0 (7m34s ago)   40m


### Was this patch authored or co-authored using generative AI tooling?
No
