### PR TITLE
[SPARK-51002] Upgrade the minimum K8s version to v1.30

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - "1.28.0"
+          - "1.30.0"
           - "1.32.0"
         mode:
           - dynamic


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the minimum K8s version to v1.30 in K8s test environment.

### Why are the changes needed?

Like Apache Spark 4.0.0, K8s environments are moving toward K8s v1.30+. We had better focus on the latest K8s versions more.
- https://github.com/apache/spark/pull/48371
- https://github.com/apache/spark/pull/49684

### Does this PR introduce _any_ user-facing change?

Technically, this is a change of test infra.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.