### PR TITLE
[SPARK-51347] Enable Ingress and Service Support for Spark Driver

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/DriverServiceIngressSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/DriverServiceIngressSpec.java
@@ -19,40 +19,23 @@
 
 package org.apache.spark.k8s.operator.spec;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.Required;
-import lombok.AllArgsConstructor;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpec;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ApplicationSpec extends BaseSpec {
-  protected String mainClass;
-  @Required protected RuntimeVersions runtimeVersions;
-  protected String jars;
-  protected String pyFiles;
-  protected String sparkRFiles;
-  protected String files;
-  @Builder.Default protected DeploymentMode deploymentMode = DeploymentMode.ClusterMode;
-  protected String proxyUser;
-  @Builder.Default protected List<String> driverArgs = new ArrayList<>();
+public class DriverServiceIngressSpec {
+  @Required protected ObjectMeta serviceMetadata;
+  @Required protected ServiceSpec serviceSpec;
 
-  @Builder.Default
-  protected ApplicationTolerations applicationTolerations = new ApplicationTolerations();
-
-  protected BaseApplicationTemplateSpec driverSpec;
-  protected BaseApplicationTemplateSpec executorSpec;
-  protected List<DriverServiceIngressSpec> driverServiceIngressList;
+  @Required protected ObjectMeta ingressMetadata;
+  protected IngressSpec ingressSpec;
 }

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -20,6 +20,7 @@
 package org.apache.spark.k8s.operator;
 
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Map;
 
 import scala.Option;
@@ -37,6 +38,7 @@ import org.apache.spark.deploy.k8s.submit.MainAppResource;
 import org.apache.spark.deploy.k8s.submit.PythonMainAppResource;
 import org.apache.spark.deploy.k8s.submit.RMainAppResource;
 import org.apache.spark.k8s.operator.spec.ApplicationSpec;
+import org.apache.spark.k8s.operator.spec.DriverServiceIngressSpec;
 import org.apache.spark.k8s.operator.utils.ModelUtils;
 
 /**
@@ -82,7 +84,7 @@ public class SparkAppSubmissionWorker {
   public SparkAppResourceSpec getResourceSpec(
       SparkApplication app, KubernetesClient client, Map<String, String> confOverrides) {
     SparkAppDriverConf appDriverConf = buildDriverConf(app, confOverrides);
-    return buildResourceSpec(appDriverConf, client);
+    return buildResourceSpec(appDriverConf, app.getSpec().getDriverServiceIngressList(), client);
   }
 
   protected SparkAppDriverConf buildDriverConf(
@@ -127,11 +129,14 @@ public class SparkAppSubmissionWorker {
   }
 
   protected SparkAppResourceSpec buildResourceSpec(
-      SparkAppDriverConf kubernetesDriverConf, KubernetesClient client) {
+      SparkAppDriverConf kubernetesDriverConf,
+      List<DriverServiceIngressSpec> driverServiceIngressList,
+      KubernetesClient client) {
     KubernetesDriverBuilder builder = new KubernetesDriverBuilder();
     KubernetesDriverSpec kubernetesDriverSpec =
         builder.buildFromFeatures(kubernetesDriverConf, client);
-    return new SparkAppResourceSpec(kubernetesDriverConf, kubernetesDriverSpec);
+    return new SparkAppResourceSpec(
+        kubernetesDriverConf, kubernetesDriverSpec, driverServiceIngressList);
   }
 
   /**

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/utils/DriverServiceIngressUtils.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/utils/DriverServiceIngressUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpec;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpecBuilder;
+
+import org.apache.spark.k8s.operator.spec.DriverServiceIngressSpec;
+
+public final class DriverServiceIngressUtils {
+  private DriverServiceIngressUtils() {}
+
+  /** Build the full spec for ingress and service. */
+  public static List<HasMetadata> buildIngressService(
+      DriverServiceIngressSpec spec, ObjectMeta driverPodMetaData) {
+    List<HasMetadata> resources = new ArrayList<>(2);
+    Service service = buildService(spec, driverPodMetaData);
+    resources.add(service);
+    resources.add(buildIngress(spec, service));
+    return resources;
+  }
+
+  private static Service buildService(DriverServiceIngressSpec spec, ObjectMeta driverPodMetaData) {
+    ObjectMeta serviceMeta = new ObjectMetaBuilder(spec.getServiceMetadata()).build();
+    serviceMeta.setNamespace(driverPodMetaData.getNamespace());
+    Map<String, String> selectors = spec.getServiceSpec().getSelector();
+    if (selectors == null || selectors.isEmpty()) {
+      selectors = driverPodMetaData.getLabels();
+    }
+    return new ServiceBuilder()
+        .withMetadata(serviceMeta)
+        .withNewSpecLike(spec.getServiceSpec())
+        .withSelector(selectors)
+        .endSpec()
+        .build();
+  }
+
+  private static Ingress buildIngress(DriverServiceIngressSpec spec, Service service) {
+    ObjectMeta metadata = new ObjectMetaBuilder(spec.getIngressMetadata()).build();
+    IngressSpec ingressSpec = new IngressSpecBuilder(spec.getIngressSpec()).build();
+    if ((ingressSpec.getRules() == null || ingressSpec.getRules().isEmpty())
+        && service.getSpec().getPorts() != null
+        && !service.getSpec().getPorts().isEmpty()) {
+      // if no rule is provided, populate default path with backend to the associated service
+      ingressSpec =
+          new IngressSpecBuilder()
+              .addNewRule()
+              .withNewHttp()
+              .addNewPath()
+              .withPath("/")
+              .withPathType("ImplementationSpecific")
+              .withNewBackend()
+              .withNewService()
+              .withName(service.getMetadata().getName())
+              .withNewPort()
+              .withNumber(service.getSpec().getPorts().get(0).getPort())
+              .endPort()
+              .endService()
+              .endBackend()
+              .endPath()
+              .endHttp()
+              .endRule()
+              .build();
+    }
+    return new IngressBuilder().withMetadata(metadata).withSpec(ingressSpec).build();
+  }
+}

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
@@ -69,7 +69,8 @@ class SparkAppResourceSpecTest {
     when(mockSpec.pod()).thenReturn(sparkPod);
     when(mockSpec.systemProperties()).thenReturn(new HashMap<>());
 
-    SparkAppResourceSpec appResourceSpec = new SparkAppResourceSpec(mockConf, mockSpec);
+    SparkAppResourceSpec appResourceSpec =
+        new SparkAppResourceSpec(mockConf, mockSpec, Collections.emptyList());
 
     Assertions.assertEquals(2, appResourceSpec.getDriverResources().size());
     Assertions.assertEquals(1, appResourceSpec.getDriverPreResources().size());

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/utils/DriverServiceIngressUtilsTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/utils/DriverServiceIngressUtilsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpec;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpecBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.k8s.operator.spec.DriverServiceIngressSpec;
+
+class DriverServiceIngressUtilsTest {
+  @Test
+  void buildIngressService() {
+    ObjectMeta driverMeta =
+        new ObjectMetaBuilder().withName("foo-driver").addToLabels("foo", "bar").build();
+    DriverServiceIngressSpec spec1 = buildSpecWithSinglePortService();
+    List<HasMetadata> resources1 = DriverServiceIngressUtils.buildIngressService(spec1, driverMeta);
+    Assertions.assertEquals(2, resources1.size());
+    Assertions.assertInstanceOf(Service.class, resources1.get(0));
+    Assertions.assertInstanceOf(Ingress.class, resources1.get(1));
+    Service service1 = (Service) resources1.get(0);
+    Assertions.assertEquals(driverMeta.getLabels(), service1.getSpec().getSelector());
+    Ingress ingress1 = (Ingress) resources1.get(1);
+    Assertions.assertEquals(1, ingress1.getSpec().getRules().size());
+    IngressRule ingressRule1 = ingress1.getSpec().getRules().get(0);
+    Assertions.assertEquals(1, ingressRule1.getHttp().getPaths().size());
+    Assertions.assertEquals(
+        service1.getMetadata().getName(),
+        ingressRule1.getHttp().getPaths().get(0).getBackend().getService().getName());
+    Assertions.assertEquals(
+        service1.getSpec().getPorts().get(0).getPort(),
+        ingressRule1.getHttp().getPaths().get(0).getBackend().getService().getPort().getNumber());
+
+    DriverServiceIngressSpec spec2 = buildSpecWithIngressSpec();
+    List<HasMetadata> resources2 = DriverServiceIngressUtils.buildIngressService(spec2, driverMeta);
+    Assertions.assertEquals(2, resources2.size());
+    Assertions.assertInstanceOf(Service.class, resources2.get(0));
+    Assertions.assertInstanceOf(Ingress.class, resources2.get(1));
+    Service service2 = (Service) resources2.get(0);
+    Assertions.assertEquals(driverMeta.getLabels(), service2.getSpec().getSelector());
+    Ingress ingress2 = (Ingress) resources2.get(1);
+    Assertions.assertEquals(spec2.getIngressSpec(), ingress2.getSpec());
+  }
+
+  private DriverServiceIngressSpec buildSpecWithSinglePortService() {
+    ServiceSpec serviceSpec1 =
+        new ServiceSpecBuilder()
+            .addNewPort()
+            .withPort(80)
+            .withProtocol("TCP")
+            .withTargetPort(new IntOrString(4040))
+            .endPort()
+            .withType("LoadBalancer")
+            .build();
+    ObjectMeta serviceMeta1 = new ObjectMetaBuilder().withName("foo-service-1").build();
+    ObjectMeta ingressMeta1 = new ObjectMetaBuilder().withName("foo-ingress-1").build();
+    return DriverServiceIngressSpec.builder()
+        .serviceMetadata(serviceMeta1)
+        .serviceSpec(serviceSpec1)
+        .ingressMetadata(ingressMeta1)
+        .build();
+  }
+
+  private DriverServiceIngressSpec buildSpecWithIngressSpec() {
+    ServiceSpec serviceSpec2 =
+        new ServiceSpecBuilder()
+            .addNewPort()
+            .withPort(19098)
+            .withProtocol("TCP")
+            .withTargetPort(new IntOrString(19098))
+            .endPort()
+            .addNewPort()
+            .withPort(19099)
+            .withProtocol("TCP")
+            .withTargetPort(new IntOrString(19099))
+            .endPort()
+            .withType("ClusterIP")
+            .build();
+    IngressSpec ingressSpec2 =
+        new IngressSpecBuilder()
+            .withIngressClassName("nginx-example")
+            .addNewRule()
+            .withNewHttp()
+            .addNewPath()
+            .withPath("/testpath1")
+            .withPathType("Prefix")
+            .withNewBackend()
+            .withNewService()
+            .withName("foo-service-2")
+            .withNewPort()
+            .withNumber(19098)
+            .endPort()
+            .endService()
+            .endBackend()
+            .endPath()
+            .endHttp()
+            .endRule()
+            .addNewRule()
+            .withNewHttp()
+            .addNewPath()
+            .withPath("/testpath2")
+            .withPathType("Prefix")
+            .withNewBackend()
+            .withNewService()
+            .withName("foo-service-2")
+            .withNewPort()
+            .withNumber(19099)
+            .endPort()
+            .endService()
+            .endBackend()
+            .endPath()
+            .endHttp()
+            .endRule()
+            .build();
+    ObjectMeta serviceMeta2 = new ObjectMetaBuilder().withName("foo-service-2").build();
+    ObjectMeta ingressMeta2 =
+        new ObjectMetaBuilder()
+            .withName("foo-ingress-2")
+            .addToAnnotations("nginx.ingress.kubernetes.io/rewrite-target", "/")
+            .build();
+    return DriverServiceIngressSpec.builder()
+        .serviceMetadata(serviceMeta2)
+        .serviceSpec(serviceSpec2)
+        .ingressMetadata(ingressMeta2)
+        .ingressSpec(ingressSpec2)
+        .build();
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

This PR adds support for launching Ingress and Services with Spark Applications.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There's common ask from user to support exposing driver via ingress and service to serve HTTP / HTTPS from outside the cluster - for example, to access Spark UI.

As we support podTemplateSupport already, this feature can also be handy for those who would like to expose additional service ports in the same pod. Therefore, this PR aims to introduce this feature in a more general way instead of just exposing Spark UI.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No - unreleased version


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

CIs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
