### PR TITLE
[SPARK-51382] Add `submit-spark-connect-server.sh` example

### DIFF
--- a/examples/submit-spark-connect-server.sh
+++ b/examples/submit-spark-connect-server.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+curl -XPOST http://localhost:6066/v1/submissions/create \
+--data '{
+  "appResource": "",
+  "sparkProperties": {
+    "spark.master": "spark://prod-master-svc:7077",
+    "spark.submit.deployMode": "cluster",
+    "spark.app.name": "SparkConnectServer",
+    "spark.driver.cores": "1",
+    "spark.driver.memory": "1g",
+    "spark.executor.cores": "1",
+    "spark.executor.memory": "1g",
+    "spark.cores.max": "2",
+    "spark.ui.reverseProxy": "true"
+  },
+  "clientSparkVersion": "",
+  "mainClass": "org.apache.spark.sql.connect.service.SparkConnectServer",
+  "environmentVariables": { },
+  "action": "CreateSubmissionRequest",
+  "appArgs": [ ]
+}'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `submit-spark-connect-server.sh` example to run `SparkConnectServer` on Spark Standalone Cluster.

Note that there are other ways to launch `SparkConnectServer` and this only aims to focus on `Spark Standalone` case.

### Why are the changes needed?

1. Install Nightly `Spark Kubernetes Operator` and run a Spark cluster.

```
$ helm install spark-kubernetes-operator \
https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz
NAME: spark-kubernetes-operator
LAST DEPLOYED: Mon Mar  3 20:55:41 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1

$ kubectl apply -f prod-cluster-with-three-workers.yaml
sparkcluster.spark.apache.org/prod created
```

2. Setup port-forwarding.
```
$ kubectl port-forward svc/prod-master-svc 6066:6066
```

```
$ kubectl port-forward svc/prod-master-svc 6066:6066
```

3. Submit `SparkConnectServer`.
```
$ ./submit-spark-connect-server.sh
{
  "action" : "CreateSubmissionResponse",
  "message" : "Driver successfully submitted as driver-20250304045839-0000",
  "serverSparkVersion" : "4.0.0-preview2",
  "submissionId" : "driver-20250304045839-0000",
  "success" : true
}%
```

<img width="423" alt="Screenshot 2025-03-03 at 21 07 06" src="https://github.com/user-attachments/assets/e5e1f11b-86c6-4e4b-8cf9-02efc213c622" />

<img width="768" alt="Screenshot 2025-03-03 at 21 05 22" src="https://github.com/user-attachments/assets/013e92d4-a33b-40c0-a20d-d31827e0a18d" />

### Does this PR introduce _any_ user-facing change?

No. This is a newly added example.

### How was this patch tested?

Manually follow the procedure.

### Was this patch authored or co-authored using generative AI tooling?

No.