### PR TITLE
[SPARK-51405][K8S] Upgrade `build-tools` to use Ubuntu 24.04 LTS instead of 22.04 LTS docker image

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM gradle:8.12.1-jdk17-jammy AS builder
+FROM gradle:8.12.1-jdk17-noble AS builder
 WORKDIR /app
 COPY . .
 RUN ./gradlew clean build -x check


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `build-tools` to use `Ubuntu 24.04 LTS` instead of `22.04 LTS` docker image

### Why are the changes needed?

To use the latest LTS at the initial release, `kubernetes-operator-0.1.0`.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a build stage image.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.