### PR TITLE
[SPARK-51406][K8S] Remove no-op `spark.log.structuredLogging.enabled=false`

### DIFF
--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -47,7 +47,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   applicationTolerations:

--- a/examples/pi-java21.yaml
+++ b/examples/pi-java21.yaml
@@ -23,7 +23,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21-scala"
   applicationTolerations:

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -24,7 +24,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
     spark.kubernetes.scheduler.name: "yunikorn"

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -23,7 +23,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala"
   applicationTolerations:

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -23,7 +23,6 @@ spec:
     spark.kubernetes.driver.master: "local[10]"
     spark.kubernetes.driver.request.cores: "5"
     spark.kubernetes.driver.limit.cores: "5"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   runtimeVersions:

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -23,7 +23,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   applicationTolerations:

--- a/examples/pyspark-pi.yaml
+++ b/examples/pyspark-pi.yaml
@@ -22,7 +22,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   applicationTolerations:

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -24,7 +24,6 @@ spec:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
-    spark.log.structuredLogging.enabled: "false"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
   runtimeVersions:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove no-op `spark.log.structuredLogging.enabled=false`.

### Why are the changes needed?

The configuration is disabled by default via the following.
- https://github.com/apache/spark/pull/49421

### Does this PR introduce _any_ user-facing change?

No, this is a kind of simplification by removing no-op extra configurations.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.