### PR TITLE
[SPARK-51410][K8S] Add `Spark Connect Plugin` example

### DIFF
--- a/examples/pi-with-spark-connect-plugin.yaml
+++ b/examples/pi-with-spark-connect-plugin.yaml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: pi-with-spark-connect-plugin
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  driverArgs: ["200000"]
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.plugins: "org.apache.spark.sql.connect.SparkConnectPlugin"
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    scalaVersion: "2.13"
+    sparkVersion: "4.0.0-preview2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Spark Connect Plugin` example by extending the existing `pi.yaml` example.

### Why are the changes needed?

To provide an example how to open `Spark Connect` port from the existing Spark applications.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new example.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.