### PR TITLE
[SPARK-51507] Support creating config map that can be mounted by Spark pods for apps

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ConfigMapSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ConfigMapSpec.java
@@ -19,41 +19,23 @@
 
 package org.apache.spark.k8s.operator.spec;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.Required;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(callSuper = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class ApplicationSpec extends BaseSpec {
-  protected String mainClass;
-  @Required protected RuntimeVersions runtimeVersions;
-  protected String jars;
-  protected String pyFiles;
-  protected String sparkRFiles;
-  protected String files;
-  @Builder.Default protected DeploymentMode deploymentMode = DeploymentMode.ClusterMode;
-  protected String proxyUser;
-  @Builder.Default protected List<String> driverArgs = new ArrayList<>();
-
-  @Builder.Default
-  protected ApplicationTolerations applicationTolerations = new ApplicationTolerations();
-
-  protected BaseApplicationTemplateSpec driverSpec;
-  protected BaseApplicationTemplateSpec executorSpec;
-  protected List<DriverServiceIngressSpec> driverServiceIngressList;
-  protected List<ConfigMapSpec> configMapSpecs;
+public class ConfigMapSpec {
+  @Required protected String name;
+  protected Map<String, String> labels;
+  protected Map<String, String> annotations;
+  protected Map<String, String> data;
 }

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
@@ -43,7 +43,9 @@ import org.apache.spark.deploy.k8s.Constants;
 import org.apache.spark.deploy.k8s.KubernetesDriverSpec;
 import org.apache.spark.deploy.k8s.SparkPod;
 import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils;
+import org.apache.spark.k8s.operator.spec.ConfigMapSpec;
 import org.apache.spark.k8s.operator.spec.DriverServiceIngressSpec;
+import org.apache.spark.k8s.operator.utils.ConfigMapSpecUtils;
 import org.apache.spark.k8s.operator.utils.DriverServiceIngressUtils;
 
 /**
@@ -66,7 +68,8 @@ public class SparkAppResourceSpec {
   public SparkAppResourceSpec(
       SparkAppDriverConf kubernetesDriverConf,
       KubernetesDriverSpec kubernetesDriverSpec,
-      List<DriverServiceIngressSpec> driverServiceIngressList) {
+      List<DriverServiceIngressSpec> driverServiceIngressList,
+      List<ConfigMapSpec> configMapSpecs) {
     this.kubernetesDriverConf = kubernetesDriverConf;
     String namespace = kubernetesDriverConf.sparkConf().get(Config.KUBERNETES_NAMESPACE().key());
     Map<String, String> confFilesMap =
@@ -93,6 +96,7 @@ public class SparkAppResourceSpec {
     this.driverResources.add(
         KubernetesClientUtils.buildConfigMap(
             kubernetesDriverConf.configMapNameDriver(), confFilesMap, new HashMap<>()));
+    this.driverPreResources.addAll(ConfigMapSpecUtils.buildConfigMaps(configMapSpecs));
     this.driverResources.addAll(configureDriverServerIngress(sparkPod, driverServiceIngressList));
     this.driverPreResources.forEach(r -> setNamespaceIfMissing(r, namespace));
     this.driverResources.forEach(r -> setNamespaceIfMissing(r, namespace));

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -38,6 +38,7 @@ import org.apache.spark.deploy.k8s.submit.MainAppResource;
 import org.apache.spark.deploy.k8s.submit.PythonMainAppResource;
 import org.apache.spark.deploy.k8s.submit.RMainAppResource;
 import org.apache.spark.k8s.operator.spec.ApplicationSpec;
+import org.apache.spark.k8s.operator.spec.ConfigMapSpec;
 import org.apache.spark.k8s.operator.spec.DriverServiceIngressSpec;
 import org.apache.spark.k8s.operator.utils.ModelUtils;
 
@@ -84,7 +85,11 @@ public class SparkAppSubmissionWorker {
   public SparkAppResourceSpec getResourceSpec(
       SparkApplication app, KubernetesClient client, Map<String, String> confOverrides) {
     SparkAppDriverConf appDriverConf = buildDriverConf(app, confOverrides);
-    return buildResourceSpec(appDriverConf, app.getSpec().getDriverServiceIngressList(), client);
+    return buildResourceSpec(
+        appDriverConf,
+        app.getSpec().getDriverServiceIngressList(),
+        app.getSpec().getConfigMapSpecs(),
+        client);
   }
 
   protected SparkAppDriverConf buildDriverConf(
@@ -131,12 +136,13 @@ public class SparkAppSubmissionWorker {
   protected SparkAppResourceSpec buildResourceSpec(
       SparkAppDriverConf kubernetesDriverConf,
       List<DriverServiceIngressSpec> driverServiceIngressList,
+      List<ConfigMapSpec> configMapSpecs,
       KubernetesClient client) {
     KubernetesDriverBuilder builder = new KubernetesDriverBuilder();
     KubernetesDriverSpec kubernetesDriverSpec =
         builder.buildFromFeatures(kubernetesDriverConf, client);
     return new SparkAppResourceSpec(
-        kubernetesDriverConf, kubernetesDriverSpec, driverServiceIngressList);
+        kubernetesDriverConf, kubernetesDriverSpec, driverServiceIngressList, configMapSpecs);
   }
 
   /**

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/utils/ConfigMapSpecUtils.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/utils/ConfigMapSpecUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+
+import org.apache.spark.k8s.operator.spec.ConfigMapSpec;
+
+public final class ConfigMapSpecUtils {
+  private ConfigMapSpecUtils() {}
+
+  public static List<ConfigMap> buildConfigMaps(List<ConfigMapSpec> configMapMountList) {
+    if (configMapMountList == null || configMapMountList.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return configMapMountList.stream()
+        .map(
+            c ->
+                new ConfigMapBuilder()
+                    .editOrNewMetadata()
+                    .withName(c.getName())
+                    .withLabels(c.getLabels())
+                    .withAnnotations(c.getAnnotations())
+                    .endMetadata()
+                    .addToData(c.getData())
+                    .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
@@ -70,7 +70,8 @@ class SparkAppResourceSpecTest {
     when(mockSpec.systemProperties()).thenReturn(new HashMap<>());
 
     SparkAppResourceSpec appResourceSpec =
-        new SparkAppResourceSpec(mockConf, mockSpec, Collections.emptyList());
+        new SparkAppResourceSpec(
+            mockConf, mockSpec, Collections.emptyList(), Collections.emptyList());
 
     Assertions.assertEquals(2, appResourceSpec.getDriverResources().size());
     Assertions.assertEquals(1, appResourceSpec.getDriverPreResources().size());

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/utils/ConfigMapSpecUtilsTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/utils/ConfigMapSpecUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.k8s.operator.spec.ConfigMapSpec;
+
+class ConfigMapSpecUtilsTest {
+
+  @Test
+  void buildConfigMaps() {
+
+    assertEquals(Collections.emptyList(), ConfigMapSpecUtils.buildConfigMaps(null));
+    assertEquals(
+        Collections.emptyList(), ConfigMapSpecUtils.buildConfigMaps(Collections.emptyList()));
+
+    Map<String, String> labels = Map.of("foo-label-key", "foo-label-value");
+    Map<String, String> annotations = Map.of("foo-annotation-key", "foo-annotation-value");
+    Map<String, String> configMapData = new HashMap<>();
+    // literal value
+    configMapData.put("foo", "bar");
+    // escaped property file
+    configMapData.put(
+        "conf.properties", "spark.foo.keyOne=\"valueOne\"\nspark.foo.keyTwo=\"valueTwo\"");
+    // escaped yaml file
+    configMapData.put("conf.yaml", "conf:\n  foo: bar\n  nestedField:\n    keyName: value");
+    ConfigMapSpec mount =
+        ConfigMapSpec.builder()
+            .name("test-config-map")
+            .labels(labels)
+            .annotations(annotations)
+            .data(configMapData)
+            .build();
+    List<ConfigMap> configMaps =
+        ConfigMapSpecUtils.buildConfigMaps(Collections.singletonList(mount));
+    assertEquals(1, configMaps.size());
+    ConfigMap configMap = configMaps.get(0);
+    assertEquals("test-config-map", configMap.getMetadata().getName());
+    assertEquals("foo-label-value", configMap.getMetadata().getLabels().get("foo-label-key"));
+    assertEquals(
+        "foo-annotation-value", configMap.getMetadata().getAnnotations().get("foo-annotation-key"));
+    assertEquals(configMapData, configMap.getData());
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

This PR introduces a new field `configMapSpecs`, which enables user to create configmap(s) which can be later mounted on driver and/or executors with values specified in SparkApplications. It also adds corresponding docs and unit tests.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There's a common user demand for the feature to create lightweight values / files override using configmap. This new feature saves the trouble for user to create configmap(s) beforehand - the config map would share the lifecycle of the corresponding Spark app.

User may mount the ConfigMap as needed in driver and executor pod templates - one example is provided in the doc. In future we may further enhance this flow by mounting the created config map automatically to Spark pods. This can be achieved by supporting volume type of ConfigMap in Spark Kubernetes, or by adding mutating webhook & alter pod templates after creation. For now, this PR opens up the possibility of creating config map and mounting them with one single spec.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No - not yet released

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Pass the CIs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No