### PR TITLE
[SPARK-51526] Upgrade Gradle shadow plugin to 8.3.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ spotbugs-plugin = "6.0.17"
 spotless-plugin = "6.25.0"
 
 # Packaging
-shadow-jar-plugin = "8.1.1"
+shadow-jar-plugin = "8.3.6"
 
 [libraries]
 kubernetes-client = { group = "io.fabric8", name = "kubernetes-client", version.ref = "fabric8" }
@@ -67,4 +67,4 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 powermock-core = { group = "org.powermock", name = "powermock-core", version.ref = "powermock"}
 spotbugs-gradle-plugin = { group = "com.github.spotbugs.snom", name = "spotbugs-gradle-plugin", version.ref = "spotbugs-plugin" }
 spotless-plugin-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless-plugin" }
-shadow = { group = "com.github.johnrengelman", name = "shadow", version.ref = "shadow-jar-plugin"}
+shadow = { group = "com.gradleup.shadow", name = "shadow-gradle-plugin", version.ref = "shadow-jar-plugin"}

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.gradleup.shadow'
 
 dependencies {
   implementation project(":spark-operator-api")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Migrate the Gradle plugin given it's changed ownership and upgrade Gradle shadow plugin to 8.3.6

### Why are the changes needed?

https://github.com/GradleUp/shadow/issues/908

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tested the build locally

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
