### PR TITLE
[SPARK-51538] Add `spark-connect-server-with-spark-cluster.yaml` example

### DIFF
--- a/examples/spark-connect-server-with-spark-cluster.yaml
+++ b/examples/spark-connect-server-with-spark-cluster.yaml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-connect-server
+spec:
+  mainClass: "org.apache.spark.sql.connect.service.SparkConnectServer"
+  sparkConf:
+    spark.master: "spark://prod-master-svc:7077"
+    spark.submit.deployMode: "cluster"
+    spark.executor.cores: "1"
+    spark.cores.max: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.ui.reverseProxy: "true"
+  runtimeVersions:
+    sparkVersion: "4.0.0-preview2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add an example to launch `Spark Connect Server` pod which uses the existing `Spark Cluster`.

### Why are the changes needed?

Since `Spark Connect Server` pod is launched outside of `Spark Cluster`, we can expose the service port more easily.

### Does this PR introduce _any_ user-facing change?

No. This is a new example.

### How was this patch tested?

Manual testing.

Launch `Spark K8s Operator`, `Spark Cluster`, and `Spark Connect Server` sequentially.
```
$ helm install spark-kubernetes-operator \
https://nightlies.apache.org/spark/charts/spark-kubernetes-operator-0.1.0-SNAPSHOT.tgz

$ kubectl apply -f examples/prod-cluster-with-three-workers.yaml

$ kubectl apply -f examples/spark-connect-server-with-spark-cluster.yaml
```

After exporting the `Spark Master` and `Spark Connect Server` ports, connect with `pyspark` client.

```
$ bin/pyspark --remote sc://localhost:15002
```

### Was this patch authored or co-authored using generative AI tooling?

No.
