### PR TITLE
[SPARK-51783] Support `ubuntu-24.04-arm` in `build-test` test pipeline

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,9 +28,10 @@ jobs:
           config: .github/.licenserc.yaml
   build-test:
     name: "Build Test CI"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ 'ubuntu-latest', 'ubuntu-24.04-arm' ]
         java-version: [ 17, 21 ]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `ubuntu-24.04-arm` in `build-test` test pipeline

### Why are the changes needed?

`Linux` arm64 architecture becomes public preview as a new GitHub Action runner. We had better utilize this resource in our test infra.
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

### How was this patch tested?

Pass the CIs.

<img width="576" alt="Screenshot 2025-04-12 at 21 11 03" src="https://github.com/user-attachments/assets/bec85656-53f9-4bec-8a4d-b9c83815fb95" />

### Was this patch authored or co-authored using generative AI tooling?

No.