### PR TITLE
[SPARK-51893] Upgrade CI to test K8s 1.33

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         kubernetes-version:
           - "1.30.0"
-          - "1.32.0"
+          - "1.33.0"
         mode:
           - dynamic
           - static


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the maximum K8s test version to 1.33 from 1.32.

### Why are the changes needed?

To improve the test coverage because K8s 1.33.0 was released on 2025-04-23.
- https://kubernetes.io/releases/#release-v1-33

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the CI log.

```
System Info:
...
  Kubelet Version:            v1.33.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.