### PR TITLE
[SPARK-51965] Update `Compatibility` section of `docs/operations.md`

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -19,9 +19,9 @@ under the License.
 
 ### Compatibility
 
-- Java 17 and 21
+- Java 17, 21 and 24
 - Kubernetes version compatibility:
-    + k8s version >= 1.28 is recommended. Operator attempts to be API compatible as possible, but 
+    + k8s version >= 1.30 is recommended. Operator attempts to be API compatible as possible, but
       patch support will not be performed on k8s versions that reached EOL.
 - Spark versions 3.5 or above.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Compatibility` section of `docs/operations.md`.

### Why are the changes needed?

To make it up-to-date with newer Java and K8s versions.
- https://github.com/apache/spark/pull/49684
- https://github.com/apache/spark-kubernetes-operator/pull/178

### Does this PR introduce _any_ user-facing change?

No, this is a doc-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.