### PR TITLE
[SPARK-51978] Upgrade `kubernetes-client` to 7.2.0 for K8s 1.33

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 [versions]
-fabric8 = "7.1.0"
+fabric8 = "7.2.0"
 lombok = "1.18.38"
 operator-sdk = "4.9.0"
 okhttp = "4.12.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `kubernetes-client` to 7.2.0 like Apache Spark.
- https://github.com/apache/spark/pull/50775

### Why are the changes needed?

`v7.2.0` supports `K8s 1.33` officially with the model update and bug fixes.
- https://github.com/fabric8io/kubernetes-client/releases/tag/v7.2.0
    - https://github.com/fabric8io/kubernetes-client/issues/7025
    - https://github.com/fabric8io/kubernetes-client/issues/7037 
 
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.