### PR TITLE
[SPARK-52003] Improve `publish_snapshot_dockerhub` GitHub Action job to support branches

### DIFF
--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main"]'
+        default: '["main", "branch-0.1"]'
 
 jobs:
   publish-snapshot-image:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1"]' ) }}
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -45,4 +45,4 @@ jobs:
         file: build-tools/docker/Dockerfile
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: apache/spark-kubernetes-operator:main-snapshot
+        tags: apache/spark-kubernetes-operator:${{ matrix.branch }}-snapshot


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `publish_snapshot_dockerhub` GitHub Action job to support branches.

### Why are the changes needed?

Previously, the job supports only `main` branch. After this PR, `branch-0.1` is added to the matrix.

However, this PR should land at only `main` branch because GitHub Action supports the schedule job only at `main` branch.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. This should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.