### PR TITLE
[SPARK-52004] Improve `publish_snapshot_chart` GitHub Action job to support branches

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main"]'
+        default: '["main", "branch-0.1"]'
 
 jobs:
   publish-snapshot-chart:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1"]' ) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -36,14 +36,19 @@ jobs:
       run: |
         ./gradlew build spark-operator-api:relocateGeneratedCRD -x check --no-daemon
     - name: Build Chart
+      env:
+        DIR: 'charts'
       run: |
+        if [[ ${{ matrix.branch }} != 'main' ]]; then
+          export DIR=charts-${{ matrix.branch }}
+        fi
         cd build-tools/helm
         sed -i 's/repository: /repository: apache\//' spark-kubernetes-operator/values.yaml
-        sed -i 's/tag: .*$/tag: main-snapshot/' spark-kubernetes-operator/values.yaml
-        mkdir -p tmp/charts
-        helm package spark-kubernetes-operator -d tmp/charts --app-version main-snapshot
-        helm repo index tmp/charts --url https://nightlies.apache.org/spark/charts
-        helm show chart tmp/charts/spark-kubernetes-operator-*.tgz
+        sed -i 's/tag: .*$/tag: ${{ matrix.branch }}-snapshot/' spark-kubernetes-operator/values.yaml
+        mkdir -p tmp/$DIR
+        helm package spark-kubernetes-operator -d tmp/$DIR --app-version ${{ matrix.branch }}-snapshot
+        helm repo index tmp/$DIR --url https://nightlies.apache.org/spark/$DIR
+        helm show chart tmp/$DIR/spark-kubernetes-operator-*.tgz
     - name: Upload
       uses: burnett01/rsync-deployments@5.2
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `publish_snapshot_chart` GitHub Action job to support branches.

### Why are the changes needed?

Previously, the job supports only `main` branch. After this PR, `branch-0.1` is added to the matrix.

However, this PR should land at only `main` branch because GitHub Action supports the schedule job only at `main` branch.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. This should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.