### PR TITLE
[SPARK-52043] Upgrade `DropWizard` to 4.2.30

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ fabric8 = "7.2.0"
 lombok = "1.18.38"
 operator-sdk = "4.9.0"
 okhttp = "4.12.0"
-dropwizard-metrics = "4.2.25"
+dropwizard-metrics = "4.2.30"
 spark = "4.0.1-SNAPSHOT"
 log4j = "2.24.2"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `DropWizard` metrics to 4.2.30.

### Why are the changes needed?

v4.2.25 is outdated over one year because it was released on Jan 24, 2024. We had better use the latest version, v4.2.30.
- [v4.2.30: Jan 14, 2025](https://github.com/dropwizard/metrics/releases/tag/v4.2.30)
- [v4.2.29: Nov 27, 2024](https://github.com/dropwizard/metrics/releases/tag/v4.2.29)
- [v4.2.28: Oct 03, 2024](https://github.com/dropwizard/metrics/releases/tag/v4.2.28)
- [v4.2.27: Aug 18, 2024](https://github.com/dropwizard/metrics/releases/tag/v4.2.27)
- [v4.2.26: Jun 09, 2024](https://github.com/dropwizard/metrics/releases/tag/v4.2.26)

Apache Spark 4.0 upgraded already.
- https://github.com/apache/spark/pull/49537
- https://github.com/apache/spark/pull/48997
- https://github.com/apache/spark/pull/48377
- https://github.com/apache/spark/pull/47799
- https://github.com/apache/spark/pull/46932

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.