### PR TITLE
[SPARK-52044] Upgrade `log4j2` to 2.24.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ operator-sdk = "4.9.0"
 okhttp = "4.12.0"
 dropwizard-metrics = "4.2.25"
 spark = "4.0.1-SNAPSHOT"
-log4j = "2.24.2"
+log4j = "2.24.3"
 
 # Test
 junit = "5.10.2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `log4j2` to 2.24.3.

### Why are the changes needed?

To bring the latest bug fixed version.
- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.24.3

Apache Spark 4.0 upgraded this already.
- https://github.com/apache/spark/pull/49189

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.