### PR TITLE
[SPARK-52045] Upgrade `junit` to 5.12.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ spark = "4.0.1-SNAPSHOT"
 log4j = "2.24.2"
 
 # Test
-junit = "5.10.2"
+junit = "5.12.2"
 jacoco = "0.8.13"
 mockito = "5.17.0"
 powermock = "2.0.9"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `junit` to 5.12.2.

### Why are the changes needed?

To bring the latest version.
- [v5.12.2 (Apr 11, 2025)](https://junit.org/junit5/docs/5.12.2/release-notes/)
- [v5.12.1 (Mar 14, 2025)](https://junit.org/junit5/docs/5.12.1/release-notes/)
- [v5.12.0 (Feb 21, 2025)](https://junit.org/junit5/docs/5.12.0/release-notes/)
- [v5.11.4 (Dec 16, 2024)](https://junit.org/junit5/docs/5.11.4/release-notes/)
- [v5.11.3 (Oct 21, 2024)](https://junit.org/junit5/docs/5.11.3/release-notes/)
- [v5.11.2 (Oct 04, 2024)](https://junit.org/junit5/docs/5.11.2/release-notes/)
- [v5.11.1 (Sep 25, 2024)](https://junit.org/junit5/docs/5.11.1/release-notes/)
- [v5.11.0 (Aug 14, 2024)](https://junit.org/junit5/docs/5.11.0/release-notes/)
- [v5.10.5 (Oct 04, 2024)](https://junit.org/junit5/docs/5.10.5/release-notes/)
- [v5.10.4 (Sep 24, 2024)](https://junit.org/junit5/docs/5.10.4/release-notes/)
- [v5.10.3 (Jun 27, 2024)](https://junit.org/junit5/docs/5.10.3/release-notes/)

Apache Spark upgraded already.
- https://github.com/apache/spark/pull/50724
- https://github.com/apache/spark/pull/49301
- https://github.com/apache/spark/pull/48834
- https://github.com/apache/spark/pull/47560

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.