### PR TITLE
[SPARK-52108] Enable `GitHub Pages`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,8 @@ github:
     merge: false
     squash: true
     rebase: true
+  ghp_branch: gh-pages
+  ghp_path: /
   autolink_jira: SPARK
 
 notifications:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `GitHub Pages` by updating `.asf.yaml`.

### Why are the changes needed?

Currently, this is not enabled by ASF policy.
- https://github.com/apache/spark-kubernetes-operator/actions/runs/15004081583

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.