### PR TITLE
[SPARK-52115] Document `Helm Chart`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Apache Spark K8s Operator
 
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/spark-kubernetes-operator)](https://artifacthub.io/packages/search?repo=spark-kubernetes-operator)
 [![GitHub Actions Build](https://github.com/apache/spark-kubernetes-operator/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/apache/spark-kubernetes-operator/actions/workflows/build_and_test.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Repo Size](https://img.shields.io/github/repo-size/apache/spark-kubernetes-operator)](https://img.shields.io/github/repo-size/apache/spark-kubernetes-operator)
@@ -7,6 +8,18 @@
 Apache Spark™ K8s Operator is a subproject of [Apache Spark](https://spark.apache.org/) and
 aims to extend K8s resource manager to manage Apache Spark applications via
 [Operator Pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
+
+## Install Helm Chart
+
+Apache Spark provides a Helm Chart.
+- <https://apache.github.io/spark-kubernetes-operator/>
+- <https://artifacthub.io/packages/helm/spark-kubernetes-operator/spark-kubernetes-operator/>
+
+```
+$ helm repo add spark-kubernetes-operator https://apache.github.io/spark-kubernetes-operator
+$ helm repo update
+$ helm install spark-kubernetes-operator spark-kubernetes-operator/spark-kubernetes-operator
+```
 
 ## Building Spark K8s Operator
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to document `Helm Chart` by updating `README.md` and providing the following links.

- <https://apache.github.io/spark-kubernetes-operator/>

    <img width="939" alt="Screenshot 2025-05-13 at 15 10 55" src="https://github.com/user-attachments/assets/b8d674ef-11e7-406f-b6f7-ea3fa89b3813" />


- <https://artifacthub.io/packages/helm/spark-kubernetes-operator/spark-kubernetes-operator/>

    <img width="616" alt="Screenshot 2025-05-13 at 15 12 01" src="https://github.com/user-attachments/assets/6f02c026-d15b-471e-9cc7-2ac12ef82654" />

### Why are the changes needed?

To recommend `Helm Chart`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.