### PR TITLE
[SPARK-52133] Set `Helm` chart version to `1.0.0-dev`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/Chart.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/Chart.yaml
@@ -14,8 +14,8 @@
 # limitations under the License.
 apiVersion: v2
 name: spark-kubernetes-operator
-description: A Helm chart for the Apache Spark Kubernetes Operator
+description: The official Helm chart to deploy Apache Spark, an unified engine for large-scale data analytics
 type: application
-version: 0.2.0-SNAPSHOT
+version: 1.0.0-dev
 appVersion: 0.2.0-SNAPSHOT
 icon: https://spark.apache.org/favicon.ico


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to change `Helm Chart` version from `0.2.0-SNAPSHOT` to `1.0.0-dev` and revise the description as a part of official release of this chart `1.0.0`.

### Why are the changes needed?

Like [Apache Airflow example](https://github.com/apache/airflow/blob/2d56d2626c84089f156a56137647498a6ad2ee7a/chart/Chart.yaml#L20-L24), `Helm Chart` version is independently managed from the application versions (which is Apache Spark K8s Operator).

```yaml
apiVersion: v2
name: airflow
version: 1.17.0-dev
appVersion: 3.0.0
description: The official Helm chart to deploy Apache Airflow, a platform to
  programmatically author, schedule, and monitor workflows
```

As a part of the following series of Helm Chart improvement, I believe we are ready to set `1.0.0` for Helm Chart itself at next release, Apache Spark K8s Operator v0.2.0.
- #190 
- #196 
- #191 
- #194 


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.