### PR TITLE
[SPARK-52135] Remove `powermock-core` dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ log4j = "2.24.3"
 junit = "5.12.2"
 jacoco = "0.8.13"
 mockito = "5.17.0"
-powermock = "2.0.9"
 
 # Build Analysis
 checkstyle = "10.17.0"
@@ -64,7 +63,6 @@ mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mo
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit"}
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit"}
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher"}
-powermock-core = { group = "org.powermock", name = "powermock-core", version.ref = "powermock"}
 spotbugs-gradle-plugin = { group = "com.github.spotbugs.snom", name = "spotbugs-gradle-plugin", version.ref = "spotbugs-plugin" }
 spotless-plugin-gradle = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless-plugin" }
 shadow = { group = "com.gradleup.shadow", name = "shadow-gradle-plugin", version.ref = "shadow-jar-plugin"}

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -77,7 +77,6 @@ dependencies {
   testImplementation(libs.mockwebserver)
   testImplementation platform(libs.junit.bom)
   testImplementation(libs.junit.jupiter)
-  testImplementation(libs.powermock.core)
   testRuntimeOnly(libs.junit.platform.launcher)
 
   testImplementation(libs.mockito.core)

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import org.powermock.reflect.Whitebox;
+import org.apache.commons.lang3.reflect.FieldUtils;
 
 import org.apache.spark.k8s.operator.Constants;
 import org.apache.spark.k8s.operator.SparkApplication;
@@ -67,6 +67,10 @@ public final class TestUtils {
   }
 
   public static <T> void setConfigKey(ConfigOption<T> configKey, T newValue) {
-    Whitebox.setInternalState(configKey, "defaultValue", newValue);
+    try {
+      FieldUtils.writeField(configKey, "defaultValue", newValue, true);
+    } catch (IllegalAccessException e) {
+      throw new UnsupportedOperationException(e);
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `powermock-core` dependency.

### Why are the changes needed?

We had better minimize the dependency list by reducing old dependency like `powermock` which was released on 2020-11-01.
- https://github.com/powermock/powermock/releases/tag/powermock-2.0.9

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.