### PR TITLE
[SPARK-52139] Fix Helm chart icon to use PNG file

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/Chart.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/Chart.yaml
@@ -18,4 +18,4 @@ description: The official Helm chart to deploy Apache Spark, an unified engine f
 type: application
 version: 1.0.0-dev
 appVersion: 0.2.0-SNAPSHOT
-icon: https://spark.apache.org/favicon.ico
+icon: https://spark.apache.org/images/spark-logo.png


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Helm` chart icon to use `PNG` file instead of `ico` file.

### Why are the changes needed?

This should be PNG file.

### Does this PR introduce _any_ user-facing change?

https://github.com/apache/airflow/blob/0dad2bb17e3f3e404a6002ed2b08a2f53e0e20b3/chart/Chart.yaml#L29

```yaml
icon: https://airflow.apache.org/images/airflow_dark_bg.png
```

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.