### PR TITLE
[SPARK-52161] Add `home`, `sources`, `maintainers`, `keywords` metadata to `Chart.yaml`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/Chart.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/Chart.yaml
@@ -14,8 +14,19 @@
 # limitations under the License.
 apiVersion: v2
 name: spark-kubernetes-operator
-description: The official Helm chart to deploy Apache Spark, an unified engine for large-scale data analytics
-type: application
 version: 1.0.0-dev
 appVersion: 0.2.0-SNAPSHOT
+description: The official Helm chart to deploy Apache Spark, an unified engine for large-scale data analytics
+type: application
+home: https://apache.github.io/spark-kubernetes-operator/
+sources:
+  - https://github.com/apache/spark-kubernetes-operator/
 icon: https://spark.apache.org/images/spark-logo.png
+keywords:
+  - apache
+  - spark
+  - sparkapp
+  - sparkcluster
+maintainers:
+  - email: dev@spark.apache.org
+    name: Apache Spark PMC


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add the following metadata to `Chart.yaml`.
- `home`
- `sources`
- `maintainers`
- `keywords`

### Why are the changes needed?

To provide a correct metadata to the users of Helm chart.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review by packaging Helm chart and generating index.

```
$ cd build-tools/helm
$ helm package --sign --key YOUR_KEY --keyring YOUR_KEYRING spark-kubernetes-operator
$ helm repo index .
$ cat index.yaml
apiVersion: v1
entries:
  spark-kubernetes-operator:
  - apiVersion: v2
    appVersion: 0.2.0-SNAPSHOT
    created: "2025-05-15T07:28:59.279471-07:00"
    description: The official Helm chart to deploy Apache Spark, an unified engine
      for large-scale data analytics
    digest: 3b90cca4a6921bccd541c5a3f10be319adc19d50a164b368776adf3736061b12
    home: https://apache.github.io/spark-kubernetes-operator/
    icon: https://spark.apache.org/images/spark-logo.png
    keywords:
    - apache
    - spark
    - sparkapp
    - sparkcluster
    maintainers:
    - email: dev@spark.apache.org
      name: Apache Spark PMC
    name: spark-kubernetes-operator
    sources:
    - https://github.com/apache/spark-kubernetes-operator/
    type: application
    urls:
    - spark-kubernetes-operator-1.0.0-dev.tgz
    version: 1.0.0-dev
generated: "2025-05-15T07:28:59.278325-07:00"
```

### Was this patch authored or co-authored using generative AI tooling?

No.