### PR TITLE
[SPARK-52194] Add `spark-connect-server.yaml` example

### DIFF
--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1alpha1
+kind: SparkApplication
+metadata:
+  name: spark-connect-server
+spec:
+  mainClass: "org.apache.spark.sql.connect.service.SparkConnectServer"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.minExecutors: "3"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    scalaVersion: "2.13"
+    sparkVersion: "4.0.0-preview2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `spark-connect-server.yaml` example.

### Why are the changes needed?

To provide an example to launch `Spark Connect Standalone Server`.

### Does this PR introduce _any_ user-facing change?

No. This is a new example.

### How was this patch tested?

Manual test.

```
$ helm install spark spark/spark-kubernetes-operator
$ kubectl apply -f examples/spark-connect-server.yaml
$ kubectl get sparkapp
NAME                   CURRENT STATE    AGE
spark-connect-server   RunningHealthy   3m1s

$ kubectl logs spark-connect-server-0-driver | tail -n1
{"ts":"2025-05-16T20:42:03.114Z","level":"INFO","msg":"Spark Connect server started at: 0:0:0:0:0:0:0:0%0:15002","context":{"host":"0:0:0:0:0:0:0:0%0","port":"15002"},"logger":"SparkConnectServer"}
```

After port-forwarding `4040`, visit the pod's driver website `Connect` tab.

<img width="739" alt="Screenshot 2025-05-16 at 13 46 09" src="https://github.com/user-attachments/assets/4537779b-03e3-4577-abc7-019739a2f84c" />

### Was this patch authored or co-authored using generative AI tooling?

No.