### PR TITLE
[SPARK-52199] Remove `Spark 3.4.3` bindings in `spark-versions` E2E test

### DIFF
--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -41,15 +41,6 @@ spec:
         value: 'apache/spark:3.5.5-scala2.12-java17-ubuntu'
   - bindings:
       - name: "SPARK_VERSION"
-        value: "3.4.3"
-      - name: "SCALA_VERSION"
-        value: "2.12"
-      - name: "JAVA_VERSION"
-        value: "11"
-      - name: "IMAGE"
-        value: 'apache/spark:3.4.3-scala2.12-java11-ubuntu'
-  - bindings:
-      - name: "SPARK_VERSION"
         value: "4.0.0-preview2"
       - name: "SCALA_VERSION"
         value: "2.13"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Spark 3.4.3` bindings in `spark-versions` E2E test.

### Why are the changes needed?

This is a leftover from the initial contribution. Since Apache Spark 3.4.x reached EOL, we had better remove this.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.