### PR TITLE
[MINOR] Remove broken URL link from `StatusRecorder` javadoc

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
@@ -40,13 +40,6 @@ import org.apache.spark.k8s.operator.listeners.BaseStatusListener;
 import org.apache.spark.k8s.operator.status.BaseStatus;
 
 /**
- *
- *
- * <pre>
- * Note - this is inspired by
- * <a href="https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/AppStatusRecorder.java">Flink Operator Status Recorder</a>
- * </pre>
- *
  * Enables additional (extendable) observers for Spark App status. Cache and version locking might
  * be removed in future version as batch app does not expect spec change after submitted.
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove a broken URL link from `StatusRecorder` java doc.

### Why are the changes needed?

This is a clean-up in Javadoc.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.