### PR TITLE
[SPARK-52200] Make `StatusRecorder.objectMapper` static

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
@@ -56,7 +56,7 @@ public class StatusRecorder<
     CR extends BaseResource<?, ?, ?, ?, STATUS>,
     LISTENER extends BaseStatusListener<STATUS, CR>> {
   protected final List<LISTENER> statusListeners;
-  protected final ObjectMapper objectMapper = ModelUtils.objectMapper;
+  protected static final ObjectMapper objectMapper = ModelUtils.objectMapper;
   protected final Class<STATUS> statusClass;
   protected final Class<CR> resourceClass;
   protected final ConcurrentHashMap<ResourceID, ObjectNode> statusCache;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to change `StatusRecorder.objectMapper` into a static variable to be clear.

### Why are the changes needed?

According to the usage pattern, this is already defined as `static final` from `ModelUtils` and `StatusRecorder` also uses in that pattern. We can declare as a `static` variable to be clear.

https://github.com/apache/spark-kubernetes-operator/blob/9256112d5f18bb3107b7d036715d92bb4393f828/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/utils/ModelUtils.java#L43

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.