### PR TITLE
[SPARK-52208] Add `branch-0.2` to `publish_snapshot_*.yml` GitHub Action jobs

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main", "branch-0.1"]'
+        default: '["main", "branch-0.1", "branch-0.2"]'
 
 jobs:
   publish-snapshot-chart:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1", "branch-0.2"]' ) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main", "branch-0.1"]'
+        default: '["main", "branch-0.1", "branch-0.2"]'
 
 jobs:
   publish-snapshot-image:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1", "branch-0.2"]' ) }}
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `branch-0.2` to `publish_snapshot_*.yml` GitHub Action jobs.

### Why are the changes needed?

The GitHub Action jobs should support newly created `branch-0.2`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be checked after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.