### PR TITLE
[SPARK-52209] Fix `operatorContainer.env` type

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.schema.json
+++ b/build-tools/helm/spark-kubernetes-operator/values.schema.json
@@ -136,7 +136,7 @@
                   "description": "JVM arguments for operator"
                 },
                 "env": {
-                  "type": "array",
+                  "type": ["null", "array"],
                   "description": "Environment variables",
                   "items": {
                     "type": "object",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `operatorDeployment.operatorPod.operatorContainer.env` type to allow `null`.

### Why are the changes needed?

To provide a correct value schema.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.