### PR TITLE
[MINOR] Simplify `helm install` instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ ./gradlew buildDockerImage
 ```bash
 $ ./gradlew spark-operator-api:relocateGeneratedCRD
 
-$ helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
+$ helm install spark -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
 ```
 
 ## Run Spark Pi App


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify `helm install` instruction.
- Use `spark` instead of `spark-kubernetes-operator` as NAME.
- Remove `--create-namespace`

### Why are the changes needed?

To make it as simple as possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No