### PR TITLE
[SPARK-52273] Use Apache Spark `4.0.0` docker image instead of `4.0.0-preview2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ ./examples/submit-pi-to-prod.sh
 {
   "action" : "CreateSubmissionResponse",
   "message" : "Driver successfully submitted as driver-20240821181327-0000",
-  "serverSparkVersion" : "4.0.0-preview2",
+  "serverSparkVersion" : "4.0.0",
   "submissionId" : "driver-20240821181327-0000",
   "success" : true
 }
@@ -84,7 +84,7 @@ $ curl http://localhost:6066/v1/submissions/status/driver-20240821181327-0000/
 {
   "action" : "SubmissionStatusResponse",
   "driverState" : "FINISHED",
-  "serverSparkVersion" : "4.0.0-preview2",
+  "serverSparkVersion" : "4.0.0",
   "submissionId" : "driver-20240821181327-0000",
   "success" : true,
   "workerHostPort" : "10.1.5.188:42099",
@@ -122,7 +122,7 @@ Events:
   Normal  Scheduled          14s   yunikorn  Successfully assigned default/pi-on-yunikorn-0-driver to node docker-desktop
   Normal  PodBindSuccessful  14s   yunikorn  Pod default/pi-on-yunikorn-0-driver is successfully bound to node docker-desktop
   Normal  TaskCompleted      6s    yunikorn  Task default/pi-on-yunikorn-0-driver is completed
-  Normal  Pulled             13s   kubelet   Container image "apache/spark:4.0.0-preview2" already present on machine
+  Normal  Pulled             13s   kubelet   Container image "apache/spark:4.0.0" already present on machine
   Normal  Created            13s   kubelet   Created container spark-kubernetes-driver
   Normal  Started            13s   kubelet   Started container spark-kubernetes-driver
 

--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -173,7 +173,7 @@ metadata:
     {{- template "spark-operator.workloadAnnotations" $ }}
 spec:
   runtimeVersions:
-    sparkVersion: 4.0.0-preview2
+    sparkVersion: 4.0.0
     scalaVersion: "2.13"
 {{- end }}
 ---

--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -48,12 +48,12 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
 ```
 
 After application is submitted, Operator will add status information to your application based on

--- a/examples/cluster-java21.yaml
+++ b/examples/cluster-java21.yaml
@@ -18,14 +18,14 @@ metadata:
   name: cluster-java21
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3
       minWorkers: 3
       maxWorkers: 3
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-java21"
     spark.master.ui.title: "Prod Spark Cluster (Java 21)"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -18,14 +18,14 @@ metadata:
   name: cluster-on-yunikorn
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.kubernetes.scheduler.name: "yunikorn"
     spark.master.ui.title: "Spark Cluster on YuniKorn Scheduler"
     spark.master.rest.enabled: "true"

--- a/examples/cluster-with-hpa-template.yaml
+++ b/examples/cluster-with-hpa-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-hpa-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
@@ -58,7 +58,7 @@ spec:
             value: 1
             periodSeconds: 1200
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-java21"
     spark.master.ui.title: "Cluster with HorizontalPodAutoscaler Template"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/cluster-with-hpa.yaml
+++ b/examples/cluster-with-hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-hpa
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3
@@ -38,7 +38,7 @@ spec:
                 cpu: "3"
                 memory: "3Gi"
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-java21"
     spark.master.ui.title: "Cluster with HorizontalPodAutoscaler"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
@@ -93,7 +93,7 @@ spec:
       annotations:
         customAnnotation: "annotation"
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.master.ui.title: "Spark Cluster with Template"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/pi-java21.yaml
+++ b/examples/pi-java21.yaml
@@ -24,9 +24,9 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-java21-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -25,7 +25,7 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.kubernetes.scheduler.name: "yunikorn"
     spark.kubernetes.driver.label.queue: "root.default"
     spark.kubernetes.executor.label.queue: "root.default"
@@ -35,4 +35,4 @@ spec:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -24,9 +24,9 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -24,6 +24,6 @@ spec:
     spark.kubernetes.driver.request.cores: "5"
     spark.kubernetes.driver.limit.cores: "5"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/pi-with-spark-connect-plugin.yaml
+++ b/examples/pi-with-spark-connect-plugin.yaml
@@ -26,9 +26,9 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -24,9 +24,9 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -18,14 +18,14 @@ metadata:
   name: prod
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3
       minWorkers: 3
       maxWorkers: 3
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.master.ui.title: "Prod Spark Cluster"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/pyspark-pi.yaml
+++ b/examples/pyspark-pi.yaml
@@ -23,8 +23,8 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -18,14 +18,14 @@ metadata:
   name: qa
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.master.ui.title: "QA Spark Cluster"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/examples/spark-connect-server-with-spark-cluster.yaml
+++ b/examples/spark-connect-server-with-spark-cluster.yaml
@@ -24,7 +24,7 @@ spec:
     spark.executor.cores: "1"
     spark.cores.max: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.ui.reverseProxy: "true"
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -24,9 +24,9 @@ spec:
     spark.dynamicAllocation.minExecutors: "3"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
     scalaVersion: "2.13"
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -25,6 +25,6 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -59,7 +59,7 @@ public class SparkClusterResourceSpec {
     String clusterName = cluster.getMetadata().getName();
     String scheduler = conf.get(Config.KUBERNETES_SCHEDULER_NAME().key(), "default-scheduler");
     String namespace = conf.get(Config.KUBERNETES_NAMESPACE().key(), clusterNamespace);
-    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.0.0-preview2");
+    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.0.0");
     ClusterSpec spec = cluster.getSpec();
     String version = spec.getRuntimeVersions().getSparkVersion();
     StringBuilder options = new StringBuilder();

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -23,13 +23,13 @@ spec:
   scenarios:
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.0.0-preview2"
+        value: "4.0.0"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: "apache/spark:4.0.0-preview2-scala2.13-java17-ubuntu"
+        value: "apache/spark:4.0.0-scala2.13-java17-ubuntu"
   - bindings:
       - name: "SPARK_VERSION"
         value: "3.5.5"
@@ -41,13 +41,13 @@ spec:
         value: 'apache/spark:3.5.5-scala2.12-java17-ubuntu'
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.0.0-preview2"
+        value: "4.0.0"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "21"
       - name: "IMAGE"
-        value: 'apache/spark:4.0.0-preview2-java21-scala'
+        value: 'apache/spark:4.0.0-java21-scala'
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
@@ -19,14 +19,14 @@ metadata:
   namespace: default
 spec:
   runtimeVersions:
-    sparkVersion: "4.0.0-preview2"
+    sparkVersion: "4.0.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1
       minWorkers: 1
       maxWorkers: 1
   sparkConf:
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
     spark.master.ui.title: "Spark Cluster E2E Test"
     spark.master.rest.enabled: "true"
     spark.master.rest.host: "0.0.0.0"

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -25,8 +25,8 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.executor.instances: "1"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala2.13-java17-ubuntu"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-scala2.13-java17-ubuntu"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: 4.0.0-preview2
+    sparkVersion: 4.0.0
     scalaVersion: "2.13"

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -25,10 +25,10 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.executor.instances: "1"
-    spark.kubernetes.container.image: "apache/spark:4.0.0-preview2-scala2.13-java17-ubuntu"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-scala2.13-java17-ubuntu"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.driver.request.cores: "0.5"
     spark.kubernetes.executor.request.cores: "0.5"
   runtimeVersions:
-    sparkVersion: 4.0.0-preview2
+    sparkVersion: 4.0.0
     scalaVersion: "2.13"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Spark `4.0.0` docker image instead of `4.0.0-preview2`.

### Why are the changes needed?

To use the latest Apache Spark.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.