### PR TITLE
[SPARK-52297] Add `Swift`-based `SparkPi` K8s `Job` example

### DIFF
--- a/examples/job/pi-swift.yaml
+++ b/examples/job/pi-swift.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: spark-connect-swift-pi
+spec:
+  template:
+    spec:
+      containers:
+      - name: job
+        image: dongjoon/spark-connect-swift:pi
+        env:
+        - name: SPARK_REMOTE
+          value: 'sc://spark-connect-server-0-driver-svc:15002'
+      restartPolicy: Never


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add [Swift-based SparkPi](https://github.com/apache/spark-connect-swift/tree/main/Examples/pi) K8s [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) example.

### Why are the changes needed?

To provide a working example with
- [Apache Spark 4.0.0 Connect Server](https://spark.apache.org/docs/4.0.0/) launched by [Apache Spark Kubernetes Operator 0.2.0](https://artifacthub.io/packages/helm/spark-kubernetes-operator/spark-kubernetes-operator) Helm chart.
- [SparkPi Swift App](https://github.com/apache/spark-connect-swift/tree/main/Examples/pi) developed with [Apache Spark Connect for Swift 0.2.0](https://swiftpackageindex.com/apache/spark-connect-swift) library.
- [Swift 6.1](https://www.swift.org) language

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new example.

### How was this patch tested?

Manual tests.

```bash
# Install Spark K8s Operator
$ helm install spark spark/spark-kubernetes-operator

# Launch Spark 4.0 Connect Server
$ kubectl apply -f examples/spark-connect-server.yaml

# Launch `Swift-based SparkPi` Application
$ kubectl  apply -f examples/job/pi-swift.yaml

# Check the log
$ kubectl logs -f job/spark-connect-swift-pi
Pi is roughly 3.142923142923143
```

### Was this patch authored or co-authored using generative AI tooling?

No.