### PR TITLE
[SPARK-52304] Add `pi-with-driver-timeout` example

### DIFF
--- a/examples/pi-with-driver-timeout.yaml
+++ b/examples/pi-with-driver-timeout.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1beta1
+kind: SparkApplication
+metadata:
+  name: pi-with-driver-timeout
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  driverArgs: ["200000"]
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.driver.timeout: "1min"  # Pod status will be 'Error'
+    spark.plugins: "org.apache.spark.deploy.DriverTimeoutPlugin"
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    scalaVersion: "2.13"
+    sparkVersion: "4.0.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi-with-driver-timeout` example.

### Why are the changes needed?

`spark.driver.timeout` with `DriverTimeoutPlugin` is a new feature of Apache Spark 4.0.0 in order to guarantee the maximum run time of the jobs in the best effort approach.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test the example (timeout: 1minutes)

```
$ kubectl apply -f examples/pi-with-driver-timeout.yaml

$ kubectl get sparkapp
NAME                     CURRENT STATE                       AGE
pi-with-driver-timeout   TerminatedWithoutReleaseResources   2m59s
```

### Was this patch authored or co-authored using generative AI tooling?

No.