### PR TITLE
[SPARK-52328] Use `apache/spark-connect-swift:pi` image

### DIFF
--- a/examples/job/pi-swift.yaml
+++ b/examples/job/pi-swift.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: job
-        image: dongjoon/spark-connect-swift:pi
+        image: apache/spark-connect-swift:pi
         env:
         - name: SPARK_REMOTE
           value: 'sc://spark-connect-server-0-driver-svc:15002'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the official `apache/spark-connect-swift:pi` image.

### Why are the changes needed?

ASF Infra team created `apache/spark-connect-swift` repo finally. We need to use the official one.

### Does this PR introduce _any_ user-facing change?

No behavior change of K8s operator because this is an example.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.