### PR TITLE
[SPARK-52464] Update `.asf.yaml` with new `README.md` link

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+# https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
 ---
 github:
   description: "Apache Spark Kubernetes Operator"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `.asf.yaml` with new `README.md` link.

### Why are the changes needed?

ASF Infra team archived the old page in favor of GitHub README.md.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.