### PR TITLE
[SPARK-52471] Add `Swift`-based `SparkPi` K8s `CronJob` example

### DIFF
--- a/examples/job/cron-pi-swift.yaml
+++ b/examples/job/cron-pi-swift.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: spark-connect-swift-pi
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: job
+            image: apache/spark-connect-swift:pi
+            env:
+            - name: SPARK_REMOTE
+              value: 'sc://spark-connect-server-0-driver-svc:15002'
+          restartPolicy: Never


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add [Swift-based SparkPi](https://github.com/apache/spark-connect-swift/tree/main/Examples/pi) K8s [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) example.

### Why are the changes needed?

To provide a working example with
- [Apache Spark 4.0.0 Connect Server](https://spark.apache.org/docs/4.0.0/) launched by [Apache Spark Kubernetes Operator 0.3.0](https://artifacthub.io/packages/helm/spark-kubernetes-operator/spark-kubernetes-operator) Helm chart.
- [SparkPi Swift App](https://github.com/apache/spark-connect-swift/tree/main/Examples/pi) developed with [Apache Spark Connect for Swift 0.3.0](https://swiftpackageindex.com/apache/spark-connect-swift) library.
- [Swift 6.1](https://www.swift.org) language

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new example.

### How was this patch tested?

Manual tests.

```bash
# Install Spark K8s Operator
$ helm install spark spark/spark-kubernetes-operator

# Launch Spark 4.0 Connect Server
$ kubectl apply -f examples/spark-connect-server.yaml

# Launch `Swift-based SparkPi` Application
$ kubectl  apply -f examples/job/cron-pi-swift.yaml

$ kubectl get cronjob
NAME                     SCHEDULE    TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
spark-connect-swift-pi   * * * * *   <none>     False     1        2s              7m51s

$ kubectl get pod -l job-name
NAME                                    READY   STATUS      RESTARTS   AGE
spark-connect-swift-pi-29163859-mkh5p   0/1     Completed   0          2m31s
spark-connect-swift-pi-29163860-btc66   0/1     Completed   0          91s
spark-connect-swift-pi-29163861-68mmt   0/1     Completed   0          31s
```

### Was this patch authored or co-authored using generative AI tooling?

No.