### PR TITLE
[SPARK-52474] Limit GHA job execution time to up to 20 minutes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,7 @@ jobs:
   license-check:
     name: "License Check"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
   build-test:
     name: "Build Test CI"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +51,7 @@ jobs:
   build-image:
     name: "Build Operator Image CI"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -65,6 +68,7 @@ jobs:
   k8s-integration-tests:
     name: "K8s Integration Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +148,7 @@ jobs:
   lint:
     name: "Linter and documentation"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to limit GHA job execution time to up to 20 minutes.

### Why are the changes needed?

According to the GitHub Action log on `main` branch, most CI finishes in 10 minutes. So, we can use `20` minutes as a job execution limit. This will stop abnormal executions. In those cases, we had better restart quickly.
- https://github.com/apache/spark-kubernetes-operator/actions/workflows/build_and_test.yml?query=branch%3Amain

### Does this PR introduce _any_ user-facing change?

No, this is a infra-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.