### PR TITLE
[SPARK-52478] Use GCS `Maven Central` mirror as the primary repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,6 @@ subprojects {
       url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
     }
     mavenCentral()
-    maven {
-      url = "https://repository.apache.org/content/repositories/snapshots/"
-    }
   }
 
   apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,12 @@ subprojects {
   }
 
   repositories {
+    // Google Mirror of Maven Central, placed first so that it's used instead of flaky Maven Central.
+    // See https://storage-download.googleapis.com/maven-central/index.html
+    maven {
+      name = "GCS Maven Central mirror"
+      url = uri("https://maven-central.storage-download.googleapis.com/maven2/")
+    }
     mavenCentral()
     maven {
       url = "https://repository.apache.org/content/repositories/snapshots/"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use GCS `Maven Central` mirror as the primary repository.

### Why are the changes needed?

Since Apache Spark 3.0.0, Apache Spark community has been taking advantage of GCS `Maven Central` to stabilize and speed up CIs. We need to follow this practice in Apache Spark K8s Operator repository.
- apache/spark#26793

In addition, this PR cleaned up the following which is a leftover of Apache Spark 4.0.0-SNAPSHOT usage before the official 4.0.0 release.

https://github.com/apache/spark-kubernetes-operator/blob/9705573c9beebc0607104ae288c3e443d7494fd4/build.gradle#L58-L60

### Does this PR introduce _any_ user-facing change?

No behavior change. This is a build-only dev-side change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.