### PR TITLE
[SPARK-52480] Remove `scalaVersion` from Spark 4+ examples

### DIFF
--- a/examples/pi-java21.yaml
+++ b/examples/pi-java21.yaml
@@ -28,5 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -34,5 +34,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -28,5 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/pi-v1alpha1.yaml
+++ b/examples/pi-v1alpha1.yaml
@@ -28,5 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/pi-with-driver-timeout.yaml
+++ b/examples/pi-with-driver-timeout.yaml
@@ -31,5 +31,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/pi-with-spark-connect-plugin.yaml
+++ b/examples/pi-with-spark-connect-plugin.yaml
@@ -30,5 +30,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -28,5 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"

--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -28,5 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    scalaVersion: "2.13"
     sparkVersion: "4.0.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `scalaVersion` from Spark 4+ examples.

### Why are the changes needed?

Since Apache Spark 4.0.0, we only provide a single Scala version which is 2.13.

### Does this PR introduce _any_ user-facing change?

No behavior change because these are examples.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.