### PR TITLE
[SPARK-52086] Upgrade `operator-sdk` to 5.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.3.1"
 lombok = "1.18.38"
-operator-sdk = "5.1.0"
+operator-sdk = "5.1.1"
 okhttp = "4.12.0"
 dropwizard-metrics = "4.2.30"
 spark = "4.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.3.1"
 lombok = "1.18.38"
-operator-sdk = "4.9.0"
+operator-sdk = "5.1.0"
 okhttp = "4.12.0"
 dropwizard-metrics = "4.2.30"
 spark = "4.0.0"

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -23,6 +23,7 @@ import static org.apache.spark.k8s.operator.utils.Utils.getAppStatusListener;
 import static org.apache.spark.k8s.operator.utils.Utils.getClusterStatusListener;
 import static org.apache.spark.k8s.operator.utils.Utils.getWatchedNamespaces;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -168,8 +169,8 @@ public class SparkOperator {
     overrider.withKubernetesClient(client);
     overrider.withStopOnInformerErrorDuringStartup(
         SparkOperatorConf.TERMINATE_ON_INFORMER_FAILURE_ENABLED.getValue());
-    overrider.withTerminationTimeoutSeconds(
-        SparkOperatorConf.RECONCILER_TERMINATION_TIMEOUT_SECONDS.getValue());
+    overrider.withReconciliationTerminationTimeout(
+        Duration.ofSeconds(SparkOperatorConf.RECONCILER_TERMINATION_TIMEOUT_SECONDS.getValue()));
     int parallelism = SparkOperatorConf.RECONCILER_PARALLELISM.getValue();
     if (parallelism > 0) {
       log.info("Configuring operator with {} reconciliation threads.", parallelism);

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -188,6 +188,7 @@ public class SparkOperator {
       overrider.withMetrics(operatorJosdkMetrics);
       metricsSystem.registerSource(operatorJosdkMetrics);
     }
+    overrider.withUseSSAToPatchPrimaryResource(false);
   }
 
   protected void overrideConfigMonitorConfigs(ConfigurationServiceOverrider overrider) {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -199,6 +199,7 @@ public class SparkOperator {
     overrider.withInformerStoppedHandler(
         (informer, ex) ->
             log.error("Dynamic config informer stopped: operator will not accept config updates."));
+    overrider.withUseSSAToPatchPrimaryResource(false);
   }
 
   protected void overrideControllerConfigs(ControllerConfigurationOverrider<?> overrider) {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
@@ -36,7 +36,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.RuntimeInfo;
-import io.javaoperatorsdk.operator.api.config.ResourceConfiguration;
 import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
 import io.javaoperatorsdk.operator.health.InformerWrappingEventSourceHealthIndicator;
 import io.javaoperatorsdk.operator.health.Status;
@@ -190,16 +189,6 @@ class HealthProbeTest {
                   }
                 }));
 
-    return new InformerWrappingEventSourceHealthIndicator() {
-      @Override
-      public Map<String, InformerHealthIndicator> informerHealthIndicators() {
-        return informers;
-      }
-
-      @Override
-      public ResourceConfiguration getInformerConfiguration() {
-        return null;
-      }
-    };
+    return () -> informers;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change Java Operator SDK version to v5.1

The intention is to keep the functionality the same as the previous version; 

- https://mvnrepository.com/artifact/io.javaoperatorsdk/java-operator-sdk/5.1.1

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Standard CI should test it.

### Was this patch authored or co-authored using generative AI tooling?

No
