### PR TITLE
[SPARK-52526] Add `Spark Thrift Server` example

### DIFF
--- a/examples/spark-thrift-server.yaml
+++ b/examples/spark-thrift-server.yaml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1beta1
+kind: SparkApplication
+metadata:
+  name: spark-thrift-server
+spec:
+  mainClass: "org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.minExecutors: "3"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-java21-scala"
+  runtimeVersions:
+    sparkVersion: "4.0.0"
+  applicationTolerations:
+    restartConfig:
+      restartPolicy: Always
+      maxRestartAttempts: 9223372036854775807


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Spark Thrift Server` example.

### Why are the changes needed?

To enrich the use case example.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests.

```
$ kubectl apply -f examples/spark-thrift-server.yaml
sparkapplication.spark.apache.org/spark-thrift-server created

$ kubectl get sparkapp
NAME                  CURRENT STATE    AGE
spark-thrift-server   RunningHealthy   26s

$ kubectl port-forward spark-thrift-server-0-driver 10000:10000
```

```
$ bin/beeline -u jdbc:hive2://localhost:10000/
Connecting to jdbc:hive2://localhost:10000/
Connected to: Spark SQL (version 4.0.0)
Driver: Hive JDBC (version 2.3.10)
Transaction isolation: TRANSACTION_REPEATABLE_READ
Beeline version 2.3.10 by Apache Hive
0: jdbc:hive2://localhost:10000/> show databases;
+------------+
| namespace  |
+------------+
| default    |
+------------+
1 row selected (0.363 seconds)
0: jdbc:hive2://localhost:10000/> show tables;
+------------+------------+--------------+
| namespace  | tableName  | isTemporary  |
+------------+------------+--------------+
+------------+------------+--------------+
No rows selected (0.087 seconds)
0: jdbc:hive2://localhost:10000/> Closing: 0: jdbc:hive2://localhost:10000/
```

### Was this patch authored or co-authored using generative AI tooling?

No.