### PR TITLE
[SPARK-52555] Enforce `UnusedLocalVariable` rule

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -26,7 +26,6 @@
     <exclude name="ImplicitFunctionalInterface" />
     <exclude name="UnitTestAssertionsShouldIncludeMessage" />
     <exclude name="UnitTestContainsTooManyAsserts" />
-    <exclude name="UnusedLocalVariable" />
     <exclude name="LooseCoupling" />
   </rule>
   <rule ref="category/java/codestyle.xml">

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/SparkOperatorTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/SparkOperatorTest.java
@@ -142,6 +142,7 @@ class SparkOperatorTest {
     }
   }
 
+  @SuppressWarnings("PMD.UnusedLocalVariable")
   @Test
   void testUpdateWatchedNamespacesWithDynamicConfigEnabled() {
     MetricsSystem mockMetricsSystem = mock(MetricsSystem.class);

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconcilerTest.java
@@ -85,6 +85,7 @@ class SparkAppReconcilerTest {
         .appendNewStateAndPersist(any(SparkAppContext.class), any(ApplicationState.class));
   }
 
+  @SuppressWarnings("PMD.UnusedLocalVariable")
   @Test
   void testCleanupRunningApp() {
     try (MockedConstruction<SparkAppContext> mockAppContext =

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
@@ -49,6 +49,7 @@ import org.apache.spark.k8s.operator.status.ApplicationAttemptSummary;
 import org.apache.spark.k8s.operator.status.ApplicationStatus;
 import org.apache.spark.k8s.operator.status.AttemptInfo;
 
+@SuppressWarnings("PMD.UnusedLocalVariable")
 class SparkAppSubmissionWorkerTest {
   @Test
   void buildDriverConfShouldApplySpecAndPropertiesOverride() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enforce `UnusedLocalVariable` rule.

### Why are the changes needed?

To keep the code quality rule.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.