### PR TITLE
[SPARK-52558] Lower `SparkOperatorConfManager` log level to WARN for `FileNotFoundException`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
@@ -20,6 +20,7 @@
 package org.apache.spark.k8s.operator.config;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
@@ -94,6 +95,8 @@ public class SparkOperatorConfManager {
     Properties properties = new Properties();
     try (InputStream inputStream = new FileInputStream(filePath)) {
       properties.load(inputStream);
+    } catch (FileNotFoundException e) {
+      log.warn("File Not Found: {}", filePath);
     } catch (IOException e) {
       log.error("Failed to load properties from {}.", filePath, e);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to lower `SparkOperatorConfManager` log level from `ERROR` to `WARN` for `FileNotFoundException` because the current logic works without any issues. In this case, `WARN` level is more proper than `ERROR` level log.

### Why are the changes needed?

To provide a proper log level for the logs.

### Does this PR introduce _any_ user-facing change?

Yes, but only log level change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.