### PR TITLE
[SPARK-52559] Synchronize `SparkOperatorConfManager.getValue`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
@@ -60,8 +60,10 @@ public class SparkOperatorConfManager {
   }
 
   public String getValue(String key) {
-    String currentValue = configOverrides.getProperty(key);
-    return StringUtils.isEmpty(currentValue) ? getInitialValue(key) : currentValue;
+    synchronized (this) {
+      String currentValue = configOverrides.getProperty(key);
+      return StringUtils.isEmpty(currentValue) ? getInitialValue(key) : currentValue;
+    }
   }
 
   public String getInitialValue(String key) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a concurrency issue by synchronizing `SparkOperatorConfManager.getValue`.

### Why are the changes needed?

`configOverrides` is supposed by being protected by `this` at `refresh` method. 

https://github.com/apache/spark-kubernetes-operator/blob/35214b00c777c724d9cd40208601839824811346/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java#L71-L76

However, currently `getValue` can access an empty value while `refresh` invokes `this.configOverrides = new Properties();` statement because `getValue` method is not synchronized properly.

https://github.com/apache/spark-kubernetes-operator/blob/35214b00c777c724d9cd40208601839824811346/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java#L62-L65

### Does this PR introduce _any_ user-facing change?

Yes, this is a bug fix.

### How was this patch tested?

Manual review. (It's a little difficult to add a concurrency failure test case).

### Was this patch authored or co-authored using generative AI tooling?

No.