### PR TITLE
[SPARK-52606] Promote Spark CRDs to `v1`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/README.md
+++ b/build-tools/helm/spark-kubernetes-operator/README.md
@@ -40,6 +40,6 @@ cluster using the [Helm](https://helm.sh) package manager. With this, you can la
 
 - Support Apache Spark 3.5+
 - Support `SparkApp` and `SparkCluster` CRDs
-  - `sparkapplications.spark.apache.org` (v1beta1)
-  - `sparkclusters.spark.apache.org` (v1beta1)
+  - `sparkapplications.spark.apache.org` (v1)
+  - `sparkclusters.spark.apache.org` (v1)
 - Support HPA for SparkCluster

--- a/build-tools/helm/spark-kubernetes-operator/crds/sparkapplications.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/crds/sparkapplications.spark.apache.org-v1.yaml
@@ -17371,6 +17371,8683 @@ spec:
               type: object
           type: object
       served: true
+      storage: false
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.currentState.currentStateSummary
+          name: Current State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                applicationTolerations:
+                  properties:
+                    applicationTimeoutConfig:
+                      properties:
+                        driverReadyTimeoutMillis:
+                          type: integer
+                        driverStartTimeoutMillis:
+                          type: integer
+                        executorStartTimeoutMillis:
+                          type: integer
+                        forceTerminationGracePeriodMillis:
+                          type: integer
+                        terminationRequeuePeriodMillis:
+                          type: integer
+                      type: object
+                    instanceConfig:
+                      properties:
+                        initExecutors:
+                          type: integer
+                        maxExecutors:
+                          type: integer
+                        minExecutors:
+                          type: integer
+                      type: object
+                    resourceRetainPolicy:
+                      enum:
+                        - Always
+                        - Never
+                        - OnFailure
+                      type: string
+                    restartConfig:
+                      properties:
+                        maxRestartAttempts:
+                          type: integer
+                        restartBackoffMillis:
+                          type: integer
+                        restartPolicy:
+                          enum:
+                            - Always
+                            - Never
+                            - OnFailure
+                            - OnInfrastructureFailure
+                          type: string
+                      type: object
+                  type: object
+                configMapSpecs:
+                  items:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      data:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                deploymentMode:
+                  enum:
+                    - ClientMode
+                    - ClusterMode
+                  type: string
+                driverArgs:
+                  items:
+                    type: string
+                  type: array
+                driverServiceIngressList:
+                  items:
+                    properties:
+                      ingressMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          creationTimestamp:
+                            type: string
+                          deletionGracePeriodSeconds:
+                            type: integer
+                          deletionTimestamp:
+                            type: string
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          generateName:
+                            type: string
+                          generation:
+                            type: integer
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          managedFields:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldsType:
+                                  type: string
+                                fieldsV1:
+                                  type: object
+                                manager:
+                                  type: string
+                                operation:
+                                  type: string
+                                subresource:
+                                  type: string
+                                time:
+                                  type: string
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          ownerReferences:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                blockOwnerDeletion:
+                                  type: boolean
+                                controller:
+                                  type: boolean
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                uid:
+                                  type: string
+                              type: object
+                            type: array
+                          resourceVersion:
+                            type: string
+                          selfLink:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      ingressSpec:
+                        properties:
+                          defaultBackend:
+                            properties:
+                              resource:
+                                properties:
+                                  apiGroup:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              service:
+                                properties:
+                                  name:
+                                    type: string
+                                  port:
+                                    properties:
+                                      name:
+                                        type: string
+                                      number:
+                                        type: integer
+                                    type: object
+                                type: object
+                            type: object
+                          ingressClassName:
+                            type: string
+                          rules:
+                            items:
+                              properties:
+                                host:
+                                  type: string
+                                http:
+                                  properties:
+                                    paths:
+                                      items:
+                                        properties:
+                                          backend:
+                                            properties:
+                                              resource:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              service:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  port:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      number:
+                                                        type: integer
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          path:
+                                            type: string
+                                          pathType:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          tls:
+                            items:
+                              properties:
+                                hosts:
+                                  items:
+                                    type: string
+                                  type: array
+                                secretName:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      serviceMetadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          creationTimestamp:
+                            type: string
+                          deletionGracePeriodSeconds:
+                            type: integer
+                          deletionTimestamp:
+                            type: string
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          generateName:
+                            type: string
+                          generation:
+                            type: integer
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          managedFields:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldsType:
+                                  type: string
+                                fieldsV1:
+                                  type: object
+                                manager:
+                                  type: string
+                                operation:
+                                  type: string
+                                subresource:
+                                  type: string
+                                time:
+                                  type: string
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          ownerReferences:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                blockOwnerDeletion:
+                                  type: boolean
+                                controller:
+                                  type: boolean
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                uid:
+                                  type: string
+                              type: object
+                            type: array
+                          resourceVersion:
+                            type: string
+                          selfLink:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      serviceSpec:
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            type: boolean
+                          clusterIP:
+                            type: string
+                          clusterIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            type: integer
+                          internalTrafficPolicy:
+                            type: string
+                          ipFamilies:
+                            items:
+                              type: string
+                            type: array
+                          ipFamilyPolicy:
+                            type: string
+                          loadBalancerClass:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  type: integer
+                                port:
+                                  type: integer
+                                protocol:
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type: array
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    type: integer
+                                type: object
+                            type: object
+                          trafficDistribution:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                    required:
+                      - ingressMetadata
+                      - serviceMetadata
+                      - serviceSpec
+                    type: object
+                  type: array
+                driverSpec:
+                  properties:
+                    podTemplateSpec:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            creationTimestamp:
+                              type: string
+                            deletionGracePeriodSeconds:
+                              type: integer
+                            deletionTimestamp:
+                              type: string
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            generateName:
+                              type: string
+                            generation:
+                              type: integer
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            managedFields:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldsType:
+                                    type: string
+                                  fieldsV1:
+                                    type: object
+                                  manager:
+                                    type: string
+                                  operation:
+                                    type: string
+                                  subresource:
+                                    type: string
+                                  time:
+                                    type: string
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            ownerReferences:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  blockOwnerDeletion:
+                                    type: boolean
+                                  controller:
+                                    type: boolean
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  uid:
+                                    type: string
+                                type: object
+                              type: array
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                            uid:
+                              type: string
+                          type: object
+                        spec:
+                          properties:
+                            activeDeadlineSeconds:
+                              type: integer
+                            affinity:
+                              properties:
+                                nodeAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          preference:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      properties:
+                                        nodeSelectorTerms:
+                                          items:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          weight:
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          weight:
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              type: boolean
+                            containers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      stopSignal:
+                                        type: string
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                type: object
+                              type: array
+                            dnsConfig:
+                              properties:
+                                nameservers:
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              type: string
+                            enableServiceLinks:
+                              type: boolean
+                            ephemeralContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      stopSignal:
+                                        type: string
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  targetContainerName:
+                                    type: string
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                type: object
+                              type: array
+                            hostAliases:
+                              items:
+                                properties:
+                                  hostnames:
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              type: boolean
+                            hostNetwork:
+                              type: boolean
+                            hostPID:
+                              type: boolean
+                            hostUsers:
+                              type: boolean
+                            hostname:
+                              type: string
+                            imagePullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            initContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      stopSignal:
+                                        type: string
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                type: object
+                              type: array
+                            nodeName:
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            os:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            preemptionPolicy:
+                              type: string
+                            priority:
+                              type: integer
+                            priorityClassName:
+                              type: string
+                            readinessGates:
+                              items:
+                                properties:
+                                  conditionType:
+                                    type: string
+                                type: object
+                              type: array
+                            resourceClaims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  resourceClaimName:
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    type: object
+                                  type: array
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              type: string
+                            runtimeClassName:
+                              type: string
+                            schedulerName:
+                              type: string
+                            schedulingGates:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            securityContext:
+                              properties:
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                fsGroup:
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  type: string
+                                runAsGroup:
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  type: integer
+                                seLinuxChangePolicy:
+                                  type: string
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                supplementalGroups:
+                                  items:
+                                    type: integer
+                                  type: array
+                                supplementalGroupsPolicy:
+                                  type: string
+                                sysctls:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              type: string
+                            serviceAccountName:
+                              type: string
+                            setHostnameAsFQDN:
+                              type: boolean
+                            shareProcessNamespace:
+                              type: boolean
+                            subdomain:
+                              type: string
+                            terminationGracePeriodSeconds:
+                              type: integer
+                            tolerations:
+                              items:
+                                properties:
+                                  effect:
+                                    type: string
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  tolerationSeconds:
+                                    type: integer
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                  maxSkew:
+                                    type: integer
+                                  minDomains:
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
+                                  topologyKey:
+                                    type: string
+                                  whenUnsatisfiable:
+                                    type: string
+                                type: object
+                              type: array
+                            volumes:
+                              items:
+                                properties:
+                                  awsElasticBlockStore:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      partition:
+                                        type: integer
+                                      readOnly:
+                                        type: boolean
+                                      volumeID:
+                                        type: string
+                                    type: object
+                                  azureDisk:
+                                    properties:
+                                      cachingMode:
+                                        type: string
+                                      diskName:
+                                        type: string
+                                      diskURI:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  azureFile:
+                                    properties:
+                                      readOnly:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                      shareName:
+                                        type: string
+                                    type: object
+                                  cephfs:
+                                    properties:
+                                      monitors:
+                                        items:
+                                          type: string
+                                        type: array
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretFile:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      user:
+                                        type: string
+                                    type: object
+                                  cinder:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      volumeID:
+                                        type: string
+                                    type: object
+                                  configMap:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  csi:
+                                    properties:
+                                      driver:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      nodePublishSecretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      readOnly:
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  downwardAPI:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        type: array
+                                    type: object
+                                  emptyDir:
+                                    properties:
+                                      medium:
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    properties:
+                                      volumeClaimTemplate:
+                                        properties:
+                                          metadata:
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              creationTimestamp:
+                                                type: string
+                                              deletionGracePeriodSeconds:
+                                                type: integer
+                                              deletionTimestamp:
+                                                type: string
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              generateName:
+                                                type: string
+                                              generation:
+                                                type: integer
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              managedFields:
+                                                items:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldsType:
+                                                      type: string
+                                                    fieldsV1:
+                                                      type: object
+                                                    manager:
+                                                      type: string
+                                                    operation:
+                                                      type: string
+                                                    subresource:
+                                                      type: string
+                                                    time:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              ownerReferences:
+                                                items:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    blockOwnerDeletion:
+                                                      type: boolean
+                                                    controller:
+                                                      type: boolean
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    uid:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              resourceVersion:
+                                                type: string
+                                              selfLink:
+                                                type: string
+                                              uid:
+                                                type: string
+                                            type: object
+                                          spec:
+                                            properties:
+                                              accessModes:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              dataSourceRef:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              storageClassName:
+                                                type: string
+                                              volumeAttributesClassName:
+                                                type: string
+                                              volumeMode:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  fc:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      lun:
+                                        type: integer
+                                      readOnly:
+                                        type: boolean
+                                      targetWWNs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      wwids:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  flexVolume:
+                                    properties:
+                                      driver:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  flocker:
+                                    properties:
+                                      datasetName:
+                                        type: string
+                                      datasetUUID:
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      partition:
+                                        type: integer
+                                      pdName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  gitRepo:
+                                    properties:
+                                      directory:
+                                        type: string
+                                      repository:
+                                        type: string
+                                      revision:
+                                        type: string
+                                    type: object
+                                  glusterfs:
+                                    properties:
+                                      endpoints:
+                                        type: string
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  hostPath:
+                                    properties:
+                                      path:
+                                        type: string
+                                      type:
+                                        type: string
+                                    type: object
+                                  image:
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    type: object
+                                  iscsi:
+                                    properties:
+                                      chapAuthDiscovery:
+                                        type: boolean
+                                      chapAuthSession:
+                                        type: boolean
+                                      fsType:
+                                        type: string
+                                      initiatorName:
+                                        type: string
+                                      iqn:
+                                        type: string
+                                      iscsiInterface:
+                                        type: string
+                                      lun:
+                                        type: integer
+                                      portals:
+                                        items:
+                                          type: string
+                                        type: array
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      targetPortal:
+                                        type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  nfs:
+                                    properties:
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      server:
+                                        type: string
+                                    type: object
+                                  persistentVolumeClaim:
+                                    properties:
+                                      claimName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  photonPersistentDisk:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      pdID:
+                                        type: string
+                                    type: object
+                                  portworxVolume:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      volumeID:
+                                        type: string
+                                    type: object
+                                  projected:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      sources:
+                                        items:
+                                          properties:
+                                            clusterTrustBundle:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                signerName:
+                                                  type: string
+                                              type: object
+                                            configMap:
+                                              properties:
+                                                items:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            downwardAPI:
+                                              properties:
+                                                items:
+                                                  items:
+                                                    properties:
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        type: object
+                                                      mode:
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            type: string
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            secret:
+                                              properties:
+                                                items:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            serviceAccountToken:
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        type: array
+                                    type: object
+                                  quobyte:
+                                    properties:
+                                      group:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      registry:
+                                        type: string
+                                      tenant:
+                                        type: string
+                                      user:
+                                        type: string
+                                      volume:
+                                        type: string
+                                    type: object
+                                  rbd:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      image:
+                                        type: string
+                                      keyring:
+                                        type: string
+                                      monitors:
+                                        items:
+                                          type: string
+                                        type: array
+                                      pool:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      user:
+                                        type: string
+                                    type: object
+                                  scaleIO:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      gateway:
+                                        type: string
+                                      protectionDomain:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      sslEnabled:
+                                        type: boolean
+                                      storageMode:
+                                        type: string
+                                      storagePool:
+                                        type: string
+                                      system:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                  secret:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      optional:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      volumeName:
+                                        type: string
+                                      volumeNamespace:
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      storagePolicyID:
+                                        type: string
+                                      storagePolicyName:
+                                        type: string
+                                      volumePath:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                executorSpec:
+                  properties:
+                    podTemplateSpec:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            creationTimestamp:
+                              type: string
+                            deletionGracePeriodSeconds:
+                              type: integer
+                            deletionTimestamp:
+                              type: string
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            generateName:
+                              type: string
+                            generation:
+                              type: integer
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            managedFields:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldsType:
+                                    type: string
+                                  fieldsV1:
+                                    type: object
+                                  manager:
+                                    type: string
+                                  operation:
+                                    type: string
+                                  subresource:
+                                    type: string
+                                  time:
+                                    type: string
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            ownerReferences:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  blockOwnerDeletion:
+                                    type: boolean
+                                  controller:
+                                    type: boolean
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  uid:
+                                    type: string
+                                type: object
+                              type: array
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                            uid:
+                              type: string
+                          type: object
+                        spec:
+                          properties:
+                            activeDeadlineSeconds:
+                              type: integer
+                            affinity:
+                              properties:
+                                nodeAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          preference:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      properties:
+                                        nodeSelectorTerms:
+                                          items:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          weight:
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          podAffinityTerm:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          weight:
+                                            type: integer
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          mismatchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                          namespaceSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              type: boolean
+                            containers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      stopSignal:
+                                        type: string
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                type: object
+                              type: array
+                            dnsConfig:
+                              properties:
+                                nameservers:
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              type: string
+                            enableServiceLinks:
+                              type: boolean
+                            ephemeralContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      stopSignal:
+                                        type: string
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  targetContainerName:
+                                    type: string
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                type: object
+                              type: array
+                            hostAliases:
+                              items:
+                                properties:
+                                  hostnames:
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              type: boolean
+                            hostNetwork:
+                              type: boolean
+                            hostPID:
+                              type: boolean
+                            hostUsers:
+                              type: boolean
+                            hostname:
+                              type: string
+                            imagePullSecrets:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            initContainers:
+                              items:
+                                properties:
+                                  args:
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    items:
+                                      properties:
+                                        configMapRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    type: string
+                                  imagePullPolicy:
+                                    type: string
+                                  lifecycle:
+                                    properties:
+                                      postStart:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          sleep:
+                                            properties:
+                                              seconds:
+                                                type: integer
+                                            type: object
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      stopSignal:
+                                        type: string
+                                    type: object
+                                  livenessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  name:
+                                    type: string
+                                  ports:
+                                    items:
+                                      properties:
+                                        containerPort:
+                                          type: integer
+                                        hostIP:
+                                          type: string
+                                        hostPort:
+                                          type: integer
+                                        name:
+                                          type: string
+                                        protocol:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    items:
+                                      properties:
+                                        resourceName:
+                                          type: string
+                                        restartPolicy:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        type: boolean
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      capabilities:
+                                        properties:
+                                          add:
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        type: boolean
+                                      procMount:
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        type: boolean
+                                      runAsGroup:
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        type: integer
+                                      grpc:
+                                        properties:
+                                          port:
+                                            type: integer
+                                          service:
+                                            type: string
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        type: object
+                                      initialDelaySeconds:
+                                        type: integer
+                                      periodSeconds:
+                                        type: integer
+                                      successThreshold:
+                                        type: integer
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                      timeoutSeconds:
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    type: boolean
+                                  stdinOnce:
+                                    type: boolean
+                                  terminationMessagePath:
+                                    type: string
+                                  terminationMessagePolicy:
+                                    type: string
+                                  tty:
+                                    type: boolean
+                                  volumeDevices:
+                                    items:
+                                      properties:
+                                        devicePath:
+                                          type: string
+                                        name:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    type: string
+                                type: object
+                              type: array
+                            nodeName:
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            os:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            preemptionPolicy:
+                              type: string
+                            priority:
+                              type: integer
+                            priorityClassName:
+                              type: string
+                            readinessGates:
+                              items:
+                                properties:
+                                  conditionType:
+                                    type: string
+                                type: object
+                              type: array
+                            resourceClaims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  resourceClaimName:
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              properties:
+                                claims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      request:
+                                        type: string
+                                    type: object
+                                  type: array
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              type: string
+                            runtimeClassName:
+                              type: string
+                            schedulerName:
+                              type: string
+                            schedulingGates:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                            securityContext:
+                              properties:
+                                appArmorProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                fsGroup:
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  type: string
+                                runAsGroup:
+                                  type: integer
+                                runAsNonRoot:
+                                  type: boolean
+                                runAsUser:
+                                  type: integer
+                                seLinuxChangePolicy:
+                                  type: string
+                                seLinuxOptions:
+                                  properties:
+                                    level:
+                                      type: string
+                                    role:
+                                      type: string
+                                    type:
+                                      type: string
+                                    user:
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  properties:
+                                    localhostProfile:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                supplementalGroups:
+                                  items:
+                                    type: integer
+                                  type: array
+                                supplementalGroupsPolicy:
+                                  type: string
+                                sysctls:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      type: string
+                                    hostProcess:
+                                      type: boolean
+                                    runAsUserName:
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              type: string
+                            serviceAccountName:
+                              type: string
+                            setHostnameAsFQDN:
+                              type: boolean
+                            shareProcessNamespace:
+                              type: boolean
+                            subdomain:
+                              type: string
+                            terminationGracePeriodSeconds:
+                              type: integer
+                            tolerations:
+                              items:
+                                properties:
+                                  effect:
+                                    type: string
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  tolerationSeconds:
+                                    type: integer
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  matchLabelKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                  maxSkew:
+                                    type: integer
+                                  minDomains:
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    type: string
+                                  topologyKey:
+                                    type: string
+                                  whenUnsatisfiable:
+                                    type: string
+                                type: object
+                              type: array
+                            volumes:
+                              items:
+                                properties:
+                                  awsElasticBlockStore:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      partition:
+                                        type: integer
+                                      readOnly:
+                                        type: boolean
+                                      volumeID:
+                                        type: string
+                                    type: object
+                                  azureDisk:
+                                    properties:
+                                      cachingMode:
+                                        type: string
+                                      diskName:
+                                        type: string
+                                      diskURI:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  azureFile:
+                                    properties:
+                                      readOnly:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                      shareName:
+                                        type: string
+                                    type: object
+                                  cephfs:
+                                    properties:
+                                      monitors:
+                                        items:
+                                          type: string
+                                        type: array
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretFile:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      user:
+                                        type: string
+                                    type: object
+                                  cinder:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      volumeID:
+                                        type: string
+                                    type: object
+                                  configMap:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  csi:
+                                    properties:
+                                      driver:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      nodePublishSecretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      readOnly:
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  downwardAPI:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              type: object
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        type: array
+                                    type: object
+                                  emptyDir:
+                                    properties:
+                                      medium:
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    properties:
+                                      volumeClaimTemplate:
+                                        properties:
+                                          metadata:
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              creationTimestamp:
+                                                type: string
+                                              deletionGracePeriodSeconds:
+                                                type: integer
+                                              deletionTimestamp:
+                                                type: string
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              generateName:
+                                                type: string
+                                              generation:
+                                                type: integer
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              managedFields:
+                                                items:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldsType:
+                                                      type: string
+                                                    fieldsV1:
+                                                      type: object
+                                                    manager:
+                                                      type: string
+                                                    operation:
+                                                      type: string
+                                                    subresource:
+                                                      type: string
+                                                    time:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              ownerReferences:
+                                                items:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    blockOwnerDeletion:
+                                                      type: boolean
+                                                    controller:
+                                                      type: boolean
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    uid:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              resourceVersion:
+                                                type: string
+                                              selfLink:
+                                                type: string
+                                              uid:
+                                                type: string
+                                            type: object
+                                          spec:
+                                            properties:
+                                              accessModes:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              dataSourceRef:
+                                                properties:
+                                                  apiGroup:
+                                                    type: string
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                type: object
+                                              resources:
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              storageClassName:
+                                                type: string
+                                              volumeAttributesClassName:
+                                                type: string
+                                              volumeMode:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  fc:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      lun:
+                                        type: integer
+                                      readOnly:
+                                        type: boolean
+                                      targetWWNs:
+                                        items:
+                                          type: string
+                                        type: array
+                                      wwids:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  flexVolume:
+                                    properties:
+                                      driver:
+                                        type: string
+                                      fsType:
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  flocker:
+                                    properties:
+                                      datasetName:
+                                        type: string
+                                      datasetUUID:
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      partition:
+                                        type: integer
+                                      pdName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  gitRepo:
+                                    properties:
+                                      directory:
+                                        type: string
+                                      repository:
+                                        type: string
+                                      revision:
+                                        type: string
+                                    type: object
+                                  glusterfs:
+                                    properties:
+                                      endpoints:
+                                        type: string
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  hostPath:
+                                    properties:
+                                      path:
+                                        type: string
+                                      type:
+                                        type: string
+                                    type: object
+                                  image:
+                                    properties:
+                                      pullPolicy:
+                                        type: string
+                                      reference:
+                                        type: string
+                                    type: object
+                                  iscsi:
+                                    properties:
+                                      chapAuthDiscovery:
+                                        type: boolean
+                                      chapAuthSession:
+                                        type: boolean
+                                      fsType:
+                                        type: string
+                                      initiatorName:
+                                        type: string
+                                      iqn:
+                                        type: string
+                                      iscsiInterface:
+                                        type: string
+                                      lun:
+                                        type: integer
+                                      portals:
+                                        items:
+                                          type: string
+                                        type: array
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      targetPortal:
+                                        type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  nfs:
+                                    properties:
+                                      path:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      server:
+                                        type: string
+                                    type: object
+                                  persistentVolumeClaim:
+                                    properties:
+                                      claimName:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                    type: object
+                                  photonPersistentDisk:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      pdID:
+                                        type: string
+                                    type: object
+                                  portworxVolume:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      volumeID:
+                                        type: string
+                                    type: object
+                                  projected:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      sources:
+                                        items:
+                                          properties:
+                                            clusterTrustBundle:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                signerName:
+                                                  type: string
+                                              type: object
+                                            configMap:
+                                              properties:
+                                                items:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            downwardAPI:
+                                              properties:
+                                                items:
+                                                  items:
+                                                    properties:
+                                                      fieldRef:
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                        type: object
+                                                      mode:
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            type: string
+                                                        type: object
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            secret:
+                                              properties:
+                                                items:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            serviceAccountToken:
+                                              properties:
+                                                audience:
+                                                  type: string
+                                                expirationSeconds:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        type: array
+                                    type: object
+                                  quobyte:
+                                    properties:
+                                      group:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      registry:
+                                        type: string
+                                      tenant:
+                                        type: string
+                                      user:
+                                        type: string
+                                      volume:
+                                        type: string
+                                    type: object
+                                  rbd:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      image:
+                                        type: string
+                                      keyring:
+                                        type: string
+                                      monitors:
+                                        items:
+                                          type: string
+                                        type: array
+                                      pool:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      user:
+                                        type: string
+                                    type: object
+                                  scaleIO:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      gateway:
+                                        type: string
+                                      protectionDomain:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      sslEnabled:
+                                        type: boolean
+                                      storageMode:
+                                        type: string
+                                      storagePool:
+                                        type: string
+                                      system:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                  secret:
+                                    properties:
+                                      defaultMode:
+                                        type: integer
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              type: integer
+                                            path:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      optional:
+                                        type: boolean
+                                      secretName:
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                        type: object
+                                      volumeName:
+                                        type: string
+                                      volumeNamespace:
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    properties:
+                                      fsType:
+                                        type: string
+                                      storagePolicyID:
+                                        type: string
+                                      storagePolicyName:
+                                        type: string
+                                      volumePath:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                files:
+                  type: string
+                jars:
+                  type: string
+                mainClass:
+                  type: string
+                proxyUser:
+                  type: string
+                pyFiles:
+                  type: string
+                runtimeVersions:
+                  properties:
+                    jdkVersion:
+                      type: string
+                    scalaVersion:
+                      type: string
+                    sparkVersion:
+                      type: string
+                  required:
+                    - sparkVersion
+                  type: object
+                sparkConf:
+                  additionalProperties:
+                    type: string
+                  type: object
+                sparkRFiles:
+                  type: string
+              required:
+                - runtimeVersions
+              type: object
+            status:
+              properties:
+                currentAttemptSummary:
+                  properties:
+                    attemptInfo:
+                      properties:
+                        id:
+                          type: integer
+                      type: object
+                    stateTransitionHistory:
+                      additionalProperties:
+                        properties:
+                          currentStateSummary:
+                            enum:
+                              - DriverEvicted
+                              - DriverReady
+                              - DriverReadyTimedOut
+                              - DriverRequested
+                              - DriverStartTimedOut
+                              - DriverStarted
+                              - ExecutorsStartTimedOut
+                              - Failed
+                              - InitializedBelowThresholdExecutors
+                              - ResourceReleased
+                              - RunningHealthy
+                              - RunningWithBelowThresholdExecutors
+                              - ScheduledToRestart
+                              - SchedulingFailure
+                              - Submitted
+                              - Succeeded
+                              - TerminatedWithoutReleaseResources
+                            type: string
+                          lastObservedDriverStatus:
+                            properties:
+                              conditions:
+                                items:
+                                  properties:
+                                    lastProbeTime:
+                                      type: string
+                                    lastTransitionTime:
+                                      type: string
+                                    message:
+                                      type: string
+                                    observedGeneration:
+                                      type: integer
+                                    reason:
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                type: array
+                              containerStatuses:
+                                items:
+                                  properties:
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    allocatedResourcesStatus:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resources:
+                                            items:
+                                              properties:
+                                                health:
+                                                  type: string
+                                                resourceID:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    containerID:
+                                      type: string
+                                    image:
+                                      type: string
+                                    imageID:
+                                      type: string
+                                    lastState:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    ready:
+                                      type: boolean
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartCount:
+                                      type: integer
+                                    started:
+                                      type: boolean
+                                    state:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                    user:
+                                      properties:
+                                        linux:
+                                          properties:
+                                            gid:
+                                              type: integer
+                                            supplementalGroups:
+                                              items:
+                                                type: integer
+                                              type: array
+                                            uid:
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              ephemeralContainerStatuses:
+                                items:
+                                  properties:
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    allocatedResourcesStatus:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resources:
+                                            items:
+                                              properties:
+                                                health:
+                                                  type: string
+                                                resourceID:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    containerID:
+                                      type: string
+                                    image:
+                                      type: string
+                                    imageID:
+                                      type: string
+                                    lastState:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    ready:
+                                      type: boolean
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartCount:
+                                      type: integer
+                                    started:
+                                      type: boolean
+                                    state:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                    user:
+                                      properties:
+                                        linux:
+                                          properties:
+                                            gid:
+                                              type: integer
+                                            supplementalGroups:
+                                              items:
+                                                type: integer
+                                              type: array
+                                            uid:
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              hostIP:
+                                type: string
+                              hostIPs:
+                                items:
+                                  properties:
+                                    ip:
+                                      type: string
+                                  type: object
+                                type: array
+                              initContainerStatuses:
+                                items:
+                                  properties:
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    allocatedResourcesStatus:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resources:
+                                            items:
+                                              properties:
+                                                health:
+                                                  type: string
+                                                resourceID:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    containerID:
+                                      type: string
+                                    image:
+                                      type: string
+                                    imageID:
+                                      type: string
+                                    lastState:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    ready:
+                                      type: boolean
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartCount:
+                                      type: integer
+                                    started:
+                                      type: boolean
+                                    state:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                    user:
+                                      properties:
+                                        linux:
+                                          properties:
+                                            gid:
+                                              type: integer
+                                            supplementalGroups:
+                                              items:
+                                                type: integer
+                                              type: array
+                                            uid:
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              message:
+                                type: string
+                              nominatedNodeName:
+                                type: string
+                              observedGeneration:
+                                type: integer
+                              phase:
+                                type: string
+                              podIP:
+                                type: string
+                              podIPs:
+                                items:
+                                  properties:
+                                    ip:
+                                      type: string
+                                  type: object
+                                type: array
+                              qosClass:
+                                type: string
+                              reason:
+                                type: string
+                              resize:
+                                type: string
+                              resourceClaimStatuses:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resourceClaimName:
+                                      type: string
+                                  type: object
+                                type: array
+                              startTime:
+                                type: string
+                            type: object
+                          lastTransitionTime:
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: object
+                  type: object
+                currentState:
+                  properties:
+                    currentStateSummary:
+                      enum:
+                        - DriverEvicted
+                        - DriverReady
+                        - DriverReadyTimedOut
+                        - DriverRequested
+                        - DriverStartTimedOut
+                        - DriverStarted
+                        - ExecutorsStartTimedOut
+                        - Failed
+                        - InitializedBelowThresholdExecutors
+                        - ResourceReleased
+                        - RunningHealthy
+                        - RunningWithBelowThresholdExecutors
+                        - ScheduledToRestart
+                        - SchedulingFailure
+                        - Submitted
+                        - Succeeded
+                        - TerminatedWithoutReleaseResources
+                      type: string
+                    lastObservedDriverStatus:
+                      properties:
+                        conditions:
+                          items:
+                            properties:
+                              lastProbeTime:
+                                type: string
+                              lastTransitionTime:
+                                type: string
+                              message:
+                                type: string
+                              observedGeneration:
+                                type: integer
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            type: object
+                          type: array
+                        containerStatuses:
+                          items:
+                            properties:
+                              allocatedResources:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              allocatedResourcesStatus:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resources:
+                                      items:
+                                        properties:
+                                          health:
+                                            type: string
+                                          resourceID:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              containerID:
+                                type: string
+                              image:
+                                type: string
+                              imageID:
+                                type: string
+                              lastState:
+                                properties:
+                                  running:
+                                    properties:
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  terminated:
+                                    properties:
+                                      containerID:
+                                        type: string
+                                      exitCode:
+                                        type: integer
+                                      finishedAt:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      signal:
+                                        type: integer
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  waiting:
+                                    properties:
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                type: string
+                              ready:
+                                type: boolean
+                              resources:
+                                properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        request:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              restartCount:
+                                type: integer
+                              started:
+                                type: boolean
+                              state:
+                                properties:
+                                  running:
+                                    properties:
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  terminated:
+                                    properties:
+                                      containerID:
+                                        type: string
+                                      exitCode:
+                                        type: integer
+                                      finishedAt:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      signal:
+                                        type: integer
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  waiting:
+                                    properties:
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                type: object
+                              stopSignal:
+                                type: string
+                              user:
+                                properties:
+                                  linux:
+                                    properties:
+                                      gid:
+                                        type: integer
+                                      supplementalGroups:
+                                        items:
+                                          type: integer
+                                        type: array
+                                      uid:
+                                        type: integer
+                                    type: object
+                                type: object
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        ephemeralContainerStatuses:
+                          items:
+                            properties:
+                              allocatedResources:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              allocatedResourcesStatus:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resources:
+                                      items:
+                                        properties:
+                                          health:
+                                            type: string
+                                          resourceID:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              containerID:
+                                type: string
+                              image:
+                                type: string
+                              imageID:
+                                type: string
+                              lastState:
+                                properties:
+                                  running:
+                                    properties:
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  terminated:
+                                    properties:
+                                      containerID:
+                                        type: string
+                                      exitCode:
+                                        type: integer
+                                      finishedAt:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      signal:
+                                        type: integer
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  waiting:
+                                    properties:
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                type: string
+                              ready:
+                                type: boolean
+                              resources:
+                                properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        request:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              restartCount:
+                                type: integer
+                              started:
+                                type: boolean
+                              state:
+                                properties:
+                                  running:
+                                    properties:
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  terminated:
+                                    properties:
+                                      containerID:
+                                        type: string
+                                      exitCode:
+                                        type: integer
+                                      finishedAt:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      signal:
+                                        type: integer
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  waiting:
+                                    properties:
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                type: object
+                              stopSignal:
+                                type: string
+                              user:
+                                properties:
+                                  linux:
+                                    properties:
+                                      gid:
+                                        type: integer
+                                      supplementalGroups:
+                                        items:
+                                          type: integer
+                                        type: array
+                                      uid:
+                                        type: integer
+                                    type: object
+                                type: object
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        hostIP:
+                          type: string
+                        hostIPs:
+                          items:
+                            properties:
+                              ip:
+                                type: string
+                            type: object
+                          type: array
+                        initContainerStatuses:
+                          items:
+                            properties:
+                              allocatedResources:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              allocatedResourcesStatus:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resources:
+                                      items:
+                                        properties:
+                                          health:
+                                            type: string
+                                          resourceID:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              containerID:
+                                type: string
+                              image:
+                                type: string
+                              imageID:
+                                type: string
+                              lastState:
+                                properties:
+                                  running:
+                                    properties:
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  terminated:
+                                    properties:
+                                      containerID:
+                                        type: string
+                                      exitCode:
+                                        type: integer
+                                      finishedAt:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      signal:
+                                        type: integer
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  waiting:
+                                    properties:
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                type: string
+                              ready:
+                                type: boolean
+                              resources:
+                                properties:
+                                  claims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        request:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              restartCount:
+                                type: integer
+                              started:
+                                type: boolean
+                              state:
+                                properties:
+                                  running:
+                                    properties:
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  terminated:
+                                    properties:
+                                      containerID:
+                                        type: string
+                                      exitCode:
+                                        type: integer
+                                      finishedAt:
+                                        type: string
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                      signal:
+                                        type: integer
+                                      startedAt:
+                                        type: string
+                                    type: object
+                                  waiting:
+                                    properties:
+                                      message:
+                                        type: string
+                                      reason:
+                                        type: string
+                                    type: object
+                                type: object
+                              stopSignal:
+                                type: string
+                              user:
+                                properties:
+                                  linux:
+                                    properties:
+                                      gid:
+                                        type: integer
+                                      supplementalGroups:
+                                        items:
+                                          type: integer
+                                        type: array
+                                      uid:
+                                        type: integer
+                                    type: object
+                                type: object
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                        message:
+                          type: string
+                        nominatedNodeName:
+                          type: string
+                        observedGeneration:
+                          type: integer
+                        phase:
+                          type: string
+                        podIP:
+                          type: string
+                        podIPs:
+                          items:
+                            properties:
+                              ip:
+                                type: string
+                            type: object
+                          type: array
+                        qosClass:
+                          type: string
+                        reason:
+                          type: string
+                        resize:
+                          type: string
+                        resourceClaimStatuses:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              resourceClaimName:
+                                type: string
+                            type: object
+                          type: array
+                        startTime:
+                          type: string
+                      type: object
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                  type: object
+                previousAttemptSummary:
+                  properties:
+                    attemptInfo:
+                      properties:
+                        id:
+                          type: integer
+                      type: object
+                    stateTransitionHistory:
+                      additionalProperties:
+                        properties:
+                          currentStateSummary:
+                            enum:
+                              - DriverEvicted
+                              - DriverReady
+                              - DriverReadyTimedOut
+                              - DriverRequested
+                              - DriverStartTimedOut
+                              - DriverStarted
+                              - ExecutorsStartTimedOut
+                              - Failed
+                              - InitializedBelowThresholdExecutors
+                              - ResourceReleased
+                              - RunningHealthy
+                              - RunningWithBelowThresholdExecutors
+                              - ScheduledToRestart
+                              - SchedulingFailure
+                              - Submitted
+                              - Succeeded
+                              - TerminatedWithoutReleaseResources
+                            type: string
+                          lastObservedDriverStatus:
+                            properties:
+                              conditions:
+                                items:
+                                  properties:
+                                    lastProbeTime:
+                                      type: string
+                                    lastTransitionTime:
+                                      type: string
+                                    message:
+                                      type: string
+                                    observedGeneration:
+                                      type: integer
+                                    reason:
+                                      type: string
+                                    status:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                type: array
+                              containerStatuses:
+                                items:
+                                  properties:
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    allocatedResourcesStatus:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resources:
+                                            items:
+                                              properties:
+                                                health:
+                                                  type: string
+                                                resourceID:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    containerID:
+                                      type: string
+                                    image:
+                                      type: string
+                                    imageID:
+                                      type: string
+                                    lastState:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    ready:
+                                      type: boolean
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartCount:
+                                      type: integer
+                                    started:
+                                      type: boolean
+                                    state:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                    user:
+                                      properties:
+                                        linux:
+                                          properties:
+                                            gid:
+                                              type: integer
+                                            supplementalGroups:
+                                              items:
+                                                type: integer
+                                              type: array
+                                            uid:
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              ephemeralContainerStatuses:
+                                items:
+                                  properties:
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    allocatedResourcesStatus:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resources:
+                                            items:
+                                              properties:
+                                                health:
+                                                  type: string
+                                                resourceID:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    containerID:
+                                      type: string
+                                    image:
+                                      type: string
+                                    imageID:
+                                      type: string
+                                    lastState:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    ready:
+                                      type: boolean
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartCount:
+                                      type: integer
+                                    started:
+                                      type: boolean
+                                    state:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                    user:
+                                      properties:
+                                        linux:
+                                          properties:
+                                            gid:
+                                              type: integer
+                                            supplementalGroups:
+                                              items:
+                                                type: integer
+                                              type: array
+                                            uid:
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              hostIP:
+                                type: string
+                              hostIPs:
+                                items:
+                                  properties:
+                                    ip:
+                                      type: string
+                                  type: object
+                                type: array
+                              initContainerStatuses:
+                                items:
+                                  properties:
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    allocatedResourcesStatus:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resources:
+                                            items:
+                                              properties:
+                                                health:
+                                                  type: string
+                                                resourceID:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                    containerID:
+                                      type: string
+                                    image:
+                                      type: string
+                                    imageID:
+                                      type: string
+                                    lastState:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    name:
+                                      type: string
+                                    ready:
+                                      type: boolean
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartCount:
+                                      type: integer
+                                    started:
+                                      type: boolean
+                                    state:
+                                      properties:
+                                        running:
+                                          properties:
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        terminated:
+                                          properties:
+                                            containerID:
+                                              type: string
+                                            exitCode:
+                                              type: integer
+                                            finishedAt:
+                                              type: string
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                            signal:
+                                              type: integer
+                                            startedAt:
+                                              type: string
+                                          type: object
+                                        waiting:
+                                          properties:
+                                            message:
+                                              type: string
+                                            reason:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                    user:
+                                      properties:
+                                        linux:
+                                          properties:
+                                            gid:
+                                              type: integer
+                                            supplementalGroups:
+                                              items:
+                                                type: integer
+                                              type: array
+                                            uid:
+                                              type: integer
+                                          type: object
+                                      type: object
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                              message:
+                                type: string
+                              nominatedNodeName:
+                                type: string
+                              observedGeneration:
+                                type: integer
+                              phase:
+                                type: string
+                              podIP:
+                                type: string
+                              podIPs:
+                                items:
+                                  properties:
+                                    ip:
+                                      type: string
+                                  type: object
+                                type: array
+                              qosClass:
+                                type: string
+                              reason:
+                                type: string
+                              resize:
+                                type: string
+                              resourceClaimStatuses:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resourceClaimName:
+                                      type: string
+                                  type: object
+                                type: array
+                              startTime:
+                                type: string
+                            type: object
+                          lastTransitionTime:
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: object
+                  type: object
+                stateTransitionHistory:
+                  additionalProperties:
+                    properties:
+                      currentStateSummary:
+                        enum:
+                          - DriverEvicted
+                          - DriverReady
+                          - DriverReadyTimedOut
+                          - DriverRequested
+                          - DriverStartTimedOut
+                          - DriverStarted
+                          - ExecutorsStartTimedOut
+                          - Failed
+                          - InitializedBelowThresholdExecutors
+                          - ResourceReleased
+                          - RunningHealthy
+                          - RunningWithBelowThresholdExecutors
+                          - ScheduledToRestart
+                          - SchedulingFailure
+                          - Submitted
+                          - Succeeded
+                          - TerminatedWithoutReleaseResources
+                        type: string
+                      lastObservedDriverStatus:
+                        properties:
+                          conditions:
+                            items:
+                              properties:
+                                lastProbeTime:
+                                  type: string
+                                lastTransitionTime:
+                                  type: string
+                                message:
+                                  type: string
+                                observedGeneration:
+                                  type: integer
+                                reason:
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  type: string
+                              type: object
+                            type: array
+                          containerStatuses:
+                            items:
+                              properties:
+                                allocatedResources:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                allocatedResourcesStatus:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      resources:
+                                        items:
+                                          properties:
+                                            health:
+                                              type: string
+                                            resourceID:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                containerID:
+                                  type: string
+                                image:
+                                  type: string
+                                imageID:
+                                  type: string
+                                lastState:
+                                  properties:
+                                    running:
+                                      properties:
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    terminated:
+                                      properties:
+                                        containerID:
+                                          type: string
+                                        exitCode:
+                                          type: integer
+                                        finishedAt:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        signal:
+                                          type: integer
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    waiting:
+                                      properties:
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                      type: object
+                                  type: object
+                                name:
+                                  type: string
+                                ready:
+                                  type: boolean
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartCount:
+                                  type: integer
+                                started:
+                                  type: boolean
+                                state:
+                                  properties:
+                                    running:
+                                      properties:
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    terminated:
+                                      properties:
+                                        containerID:
+                                          type: string
+                                        exitCode:
+                                          type: integer
+                                        finishedAt:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        signal:
+                                          type: integer
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    waiting:
+                                      properties:
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  type: string
+                                user:
+                                  properties:
+                                    linux:
+                                      properties:
+                                        gid:
+                                          type: integer
+                                        supplementalGroups:
+                                          items:
+                                            type: integer
+                                          type: array
+                                        uid:
+                                          type: integer
+                                      type: object
+                                  type: object
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          ephemeralContainerStatuses:
+                            items:
+                              properties:
+                                allocatedResources:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                allocatedResourcesStatus:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      resources:
+                                        items:
+                                          properties:
+                                            health:
+                                              type: string
+                                            resourceID:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                containerID:
+                                  type: string
+                                image:
+                                  type: string
+                                imageID:
+                                  type: string
+                                lastState:
+                                  properties:
+                                    running:
+                                      properties:
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    terminated:
+                                      properties:
+                                        containerID:
+                                          type: string
+                                        exitCode:
+                                          type: integer
+                                        finishedAt:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        signal:
+                                          type: integer
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    waiting:
+                                      properties:
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                      type: object
+                                  type: object
+                                name:
+                                  type: string
+                                ready:
+                                  type: boolean
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartCount:
+                                  type: integer
+                                started:
+                                  type: boolean
+                                state:
+                                  properties:
+                                    running:
+                                      properties:
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    terminated:
+                                      properties:
+                                        containerID:
+                                          type: string
+                                        exitCode:
+                                          type: integer
+                                        finishedAt:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        signal:
+                                          type: integer
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    waiting:
+                                      properties:
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  type: string
+                                user:
+                                  properties:
+                                    linux:
+                                      properties:
+                                        gid:
+                                          type: integer
+                                        supplementalGroups:
+                                          items:
+                                            type: integer
+                                          type: array
+                                        uid:
+                                          type: integer
+                                      type: object
+                                  type: object
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          hostIP:
+                            type: string
+                          hostIPs:
+                            items:
+                              properties:
+                                ip:
+                                  type: string
+                              type: object
+                            type: array
+                          initContainerStatuses:
+                            items:
+                              properties:
+                                allocatedResources:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                allocatedResourcesStatus:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      resources:
+                                        items:
+                                          properties:
+                                            health:
+                                              type: string
+                                            resourceID:
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                                containerID:
+                                  type: string
+                                image:
+                                  type: string
+                                imageID:
+                                  type: string
+                                lastState:
+                                  properties:
+                                    running:
+                                      properties:
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    terminated:
+                                      properties:
+                                        containerID:
+                                          type: string
+                                        exitCode:
+                                          type: integer
+                                        finishedAt:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        signal:
+                                          type: integer
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    waiting:
+                                      properties:
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                      type: object
+                                  type: object
+                                name:
+                                  type: string
+                                ready:
+                                  type: boolean
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartCount:
+                                  type: integer
+                                started:
+                                  type: boolean
+                                state:
+                                  properties:
+                                    running:
+                                      properties:
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    terminated:
+                                      properties:
+                                        containerID:
+                                          type: string
+                                        exitCode:
+                                          type: integer
+                                        finishedAt:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        signal:
+                                          type: integer
+                                        startedAt:
+                                          type: string
+                                      type: object
+                                    waiting:
+                                      properties:
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  type: string
+                                user:
+                                  properties:
+                                    linux:
+                                      properties:
+                                        gid:
+                                          type: integer
+                                        supplementalGroups:
+                                          items:
+                                            type: integer
+                                          type: array
+                                        uid:
+                                          type: integer
+                                      type: object
+                                  type: object
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                          message:
+                            type: string
+                          nominatedNodeName:
+                            type: string
+                          observedGeneration:
+                            type: integer
+                          phase:
+                            type: string
+                          podIP:
+                            type: string
+                          podIPs:
+                            items:
+                              properties:
+                                ip:
+                                  type: string
+                              type: object
+                            type: array
+                          qosClass:
+                            type: string
+                          reason:
+                            type: string
+                          resize:
+                            type: string
+                          resourceClaimStatuses:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                resourceClaimName:
+                                  type: string
+                              type: object
+                            type: array
+                          startTime:
+                            type: string
+                        type: object
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                    type: object
+                  type: object
+              type: object
+          type: object
+      served: true
       storage: true
       subresources:
         status: {}

--- a/build-tools/helm/spark-kubernetes-operator/crds/sparkclusters.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/crds/sparkclusters.spark.apache.org-v1.yaml
@@ -14593,6 +14593,7294 @@ spec:
               type: object
           type: object
       served: true
+      storage: false
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.currentState.currentStateSummary
+          name: Current State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                clusterTolerations:
+                  properties:
+                    instanceConfig:
+                      properties:
+                        initWorkers:
+                          type: integer
+                        maxWorkers:
+                          type: integer
+                        minWorkers:
+                          type: integer
+                      required:
+                        - initWorkers
+                        - maxWorkers
+                        - minWorkers
+                      type: object
+                  required:
+                    - instanceConfig
+                  type: object
+                masterSpec:
+                  properties:
+                    serviceMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        creationTimestamp:
+                          type: string
+                        deletionGracePeriodSeconds:
+                          type: integer
+                        deletionTimestamp:
+                          type: string
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          type: string
+                        generation:
+                          type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        managedFields:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              fieldsType:
+                                type: string
+                              fieldsV1:
+                                type: object
+                              manager:
+                                type: string
+                              operation:
+                                type: string
+                              subresource:
+                                type: string
+                              time:
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        ownerReferences:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              blockOwnerDeletion:
+                                type: boolean
+                              controller:
+                                type: boolean
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              uid:
+                                type: string
+                            type: object
+                          type: array
+                        resourceVersion:
+                          type: string
+                        selfLink:
+                          type: string
+                        uid:
+                          type: string
+                      type: object
+                    serviceSpec:
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          type: boolean
+                        clusterIP:
+                          type: string
+                        clusterIPs:
+                          items:
+                            type: string
+                          type: array
+                        externalIPs:
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          type: string
+                        externalTrafficPolicy:
+                          type: string
+                        healthCheckNodePort:
+                          type: integer
+                        internalTrafficPolicy:
+                          type: string
+                        ipFamilies:
+                          items:
+                            type: string
+                          type: array
+                        ipFamilyPolicy:
+                          type: string
+                        loadBalancerClass:
+                          type: string
+                        loadBalancerIP:
+                          type: string
+                        loadBalancerSourceRanges:
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          items:
+                            properties:
+                              appProtocol:
+                                type: string
+                              name:
+                                type: string
+                              nodePort:
+                                type: integer
+                              port:
+                                type: integer
+                              protocol:
+                                type: string
+                              targetPort:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type: array
+                        publishNotReadyAddresses:
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        sessionAffinity:
+                          type: string
+                        sessionAffinityConfig:
+                          properties:
+                            clientIP:
+                              properties:
+                                timeoutSeconds:
+                                  type: integer
+                              type: object
+                          type: object
+                        trafficDistribution:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    statefulSetMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        creationTimestamp:
+                          type: string
+                        deletionGracePeriodSeconds:
+                          type: integer
+                        deletionTimestamp:
+                          type: string
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          type: string
+                        generation:
+                          type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        managedFields:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              fieldsType:
+                                type: string
+                              fieldsV1:
+                                type: object
+                              manager:
+                                type: string
+                              operation:
+                                type: string
+                              subresource:
+                                type: string
+                              time:
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        ownerReferences:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              blockOwnerDeletion:
+                                type: boolean
+                              controller:
+                                type: boolean
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              uid:
+                                type: string
+                            type: object
+                          type: array
+                        resourceVersion:
+                          type: string
+                        selfLink:
+                          type: string
+                        uid:
+                          type: string
+                      type: object
+                    statefulSetSpec:
+                      properties:
+                        minReadySeconds:
+                          type: integer
+                        ordinals:
+                          properties:
+                            start:
+                              type: integer
+                          type: object
+                        persistentVolumeClaimRetentionPolicy:
+                          properties:
+                            whenDeleted:
+                              type: string
+                            whenScaled:
+                              type: string
+                          type: object
+                        podManagementPolicy:
+                          type: string
+                        replicas:
+                          type: integer
+                        revisionHistoryLimit:
+                          type: integer
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        serviceName:
+                          type: string
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                creationTimestamp:
+                                  type: string
+                                deletionGracePeriodSeconds:
+                                  type: integer
+                                deletionTimestamp:
+                                  type: string
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                generateName:
+                                  type: string
+                                generation:
+                                  type: integer
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                managedFields:
+                                  items:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldsType:
+                                        type: string
+                                      fieldsV1:
+                                        type: object
+                                      manager:
+                                        type: string
+                                      operation:
+                                        type: string
+                                      subresource:
+                                        type: string
+                                      time:
+                                        type: string
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                ownerReferences:
+                                  items:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      blockOwnerDeletion:
+                                        type: boolean
+                                      controller:
+                                        type: boolean
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      uid:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourceVersion:
+                                  type: string
+                                selfLink:
+                                  type: string
+                                uid:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  type: integer
+                                affinity:
+                                  properties:
+                                    nodeAffinity:
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              preference:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchFields:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              weight:
+                                                type: integer
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          properties:
+                                            nodeSelectorTerms:
+                                              items:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchFields:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    podAffinity:
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              podAffinityTerm:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  matchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  mismatchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namespaceSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    type: string
+                                                type: object
+                                              weight:
+                                                type: integer
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                    podAntiAffinity:
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              podAffinityTerm:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  matchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  mismatchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namespaceSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    type: string
+                                                type: object
+                                              weight:
+                                                type: integer
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                automountServiceAccountToken:
+                                  type: boolean
+                                containers:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      lifecycle:
+                                        properties:
+                                          postStart:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      name:
+                                        type: string
+                                      ports:
+                                        items:
+                                          properties:
+                                            containerPort:
+                                              type: integer
+                                            hostIP:
+                                              type: string
+                                            hostPort:
+                                              type: integer
+                                            name:
+                                              type: string
+                                            protocol:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      readinessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        items:
+                                          properties:
+                                            resourceName:
+                                              type: string
+                                            restartPolicy:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        type: boolean
+                                      stdinOnce:
+                                        type: boolean
+                                      terminationMessagePath:
+                                        type: string
+                                      terminationMessagePolicy:
+                                        type: string
+                                      tty:
+                                        type: boolean
+                                      volumeDevices:
+                                        items:
+                                          properties:
+                                            devicePath:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              type: string
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        type: string
+                                    type: object
+                                  type: array
+                                dnsConfig:
+                                  properties:
+                                    nameservers:
+                                      items:
+                                        type: string
+                                      type: array
+                                    options:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    searches:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                dnsPolicy:
+                                  type: string
+                                enableServiceLinks:
+                                  type: boolean
+                                ephemeralContainers:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      lifecycle:
+                                        properties:
+                                          postStart:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      name:
+                                        type: string
+                                      ports:
+                                        items:
+                                          properties:
+                                            containerPort:
+                                              type: integer
+                                            hostIP:
+                                              type: string
+                                            hostPort:
+                                              type: integer
+                                            name:
+                                              type: string
+                                            protocol:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      readinessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        items:
+                                          properties:
+                                            resourceName:
+                                              type: string
+                                            restartPolicy:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        type: boolean
+                                      stdinOnce:
+                                        type: boolean
+                                      targetContainerName:
+                                        type: string
+                                      terminationMessagePath:
+                                        type: string
+                                      terminationMessagePolicy:
+                                        type: string
+                                      tty:
+                                        type: boolean
+                                      volumeDevices:
+                                        items:
+                                          properties:
+                                            devicePath:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              type: string
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        type: string
+                                    type: object
+                                  type: array
+                                hostAliases:
+                                  items:
+                                    properties:
+                                      hostnames:
+                                        items:
+                                          type: string
+                                        type: array
+                                      ip:
+                                        type: string
+                                    type: object
+                                  type: array
+                                hostIPC:
+                                  type: boolean
+                                hostNetwork:
+                                  type: boolean
+                                hostPID:
+                                  type: boolean
+                                hostUsers:
+                                  type: boolean
+                                hostname:
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                initContainers:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      lifecycle:
+                                        properties:
+                                          postStart:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      name:
+                                        type: string
+                                      ports:
+                                        items:
+                                          properties:
+                                            containerPort:
+                                              type: integer
+                                            hostIP:
+                                              type: string
+                                            hostPort:
+                                              type: integer
+                                            name:
+                                              type: string
+                                            protocol:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      readinessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        items:
+                                          properties:
+                                            resourceName:
+                                              type: string
+                                            restartPolicy:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        type: boolean
+                                      stdinOnce:
+                                        type: boolean
+                                      terminationMessagePath:
+                                        type: string
+                                      terminationMessagePolicy:
+                                        type: string
+                                      tty:
+                                        type: boolean
+                                      volumeDevices:
+                                        items:
+                                          properties:
+                                            devicePath:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              type: string
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        type: string
+                                    type: object
+                                  type: array
+                                nodeName:
+                                  type: string
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                os:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                overhead:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                preemptionPolicy:
+                                  type: string
+                                priority:
+                                  type: integer
+                                priorityClassName:
+                                  type: string
+                                readinessGates:
+                                  items:
+                                    properties:
+                                      conditionType:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourceClaims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      resourceClaimName:
+                                        type: string
+                                      resourceClaimTemplateName:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                runtimeClassName:
+                                  type: string
+                                schedulerName:
+                                  type: string
+                                schedulingGates:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                securityContext:
+                                  properties:
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    fsGroup:
+                                      type: integer
+                                    fsGroupChangePolicy:
+                                      type: string
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxChangePolicy:
+                                      type: string
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    supplementalGroups:
+                                      items:
+                                        type: integer
+                                      type: array
+                                    supplementalGroupsPolicy:
+                                      type: string
+                                    sysctls:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccount:
+                                  type: string
+                                serviceAccountName:
+                                  type: string
+                                setHostnameAsFQDN:
+                                  type: boolean
+                                shareProcessNamespace:
+                                  type: boolean
+                                subdomain:
+                                  type: string
+                                terminationGracePeriodSeconds:
+                                  type: integer
+                                tolerations:
+                                  items:
+                                    properties:
+                                      effect:
+                                        type: string
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      tolerationSeconds:
+                                        type: integer
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                topologySpreadConstraints:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                      maxSkew:
+                                        type: integer
+                                      minDomains:
+                                        type: integer
+                                      nodeAffinityPolicy:
+                                        type: string
+                                      nodeTaintsPolicy:
+                                        type: string
+                                      topologyKey:
+                                        type: string
+                                      whenUnsatisfiable:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumes:
+                                  items:
+                                    properties:
+                                      awsElasticBlockStore:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          partition:
+                                            type: integer
+                                          readOnly:
+                                            type: boolean
+                                          volumeID:
+                                            type: string
+                                        type: object
+                                      azureDisk:
+                                        properties:
+                                          cachingMode:
+                                            type: string
+                                          diskName:
+                                            type: string
+                                          diskURI:
+                                            type: string
+                                          fsType:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      azureFile:
+                                        properties:
+                                          readOnly:
+                                            type: boolean
+                                          secretName:
+                                            type: string
+                                          shareName:
+                                            type: string
+                                        type: object
+                                      cephfs:
+                                        properties:
+                                          monitors:
+                                            items:
+                                              type: string
+                                            type: array
+                                          path:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretFile:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          user:
+                                            type: string
+                                        type: object
+                                      cinder:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          volumeID:
+                                            type: string
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      csi:
+                                        properties:
+                                          driver:
+                                            type: string
+                                          fsType:
+                                            type: string
+                                          nodePublishSecretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          readOnly:
+                                            type: boolean
+                                          volumeAttributes:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      downwardAPI:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                        type: object
+                                      emptyDir:
+                                        properties:
+                                          medium:
+                                            type: string
+                                          sizeLimit:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      ephemeral:
+                                        properties:
+                                          volumeClaimTemplate:
+                                            properties:
+                                              metadata:
+                                                properties:
+                                                  annotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  creationTimestamp:
+                                                    type: string
+                                                  deletionGracePeriodSeconds:
+                                                    type: integer
+                                                  deletionTimestamp:
+                                                    type: string
+                                                  finalizers:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  generateName:
+                                                    type: string
+                                                  generation:
+                                                    type: integer
+                                                  labels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  managedFields:
+                                                    items:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldsType:
+                                                          type: string
+                                                        fieldsV1:
+                                                          type: object
+                                                        manager:
+                                                          type: string
+                                                        operation:
+                                                          type: string
+                                                        subresource:
+                                                          type: string
+                                                        time:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                  ownerReferences:
+                                                    items:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        blockOwnerDeletion:
+                                                          type: boolean
+                                                        controller:
+                                                          type: boolean
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        uid:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  resourceVersion:
+                                                    type: string
+                                                  selfLink:
+                                                    type: string
+                                                  uid:
+                                                    type: string
+                                                type: object
+                                              spec:
+                                                properties:
+                                                  accessModes:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  dataSource:
+                                                    properties:
+                                                      apiGroup:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  dataSourceRef:
+                                                    properties:
+                                                      apiGroup:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                    type: object
+                                                  resources:
+                                                    properties:
+                                                      limits:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        type: object
+                                                      requests:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        type: object
+                                                    type: object
+                                                  selector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  storageClassName:
+                                                    type: string
+                                                  volumeAttributesClassName:
+                                                    type: string
+                                                  volumeMode:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                        type: object
+                                      fc:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          lun:
+                                            type: integer
+                                          readOnly:
+                                            type: boolean
+                                          targetWWNs:
+                                            items:
+                                              type: string
+                                            type: array
+                                          wwids:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      flexVolume:
+                                        properties:
+                                          driver:
+                                            type: string
+                                          fsType:
+                                            type: string
+                                          options:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      flocker:
+                                        properties:
+                                          datasetName:
+                                            type: string
+                                          datasetUUID:
+                                            type: string
+                                        type: object
+                                      gcePersistentDisk:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          partition:
+                                            type: integer
+                                          pdName:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      gitRepo:
+                                        properties:
+                                          directory:
+                                            type: string
+                                          repository:
+                                            type: string
+                                          revision:
+                                            type: string
+                                        type: object
+                                      glusterfs:
+                                        properties:
+                                          endpoints:
+                                            type: string
+                                          path:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      hostPath:
+                                        properties:
+                                          path:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      image:
+                                        properties:
+                                          pullPolicy:
+                                            type: string
+                                          reference:
+                                            type: string
+                                        type: object
+                                      iscsi:
+                                        properties:
+                                          chapAuthDiscovery:
+                                            type: boolean
+                                          chapAuthSession:
+                                            type: boolean
+                                          fsType:
+                                            type: string
+                                          initiatorName:
+                                            type: string
+                                          iqn:
+                                            type: string
+                                          iscsiInterface:
+                                            type: string
+                                          lun:
+                                            type: integer
+                                          portals:
+                                            items:
+                                              type: string
+                                            type: array
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          targetPortal:
+                                            type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      nfs:
+                                        properties:
+                                          path:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          server:
+                                            type: string
+                                        type: object
+                                      persistentVolumeClaim:
+                                        properties:
+                                          claimName:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      photonPersistentDisk:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          pdID:
+                                            type: string
+                                        type: object
+                                      portworxVolume:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          volumeID:
+                                            type: string
+                                        type: object
+                                      projected:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          sources:
+                                            items:
+                                              properties:
+                                                clusterTrustBundle:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    signerName:
+                                                      type: string
+                                                  type: object
+                                                configMap:
+                                                  properties:
+                                                    items:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          mode:
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                        type: object
+                                                      type: array
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                downwardAPI:
+                                                  properties:
+                                                    items:
+                                                      items:
+                                                        properties:
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            type: object
+                                                          mode:
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                type: string
+                                                            type: object
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                secret:
+                                                  properties:
+                                                    items:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          mode:
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                        type: object
+                                                      type: array
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                serviceAccountToken:
+                                                  properties:
+                                                    audience:
+                                                      type: string
+                                                    expirationSeconds:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                        type: object
+                                      quobyte:
+                                        properties:
+                                          group:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          registry:
+                                            type: string
+                                          tenant:
+                                            type: string
+                                          user:
+                                            type: string
+                                          volume:
+                                            type: string
+                                        type: object
+                                      rbd:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          image:
+                                            type: string
+                                          keyring:
+                                            type: string
+                                          monitors:
+                                            items:
+                                              type: string
+                                            type: array
+                                          pool:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          user:
+                                            type: string
+                                        type: object
+                                      scaleIO:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          gateway:
+                                            type: string
+                                          protectionDomain:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          sslEnabled:
+                                            type: boolean
+                                          storageMode:
+                                            type: string
+                                          storagePool:
+                                            type: string
+                                          system:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                      secret:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          optional:
+                                            type: boolean
+                                          secretName:
+                                            type: string
+                                        type: object
+                                      storageos:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          volumeName:
+                                            type: string
+                                          volumeNamespace:
+                                            type: string
+                                        type: object
+                                      vsphereVolume:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          storagePolicyID:
+                                            type: string
+                                          storagePolicyName:
+                                            type: string
+                                          volumePath:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        updateStrategy:
+                          properties:
+                            rollingUpdate:
+                              properties:
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                partition:
+                                  type: integer
+                              type: object
+                            type:
+                              type: string
+                          type: object
+                        volumeClaimTemplates:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  creationTimestamp:
+                                    type: string
+                                  deletionGracePeriodSeconds:
+                                    type: integer
+                                  deletionTimestamp:
+                                    type: string
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  generateName:
+                                    type: string
+                                  generation:
+                                    type: integer
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  managedFields:
+                                    items:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldsType:
+                                          type: string
+                                        fieldsV1:
+                                          type: object
+                                        manager:
+                                          type: string
+                                        operation:
+                                          type: string
+                                        subresource:
+                                          type: string
+                                        time:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  ownerReferences:
+                                    items:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        blockOwnerDeletion:
+                                          type: boolean
+                                        controller:
+                                          type: boolean
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        uid:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourceVersion:
+                                    type: string
+                                  selfLink:
+                                    type: string
+                                  uid:
+                                    type: string
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  dataSourceRef:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeAttributesClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                              status:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  allocatedResourceStatuses:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  allocatedResources:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  capacity:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  conditions:
+                                    items:
+                                      properties:
+                                        lastProbeTime:
+                                          type: string
+                                        lastTransitionTime:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        status:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  currentVolumeAttributesClassName:
+                                    type: string
+                                  modifyVolumeStatus:
+                                    properties:
+                                      status:
+                                        type: string
+                                      targetVolumeAttributesClassName:
+                                        type: string
+                                    type: object
+                                  phase:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                runtimeVersions:
+                  properties:
+                    jdkVersion:
+                      type: string
+                    scalaVersion:
+                      type: string
+                    sparkVersion:
+                      type: string
+                  required:
+                    - sparkVersion
+                  type: object
+                sparkConf:
+                  additionalProperties:
+                    type: string
+                  type: object
+                workerSpec:
+                  properties:
+                    horizontalPodAutoscalerSpec:
+                      properties:
+                        behavior:
+                          properties:
+                            scaleDown:
+                              properties:
+                                policies:
+                                  items:
+                                    properties:
+                                      periodSeconds:
+                                        type: integer
+                                      type:
+                                        type: string
+                                      value:
+                                        type: integer
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  type: integer
+                                tolerance:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            scaleUp:
+                              properties:
+                                policies:
+                                  items:
+                                    properties:
+                                      periodSeconds:
+                                        type: integer
+                                      type:
+                                        type: string
+                                      value:
+                                        type: integer
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  type: integer
+                                tolerance:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        maxReplicas:
+                          type: integer
+                        metrics:
+                          items:
+                            properties:
+                              containerResource:
+                                properties:
+                                  container:
+                                    type: string
+                                  name:
+                                    type: string
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              external:
+                                properties:
+                                  metric:
+                                    properties:
+                                      name:
+                                        type: string
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              object:
+                                properties:
+                                  describedObject:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  metric:
+                                    properties:
+                                      name:
+                                        type: string
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              pods:
+                                properties:
+                                  metric:
+                                    properties:
+                                      name:
+                                        type: string
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              resource:
+                                properties:
+                                  name:
+                                    type: string
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              type:
+                                type: string
+                            type: object
+                          type: array
+                        minReplicas:
+                          type: integer
+                        scaleTargetRef:
+                          properties:
+                            apiVersion:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                    serviceMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        creationTimestamp:
+                          type: string
+                        deletionGracePeriodSeconds:
+                          type: integer
+                        deletionTimestamp:
+                          type: string
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          type: string
+                        generation:
+                          type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        managedFields:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              fieldsType:
+                                type: string
+                              fieldsV1:
+                                type: object
+                              manager:
+                                type: string
+                              operation:
+                                type: string
+                              subresource:
+                                type: string
+                              time:
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        ownerReferences:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              blockOwnerDeletion:
+                                type: boolean
+                              controller:
+                                type: boolean
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              uid:
+                                type: string
+                            type: object
+                          type: array
+                        resourceVersion:
+                          type: string
+                        selfLink:
+                          type: string
+                        uid:
+                          type: string
+                      type: object
+                    serviceSpec:
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          type: boolean
+                        clusterIP:
+                          type: string
+                        clusterIPs:
+                          items:
+                            type: string
+                          type: array
+                        externalIPs:
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          type: string
+                        externalTrafficPolicy:
+                          type: string
+                        healthCheckNodePort:
+                          type: integer
+                        internalTrafficPolicy:
+                          type: string
+                        ipFamilies:
+                          items:
+                            type: string
+                          type: array
+                        ipFamilyPolicy:
+                          type: string
+                        loadBalancerClass:
+                          type: string
+                        loadBalancerIP:
+                          type: string
+                        loadBalancerSourceRanges:
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          items:
+                            properties:
+                              appProtocol:
+                                type: string
+                              name:
+                                type: string
+                              nodePort:
+                                type: integer
+                              port:
+                                type: integer
+                              protocol:
+                                type: string
+                              targetPort:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type: array
+                        publishNotReadyAddresses:
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        sessionAffinity:
+                          type: string
+                        sessionAffinityConfig:
+                          properties:
+                            clientIP:
+                              properties:
+                                timeoutSeconds:
+                                  type: integer
+                              type: object
+                          type: object
+                        trafficDistribution:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    statefulSetMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        creationTimestamp:
+                          type: string
+                        deletionGracePeriodSeconds:
+                          type: integer
+                        deletionTimestamp:
+                          type: string
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          type: string
+                        generation:
+                          type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        managedFields:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              fieldsType:
+                                type: string
+                              fieldsV1:
+                                type: object
+                              manager:
+                                type: string
+                              operation:
+                                type: string
+                              subresource:
+                                type: string
+                              time:
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        ownerReferences:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              blockOwnerDeletion:
+                                type: boolean
+                              controller:
+                                type: boolean
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              uid:
+                                type: string
+                            type: object
+                          type: array
+                        resourceVersion:
+                          type: string
+                        selfLink:
+                          type: string
+                        uid:
+                          type: string
+                      type: object
+                    statefulSetSpec:
+                      properties:
+                        minReadySeconds:
+                          type: integer
+                        ordinals:
+                          properties:
+                            start:
+                              type: integer
+                          type: object
+                        persistentVolumeClaimRetentionPolicy:
+                          properties:
+                            whenDeleted:
+                              type: string
+                            whenScaled:
+                              type: string
+                          type: object
+                        podManagementPolicy:
+                          type: string
+                        replicas:
+                          type: integer
+                        revisionHistoryLimit:
+                          type: integer
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        serviceName:
+                          type: string
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                creationTimestamp:
+                                  type: string
+                                deletionGracePeriodSeconds:
+                                  type: integer
+                                deletionTimestamp:
+                                  type: string
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                generateName:
+                                  type: string
+                                generation:
+                                  type: integer
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                managedFields:
+                                  items:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldsType:
+                                        type: string
+                                      fieldsV1:
+                                        type: object
+                                      manager:
+                                        type: string
+                                      operation:
+                                        type: string
+                                      subresource:
+                                        type: string
+                                      time:
+                                        type: string
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                ownerReferences:
+                                  items:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      blockOwnerDeletion:
+                                        type: boolean
+                                      controller:
+                                        type: boolean
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      uid:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourceVersion:
+                                  type: string
+                                selfLink:
+                                  type: string
+                                uid:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  type: integer
+                                affinity:
+                                  properties:
+                                    nodeAffinity:
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              preference:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchFields:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              weight:
+                                                type: integer
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          properties:
+                                            nodeSelectorTerms:
+                                              items:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchFields:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    podAffinity:
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              podAffinityTerm:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  matchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  mismatchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namespaceSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    type: string
+                                                type: object
+                                              weight:
+                                                type: integer
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                    podAntiAffinity:
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              podAffinityTerm:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  matchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  mismatchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namespaceSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    type: string
+                                                type: object
+                                              weight:
+                                                type: integer
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              mismatchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              namespaceSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                type: string
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                automountServiceAccountToken:
+                                  type: boolean
+                                containers:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      lifecycle:
+                                        properties:
+                                          postStart:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      name:
+                                        type: string
+                                      ports:
+                                        items:
+                                          properties:
+                                            containerPort:
+                                              type: integer
+                                            hostIP:
+                                              type: string
+                                            hostPort:
+                                              type: integer
+                                            name:
+                                              type: string
+                                            protocol:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      readinessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        items:
+                                          properties:
+                                            resourceName:
+                                              type: string
+                                            restartPolicy:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        type: boolean
+                                      stdinOnce:
+                                        type: boolean
+                                      terminationMessagePath:
+                                        type: string
+                                      terminationMessagePolicy:
+                                        type: string
+                                      tty:
+                                        type: boolean
+                                      volumeDevices:
+                                        items:
+                                          properties:
+                                            devicePath:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              type: string
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        type: string
+                                    type: object
+                                  type: array
+                                dnsConfig:
+                                  properties:
+                                    nameservers:
+                                      items:
+                                        type: string
+                                      type: array
+                                    options:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    searches:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                dnsPolicy:
+                                  type: string
+                                enableServiceLinks:
+                                  type: boolean
+                                ephemeralContainers:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      lifecycle:
+                                        properties:
+                                          postStart:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      name:
+                                        type: string
+                                      ports:
+                                        items:
+                                          properties:
+                                            containerPort:
+                                              type: integer
+                                            hostIP:
+                                              type: string
+                                            hostPort:
+                                              type: integer
+                                            name:
+                                              type: string
+                                            protocol:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      readinessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        items:
+                                          properties:
+                                            resourceName:
+                                              type: string
+                                            restartPolicy:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        type: boolean
+                                      stdinOnce:
+                                        type: boolean
+                                      targetContainerName:
+                                        type: string
+                                      terminationMessagePath:
+                                        type: string
+                                      terminationMessagePolicy:
+                                        type: string
+                                      tty:
+                                        type: boolean
+                                      volumeDevices:
+                                        items:
+                                          properties:
+                                            devicePath:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              type: string
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        type: string
+                                    type: object
+                                  type: array
+                                hostAliases:
+                                  items:
+                                    properties:
+                                      hostnames:
+                                        items:
+                                          type: string
+                                        type: array
+                                      ip:
+                                        type: string
+                                    type: object
+                                  type: array
+                                hostIPC:
+                                  type: boolean
+                                hostNetwork:
+                                  type: boolean
+                                hostPID:
+                                  type: boolean
+                                hostUsers:
+                                  type: boolean
+                                hostname:
+                                  type: string
+                                imagePullSecrets:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                initContainers:
+                                  items:
+                                    properties:
+                                      args:
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                configMapKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        items:
+                                          properties:
+                                            configMapRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        type: string
+                                      imagePullPolicy:
+                                        type: string
+                                      lifecycle:
+                                        properties:
+                                          postStart:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                type: object
+                                              sleep:
+                                                properties:
+                                                  seconds:
+                                                    type: integer
+                                                type: object
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      name:
+                                        type: string
+                                      ports:
+                                        items:
+                                          properties:
+                                            containerPort:
+                                              type: integer
+                                            hostIP:
+                                              type: string
+                                            hostPort:
+                                              type: integer
+                                            name:
+                                              type: string
+                                            protocol:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      readinessProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        items:
+                                          properties:
+                                            resourceName:
+                                              type: string
+                                            restartPolicy:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        type: string
+                                      securityContext:
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            type: boolean
+                                          appArmorProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          capabilities:
+                                            properties:
+                                              add:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            type: boolean
+                                          procMount:
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            type: boolean
+                                          runAsGroup:
+                                            type: integer
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                          seLinuxOptions:
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            properties:
+                                              localhostProfile:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              hostProcess:
+                                                type: boolean
+                                              runAsUserName:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        properties:
+                                          exec:
+                                            properties:
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            type: integer
+                                          grpc:
+                                            properties:
+                                              port:
+                                                type: integer
+                                              service:
+                                                type: string
+                                            type: object
+                                          httpGet:
+                                            properties:
+                                              host:
+                                                type: string
+                                              httpHeaders:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              path:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                type: string
+                                            type: object
+                                          initialDelaySeconds:
+                                            type: integer
+                                          periodSeconds:
+                                            type: integer
+                                          successThreshold:
+                                            type: integer
+                                          tcpSocket:
+                                            properties:
+                                              host:
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            type: integer
+                                          timeoutSeconds:
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        type: boolean
+                                      stdinOnce:
+                                        type: boolean
+                                      terminationMessagePath:
+                                        type: string
+                                      terminationMessagePolicy:
+                                        type: string
+                                      tty:
+                                        type: boolean
+                                      volumeDevices:
+                                        items:
+                                          properties:
+                                            devicePath:
+                                              type: string
+                                            name:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        items:
+                                          properties:
+                                            mountPath:
+                                              type: string
+                                            mountPropagation:
+                                              type: string
+                                            name:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              type: string
+                                            subPath:
+                                              type: string
+                                            subPathExpr:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        type: string
+                                    type: object
+                                  type: array
+                                nodeName:
+                                  type: string
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                os:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                overhead:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                preemptionPolicy:
+                                  type: string
+                                priority:
+                                  type: integer
+                                priorityClassName:
+                                  type: string
+                                readinessGates:
+                                  items:
+                                    properties:
+                                      conditionType:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourceClaims:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      resourceClaimName:
+                                        type: string
+                                      resourceClaimTemplateName:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                runtimeClassName:
+                                  type: string
+                                schedulerName:
+                                  type: string
+                                schedulingGates:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                securityContext:
+                                  properties:
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    fsGroup:
+                                      type: integer
+                                    fsGroupChangePolicy:
+                                      type: string
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxChangePolicy:
+                                      type: string
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    supplementalGroups:
+                                      items:
+                                        type: integer
+                                      type: array
+                                    supplementalGroupsPolicy:
+                                      type: string
+                                    sysctls:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccount:
+                                  type: string
+                                serviceAccountName:
+                                  type: string
+                                setHostnameAsFQDN:
+                                  type: boolean
+                                shareProcessNamespace:
+                                  type: boolean
+                                subdomain:
+                                  type: string
+                                terminationGracePeriodSeconds:
+                                  type: integer
+                                tolerations:
+                                  items:
+                                    properties:
+                                      effect:
+                                        type: string
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      tolerationSeconds:
+                                        type: integer
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                topologySpreadConstraints:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      matchLabelKeys:
+                                        items:
+                                          type: string
+                                        type: array
+                                      maxSkew:
+                                        type: integer
+                                      minDomains:
+                                        type: integer
+                                      nodeAffinityPolicy:
+                                        type: string
+                                      nodeTaintsPolicy:
+                                        type: string
+                                      topologyKey:
+                                        type: string
+                                      whenUnsatisfiable:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumes:
+                                  items:
+                                    properties:
+                                      awsElasticBlockStore:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          partition:
+                                            type: integer
+                                          readOnly:
+                                            type: boolean
+                                          volumeID:
+                                            type: string
+                                        type: object
+                                      azureDisk:
+                                        properties:
+                                          cachingMode:
+                                            type: string
+                                          diskName:
+                                            type: string
+                                          diskURI:
+                                            type: string
+                                          fsType:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      azureFile:
+                                        properties:
+                                          readOnly:
+                                            type: boolean
+                                          secretName:
+                                            type: string
+                                          shareName:
+                                            type: string
+                                        type: object
+                                      cephfs:
+                                        properties:
+                                          monitors:
+                                            items:
+                                              type: string
+                                            type: array
+                                          path:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretFile:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          user:
+                                            type: string
+                                        type: object
+                                      cinder:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          volumeID:
+                                            type: string
+                                        type: object
+                                      configMap:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      csi:
+                                        properties:
+                                          driver:
+                                            type: string
+                                          fsType:
+                                            type: string
+                                          nodePublishSecretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          readOnly:
+                                            type: boolean
+                                          volumeAttributes:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      downwardAPI:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                fieldRef:
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                  type: object
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                        type: object
+                                      emptyDir:
+                                        properties:
+                                          medium:
+                                            type: string
+                                          sizeLimit:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      ephemeral:
+                                        properties:
+                                          volumeClaimTemplate:
+                                            properties:
+                                              metadata:
+                                                properties:
+                                                  annotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  creationTimestamp:
+                                                    type: string
+                                                  deletionGracePeriodSeconds:
+                                                    type: integer
+                                                  deletionTimestamp:
+                                                    type: string
+                                                  finalizers:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  generateName:
+                                                    type: string
+                                                  generation:
+                                                    type: integer
+                                                  labels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  managedFields:
+                                                    items:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldsType:
+                                                          type: string
+                                                        fieldsV1:
+                                                          type: object
+                                                        manager:
+                                                          type: string
+                                                        operation:
+                                                          type: string
+                                                        subresource:
+                                                          type: string
+                                                        time:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
+                                                  ownerReferences:
+                                                    items:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        blockOwnerDeletion:
+                                                          type: boolean
+                                                        controller:
+                                                          type: boolean
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        uid:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  resourceVersion:
+                                                    type: string
+                                                  selfLink:
+                                                    type: string
+                                                  uid:
+                                                    type: string
+                                                type: object
+                                              spec:
+                                                properties:
+                                                  accessModes:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  dataSource:
+                                                    properties:
+                                                      apiGroup:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                    type: object
+                                                  dataSourceRef:
+                                                    properties:
+                                                      apiGroup:
+                                                        type: string
+                                                      kind:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                    type: object
+                                                  resources:
+                                                    properties:
+                                                      limits:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        type: object
+                                                      requests:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        type: object
+                                                    type: object
+                                                  selector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                  storageClassName:
+                                                    type: string
+                                                  volumeAttributesClassName:
+                                                    type: string
+                                                  volumeMode:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                        type: object
+                                      fc:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          lun:
+                                            type: integer
+                                          readOnly:
+                                            type: boolean
+                                          targetWWNs:
+                                            items:
+                                              type: string
+                                            type: array
+                                          wwids:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      flexVolume:
+                                        properties:
+                                          driver:
+                                            type: string
+                                          fsType:
+                                            type: string
+                                          options:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      flocker:
+                                        properties:
+                                          datasetName:
+                                            type: string
+                                          datasetUUID:
+                                            type: string
+                                        type: object
+                                      gcePersistentDisk:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          partition:
+                                            type: integer
+                                          pdName:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      gitRepo:
+                                        properties:
+                                          directory:
+                                            type: string
+                                          repository:
+                                            type: string
+                                          revision:
+                                            type: string
+                                        type: object
+                                      glusterfs:
+                                        properties:
+                                          endpoints:
+                                            type: string
+                                          path:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      hostPath:
+                                        properties:
+                                          path:
+                                            type: string
+                                          type:
+                                            type: string
+                                        type: object
+                                      image:
+                                        properties:
+                                          pullPolicy:
+                                            type: string
+                                          reference:
+                                            type: string
+                                        type: object
+                                      iscsi:
+                                        properties:
+                                          chapAuthDiscovery:
+                                            type: boolean
+                                          chapAuthSession:
+                                            type: boolean
+                                          fsType:
+                                            type: string
+                                          initiatorName:
+                                            type: string
+                                          iqn:
+                                            type: string
+                                          iscsiInterface:
+                                            type: string
+                                          lun:
+                                            type: integer
+                                          portals:
+                                            items:
+                                              type: string
+                                            type: array
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          targetPortal:
+                                            type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      nfs:
+                                        properties:
+                                          path:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          server:
+                                            type: string
+                                        type: object
+                                      persistentVolumeClaim:
+                                        properties:
+                                          claimName:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                        type: object
+                                      photonPersistentDisk:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          pdID:
+                                            type: string
+                                        type: object
+                                      portworxVolume:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          volumeID:
+                                            type: string
+                                        type: object
+                                      projected:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          sources:
+                                            items:
+                                              properties:
+                                                clusterTrustBundle:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    signerName:
+                                                      type: string
+                                                  type: object
+                                                configMap:
+                                                  properties:
+                                                    items:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          mode:
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                        type: object
+                                                      type: array
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                downwardAPI:
+                                                  properties:
+                                                    items:
+                                                      items:
+                                                        properties:
+                                                          fieldRef:
+                                                            properties:
+                                                              apiVersion:
+                                                                type: string
+                                                              fieldPath:
+                                                                type: string
+                                                            type: object
+                                                          mode:
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                          resourceFieldRef:
+                                                            properties:
+                                                              containerName:
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                type: string
+                                                            type: object
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                secret:
+                                                  properties:
+                                                    items:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          mode:
+                                                            type: integer
+                                                          path:
+                                                            type: string
+                                                        type: object
+                                                      type: array
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                serviceAccountToken:
+                                                  properties:
+                                                    audience:
+                                                      type: string
+                                                    expirationSeconds:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            type: array
+                                        type: object
+                                      quobyte:
+                                        properties:
+                                          group:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          registry:
+                                            type: string
+                                          tenant:
+                                            type: string
+                                          user:
+                                            type: string
+                                          volume:
+                                            type: string
+                                        type: object
+                                      rbd:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          image:
+                                            type: string
+                                          keyring:
+                                            type: string
+                                          monitors:
+                                            items:
+                                              type: string
+                                            type: array
+                                          pool:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          user:
+                                            type: string
+                                        type: object
+                                      scaleIO:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          gateway:
+                                            type: string
+                                          protectionDomain:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          sslEnabled:
+                                            type: boolean
+                                          storageMode:
+                                            type: string
+                                          storagePool:
+                                            type: string
+                                          system:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                      secret:
+                                        properties:
+                                          defaultMode:
+                                            type: integer
+                                          items:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                path:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          optional:
+                                            type: boolean
+                                          secretName:
+                                            type: string
+                                        type: object
+                                      storageos:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          volumeName:
+                                            type: string
+                                          volumeNamespace:
+                                            type: string
+                                        type: object
+                                      vsphereVolume:
+                                        properties:
+                                          fsType:
+                                            type: string
+                                          storagePolicyID:
+                                            type: string
+                                          storagePolicyName:
+                                            type: string
+                                          volumePath:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        updateStrategy:
+                          properties:
+                            rollingUpdate:
+                              properties:
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                partition:
+                                  type: integer
+                              type: object
+                            type:
+                              type: string
+                          type: object
+                        volumeClaimTemplates:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  creationTimestamp:
+                                    type: string
+                                  deletionGracePeriodSeconds:
+                                    type: integer
+                                  deletionTimestamp:
+                                    type: string
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  generateName:
+                                    type: string
+                                  generation:
+                                    type: integer
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  managedFields:
+                                    items:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldsType:
+                                          type: string
+                                        fieldsV1:
+                                          type: object
+                                        manager:
+                                          type: string
+                                        operation:
+                                          type: string
+                                        subresource:
+                                          type: string
+                                        time:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  ownerReferences:
+                                    items:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        blockOwnerDeletion:
+                                          type: boolean
+                                        controller:
+                                          type: boolean
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        uid:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resourceVersion:
+                                    type: string
+                                  selfLink:
+                                    type: string
+                                  uid:
+                                    type: string
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  dataSourceRef:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeAttributesClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                              status:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  allocatedResourceStatuses:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  allocatedResources:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  capacity:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  conditions:
+                                    items:
+                                      properties:
+                                        lastProbeTime:
+                                          type: string
+                                        lastTransitionTime:
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        status:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  currentVolumeAttributesClassName:
+                                    type: string
+                                  modifyVolumeStatus:
+                                    properties:
+                                      status:
+                                        type: string
+                                      targetVolumeAttributesClassName:
+                                        type: string
+                                    type: object
+                                  phase:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              required:
+                - clusterTolerations
+                - runtimeVersions
+              type: object
+            status:
+              properties:
+                currentAttemptSummary:
+                  properties:
+                    attemptInfo:
+                      properties:
+                        id:
+                          type: integer
+                      type: object
+                    stateTransitionHistory:
+                      additionalProperties:
+                        properties:
+                          currentStateSummary:
+                            enum:
+                              - Failed
+                              - ResourceReleased
+                              - RunningHealthy
+                              - SchedulingFailure
+                              - Submitted
+                            type: string
+                          lastTransitionTime:
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: object
+                  type: object
+                currentState:
+                  properties:
+                    currentStateSummary:
+                      enum:
+                        - Failed
+                        - ResourceReleased
+                        - RunningHealthy
+                        - SchedulingFailure
+                        - Submitted
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                  type: object
+                previousAttemptSummary:
+                  properties:
+                    attemptInfo:
+                      properties:
+                        id:
+                          type: integer
+                      type: object
+                    stateTransitionHistory:
+                      additionalProperties:
+                        properties:
+                          currentStateSummary:
+                            enum:
+                              - Failed
+                              - ResourceReleased
+                              - RunningHealthy
+                              - SchedulingFailure
+                              - Submitted
+                            type: string
+                          lastTransitionTime:
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: object
+                  type: object
+                stateTransitionHistory:
+                  additionalProperties:
+                    properties:
+                      currentStateSummary:
+                        enum:
+                          - Failed
+                          - ResourceReleased
+                          - RunningHealthy
+                          - SchedulingFailure
+                          - Submitted
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                    type: object
+                  type: object
+              type: object
+          type: object
+      served: true
       storage: true
       subresources:
         status: {}

--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -161,7 +161,7 @@ metadata:
 {{- end }}
 {{- if $workloadResources.sparkApplicationSentinel.create }}
 {{- range $sentinelNs := .Values.workloadResources.sparkApplicationSentinel.sentinelNamespaces.data }}
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: {{ $workloadResources.sparkApplicationSentinel.name }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,7 +144,7 @@ send the HTTP Get to the liveness endpoint, and the
 kubelet will then kill the spark operator container and restart it.
 
 ```yaml
-apiVersion: org.apache.spark/v1beta1
+apiVersion: org.apache.spark/v1
 kind: SparkApplication
 metadata:
   name: spark-sentinel-resources

--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -35,7 +35,7 @@ SparkApplication can be defined in YAML format. User may configure the applicati
 and configurations. Let's start with the [Spark-Pi example](../examples/pi.yaml):
 
 ```yaml
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi

--- a/examples/cluster-java21.yaml
+++ b/examples/cluster-java21.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: cluster-java21

--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: cluster-on-yunikorn

--- a/examples/cluster-with-hpa-template.yaml
+++ b/examples/cluster-with-hpa-template.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: cluster-with-hpa-template

--- a/examples/cluster-with-hpa.yaml
+++ b/examples/cluster-with-hpa.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: cluster-with-hpa

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: cluster-with-template

--- a/examples/dfs-read-write.yaml
+++ b/examples/dfs-read-write.yaml
@@ -15,7 +15,7 @@
 #
 # Since this requires a remote storage, prepare it via `localstack.yml`.
 #
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: dfs-read-write

--- a/examples/pi-java21.yaml
+++ b/examples/pi-java21.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-java21

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-on-yunikorn

--- a/examples/pi-scala.yaml
+++ b/examples/pi-scala.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-scala

--- a/examples/pi-with-driver-timeout.yaml
+++ b/examples/pi-with-driver-timeout.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-with-driver-timeout

--- a/examples/pi-with-eventlog.yaml
+++ b/examples/pi-with-eventlog.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-with-eventlog

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-with-one-pod

--- a/examples/pi-with-spark-connect-plugin.yaml
+++ b/examples/pi-with-spark-connect-plugin.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-with-spark-connect-plugin

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi

--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: prod

--- a/examples/pyspark-pi.yaml
+++ b/examples/pyspark-pi.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: pi-python

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: qa

--- a/examples/spark-connect-server-with-spark-cluster.yaml
+++ b/examples/spark-connect-server-with-spark-cluster.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-connect-server

--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-connect-server

--- a/examples/spark-history-server.yaml
+++ b/examples/spark-history-server.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-history-server

--- a/examples/spark-thrift-server.yaml
+++ b/examples/spark-thrift-server.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-thrift-server

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: sql

--- a/examples/stream-word-count.yaml
+++ b/examples/stream-word-count.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: stream-word-count

--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/Constants.java
@@ -22,7 +22,7 @@ package org.apache.spark.k8s.operator;
 @SuppressWarnings("PMD.DataClass")
 public class Constants {
   public static final String API_GROUP = "spark.apache.org";
-  public static final String API_VERSION = "v1beta1";
+  public static final String API_VERSION = "v1";
   public static final String LABEL_SPARK_APPLICATION_NAME = "spark.operator/spark-app-name";
   public static final String LABEL_SPARK_CLUSTER_NAME = "spark.operator/spark-cluster-name";
   public static final String LABEL_SPARK_OPERATOR_NAME = "spark.operator/name";

--- a/tests/e2e/assertions/spark-application/spark-state-transition.yaml
+++ b/tests/e2e/assertions/spark-application/spark-state-transition.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-job-succeeded-test

--- a/tests/e2e/assertions/spark-cluster/spark-cluster-state-transition.yaml
+++ b/tests/e2e/assertions/spark-cluster/spark-cluster-state-transition.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: spark-cluster-succeeded-test

--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
         - events:
             namespace: default
         - describe:
-            apiVersion: spark.apache.org/v1beta1
+            apiVersion: spark.apache.org/v1
             kind: SparkApplication
             namespace: default
         - describe:

--- a/tests/e2e/python/pyspark-example.yaml
+++ b/tests/e2e/python/pyspark-example.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: ($SPARK_APPLICATION_NAME)

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -83,7 +83,7 @@ spec:
         - events:
             namespace: default
         - describe:
-            apiVersion: spark.apache.org/v1beta1
+            apiVersion: spark.apache.org/v1
             kind: SparkApplication
             namespace: default
         - describe:

--- a/tests/e2e/spark-versions/spark-example.yaml
+++ b/tests/e2e/spark-versions/spark-example.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: ($SPARK_APPLICATION_NAME)

--- a/tests/e2e/state-transition/chainsaw-test.yaml
+++ b/tests/e2e/state-transition/chainsaw-test.yaml
@@ -47,7 +47,7 @@ spec:
         file: "../assertions/spark-application/spark-state-transition.yaml"
     catch:
     - describe:
-        apiVersion: spark.apache.org/v1beta1
+        apiVersion: spark.apache.org/v1
         kind: SparkApplication
         namespace: default
     finally:
@@ -72,7 +72,7 @@ spec:
         file: "../assertions/spark-cluster/spark-cluster-state-transition.yaml"
     catch:
     - describe:
-        apiVersion: spark.apache.org/v1beta1
+        apiVersion: spark.apache.org/v1
         kind: SparkCluster
         namespace: default
     finally:

--- a/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkCluster
 metadata:
   name: spark-cluster-succeeded-test

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-job-succeeded-test

--- a/tests/e2e/watched-namespaces/chainsaw-test.yaml
+++ b/tests/e2e/watched-namespaces/chainsaw-test.yaml
@@ -59,11 +59,11 @@ spec:
           namespace: default
           selector: app.kubernetes.io/component=operator-deployment,app.kubernetes.io/name=spark-kubernetes-operator
       - describe:
-          apiVersion: spark.apache.org/v1beta1
+          apiVersion: spark.apache.org/v1
           kind: SparkApplication
           namespace: spark-1
       - describe:
-          apiVersion: spark.apache.org/v1beta1
+          apiVersion: spark.apache.org/v1
           kind: SparkApplication
           namespace: spark-2
     finally:
@@ -103,7 +103,7 @@ spec:
           namespace: default-2
           selector: app.kubernetes.io/component=operator-deployment,app.kubernetes.io/name=spark-kubernetes-operator
       - describe:
-          apiVersion: spark.apache.org/v1beta1
+          apiVersion: spark.apache.org/v1
           kind: SparkApplication
           namespace: spark-3
       - get:

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: spark-job-succeeded-test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `Spark CRDs` from `v1beta1` to `v1` at Apache Spark K8s Operator `0.5.0`. After finalizing CRDs to `v1`, we are going to start to prepare `Apache Spark K8s Operator 1.0` release.

### Why are the changes needed?

To show the maturity of these CRDs according to K8s API versioning.
- https://kubernetes.io/docs/reference/using-api/

| Version | Description |
| -------  | ----------- |
| Alpha | The software is recommended for use only in short-lived testing clusters, <br> due to increased risk of bugs and lack of long-term support |
| Beta | The software is not recommended for production uses. <br> The support for a feature will not be dropped, though the details may change. |
| Stable | The version name is vX where X is an integer |

### Does this PR introduce _any_ user-facing change?

We support all `v1alpha`, `v1beta1`, and `v1` because they are identical.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.