### PR TITLE
[SPARK-52607] Add `pi-v1beta1.yaml` example

### DIFF
--- a/examples/pi-v1beta1.yaml
+++ b/examples/pi-v1beta1.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1beta1
+kind: SparkApplication
+metadata:
+  name: pi-v1beta1
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    sparkVersion: "4.0.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi-v1beta1.yaml` example.

```bash
$ diff examples/pi.yaml examples/pi-v1beta1.yaml
15c15
< apiVersion: spark.apache.org/v1
---
> apiVersion: spark.apache.org/v1beta1
18c18
<   name: pi
---
>   name: pi-v1beta1
```

### Why are the changes needed?

To give an example to support old versions.

```
$ ./gradlew build -x test

$ ./gradlew buildDockerImage

$ helm install spark -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/

$ kubectl apply -f examples/pi.yaml

$ kubectl apply -f examples/pi-v1alpha1.yaml

$ kubectl apply -f examples/pi-v1beta1.yaml

$ kubectl get sparkapp
NAME          CURRENT STATE      AGE
pi            ResourceReleased   92s
pi-v1alpha1   ResourceReleased   46s
pi-v1beta1    ResourceReleased   33s
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is an example.

### Was this patch authored or co-authored using generative AI tooling?

No.