### PR TITLE
[SPARK-52623] Add `spark.ui.port` to `Spark History Server` example

### DIFF
--- a/examples/spark-history-server.yaml
+++ b/examples/spark-history-server.yaml
@@ -24,6 +24,7 @@ spec:
     spark.driver.memory: "2g"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.0-java21-scala"
+    spark.ui.port: "18080"
     spark.history.fs.logDirectory: "s3a://spark-events"
     spark.history.fs.cleaner.enabled: "true"
     spark.history.fs.cleaner.maxAge: "30d"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `spark.ui.port` to `Spark History Server` example.

### Why are the changes needed?

To add `18080` to the K8s Service entity.

### Does this PR introduce _any_ user-facing change?

No, this is an example.

### How was this patch tested?

Manual test.

```
$ kubectl get sparkapp
NAME                   CURRENT STATE    AGE
spark-history-server   RunningHealthy   8m53s

$ kubectl get svc spark-history-server-0-driver-svc
NAME                                TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                       AGE
spark-history-server-0-driver-svc   ClusterIP   None         <none>        7078/TCP,7079/TCP,18080/TCP   8m55s
```

### Was this patch authored or co-authored using generative AI tooling?

No.