### PR TITLE
[SPARK-52624] Upgrade `spotbugs-tool` to 4.9.3 and `spotbugs-plugin` to 6.1.13

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,8 +31,8 @@ mockito = "5.18.0"
 # Build Analysis
 checkstyle = "10.23.1"
 pmd = "7.13.0"
-spotbugs-tool = "4.8.6"
-spotbugs-plugin = "6.0.17"
+spotbugs-tool = "4.9.3"
+spotbugs-plugin = "6.1.13"
 spotless-plugin = "6.25.0"
 
 # Packaging

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptorTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptorTest.java
@@ -50,7 +50,7 @@ import org.apache.spark.k8s.operator.spec.ApplicationSpec;
 @EnableKubernetesMockClient(crud = true)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SuppressFBWarnings(
-    value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD", "UUF_UNUSED_FIELD"},
+    value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD"},
     justification = "Unwritten fields are covered by Kubernetes mock client")
 class KubernetesMetricsInterceptorTest {
 

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
@@ -47,7 +47,7 @@ import org.apache.spark.k8s.operator.metrics.healthcheck.SentinelManager;
 
 @EnableKubernetesMockClient(crud = true)
 @SuppressFBWarnings(
-    value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD", "UUF_UNUSED_FIELD"},
+    value = {"UWF_UNWRITTEN_FIELD"},
     justification = "Unwritten fields are covered by Kubernetes mock client")
 class HealthProbeTest {
   private static Operator operator;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade
- `spotbugs-tool` from `4.8.6` to `4.9.3`
- `spotbugs-plugin` from `6.0.17` to 6.1.13

While updating the above, the following are fixed.

```
> Task :spark-operator:spotbugsTest FAILED
M D US: Suppressing annotation on the class org.apache.spark.k8s.operator.probe.HealthProbeTest is unnecessary  At HealthProbeTest.java:[lines 52-192]
M D US: Suppressing annotation on the class org.apache.spark.k8s.operator.metrics.source.KubernetesMetricsInterceptorTest is unnecessary  At KubernetesMetricsInterceptorTest.java:[lines 55-153]
```

### Why are the changes needed?

To bring the latest updates.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.