### PR TITLE
[SPARK-52664] Add `branch-0.4` to `publish_snapshot_*.yml` GitHub Action jobs

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main", "branch-0.1", "branch-0.2"]'
+        default: '["main", "branch-0.4"]'
 
 jobs:
   publish-snapshot-chart:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1", "branch-0.2"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.4"]' ) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main", "branch-0.1", "branch-0.2"]'
+        default: '["main", "branch-0.4"]'
 
 jobs:
   publish-snapshot-image:
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
-        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.1", "branch-0.2"]' ) }}
+        branch: ${{ fromJSON( inputs.branch || '["main", "branch-0.4"]' ) }}
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `branch-0.4` to `publish_snapshot_*.yml` GitHub Action jobs.

### Why are the changes needed?

To publish the latest snapshots (0.5.0-SNAPSHOT and 0.4.1-SNAPSHOT) instead of old 0.1.1-SNAPSHOT and 0.2.1-SNAPSHOT.
- https://github.com/apache/spark-kubernetes-operator/tree/branch-0.4

### Does this PR introduce _any_ user-facing change?

No, this is an infra change.

### How was this patch tested?

Since this is a daily job, this should be tested after merging into `main` branch.

### Was this patch authored or co-authored using generative AI tooling?

No.