### PR TITLE
[SPARK-52667] Improve `SparkAppReconciler` to show app names during cleaning up

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconciler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconciler.java
@@ -183,7 +183,7 @@ public class SparkAppReconciler implements Reconciler<SparkApplication>, Cleaner
     LoggingUtils.TrackedMDC trackedMDC = new LoggingUtils.TrackedMDC();
     try {
       trackedMDC.set(sparkApplication);
-      log.info("Cleaning up resources for SparkApp.");
+      log.info("Cleaning up resources for SparkApp:" + sparkApplication.getMetadata().getName());
       SparkAppContext ctx = new SparkAppContext(sparkApplication, context, submissionWorker);
       List<AppReconcileStep> cleanupSteps = new ArrayList<>();
       cleanupSteps.add(new AppValidateStep());
@@ -200,7 +200,7 @@ public class SparkAppReconciler implements Reconciler<SparkApplication>, Cleaner
         }
       }
     } finally {
-      log.info("Cleanup completed");
+      log.debug("Cleanup completed");
       trackedMDC.reset();
     }
     sparkAppStatusRecorder.removeCachedStatus(sparkApplication);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SparkAppReconciler` to show app names during cleaning up.

### Why are the changes needed?

**BEFORE**

```
25/07/03 05:54:22 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:22 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:22 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:22 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:23 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:23 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:23 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:23 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:23 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:23 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:23 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:23 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:23 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:23 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:24 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:24 INFO SparkAppReconciler: Cleanup completed
25/07/03 05:54:24 INFO SparkAppReconciler: Cleaning up resources for SparkApp.
25/07/03 05:54:24 INFO SparkAppReconciler: Cleanup completed
```

**AFTER**
```
25/07/03 06:06:57 INFO SparkAppReconciler: Cleaning up resources for SparkApp:pi
25/07/03 06:07:02 INFO SparkAppReconciler: Cleaning up resources for SparkApp:pi-java21
```

### Does this PR introduce _any_ user-facing change?

No behavior change. This is only changing log message information.

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

No.