### PR TITLE
[SPARK-52668] Set `(Initial|Max)RAMPercentage` to 80% by default

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -41,7 +41,7 @@ operatorDeployment:
     # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     topologySpreadConstraints: [ ]
     operatorContainer:
-      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC"
+      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80"
       env:
         - name: "SPARK_USER"
           value: "spark"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `(Initial|Max)RAMPercentage` Java option to `80%` by default.

### Why are the changes needed?

1. Af the pod creation time, this will be determined automatically based on the user-provided pod memory size.
2. During runtime, this will reduce GC resizing overhead because we have a fixed size.

### Does this PR introduce _any_ user-facing change?

Only JVM GC behavior changes.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.