### PR TITLE
[SPARK-52676] Use Java 21 for `SparkApp` benchmark

### DIFF
--- a/tests/benchmark/sparkapps.sh
+++ b/tests/benchmark/sparkapps.sh
@@ -42,7 +42,7 @@ spec:
     spark.kubernetes.driver.request.memory: "100Mi"
     spark.kubernetes.driver.master: "local[1]"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.0"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-java21-scala"
   runtimeVersions:
     sparkVersion: "4.0.0"
 ---


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 21 for `SparkApp` benchmark.

### Why are the changes needed?


**BEFORE**

```
$ docker run -it --rm apache/spark:4.0.0 java --version
openjdk 17.0.15 2025-04-15
OpenJDK Runtime Environment Temurin-17.0.15+6 (build 17.0.15+6)
```

**AFTER**

```
$ docker run -it --rm apache/spark:4.0.0-java21-scala java --version
openjdk 21.0.7 2025-04-15 LTS
OpenJDK Runtime Environment Temurin-21.0.7+6 (build 21.0.7+6-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.7+6 (build 21.0.7+6-LTS, mixed mode, sharing)
```

In addition, this PR uses the smaller image because we don't need Python.
```
$ docker images | grep apache/spark
apache/spark      4.0.0                                      d25d55f20f67   9 days ago      1.25GB
apache/spark      4.0.0-java21-scala                         94b89e5b436d   9 days ago      977MB
```


### Does this PR introduce _any_ user-facing change?

No, this is a test change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.