### PR TITLE
[SPARK-52679] Revise `appender.console.layout.pattern` to include MDC keys and thread name

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -176,7 +176,7 @@ operatorConfiguration:
     appender.console.name = console
     appender.console.target = SYSTEM_ERR
     appender.console.layout.type = PatternLayout
-    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X %C{1.} [%t] %m%n%ex
   spark-operator.properties: |+
     # Property Overrides. e.g.
     # spark.kubernetes.operator.reconciler.intervalSeconds=60


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates default log4j properties in  Operator helm chart, to make sure it surfaces MDC keys and thread name as needed

### Why are the changes needed?

The layout does not include all MDC keys which would provide critical information regarding the resource being reconciled.

### Does this PR introduce _any_ user-facing change?

Logging enhancements expected for operator

### How was this patch tested?

CIs for lint, and validated logging in dev environments

### Was this patch authored or co-authored using generative AI tooling?

No