### PR TITLE
[SPARK-52755] Remove `ConfigMap` informer from config reconciler

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ shadow-jar-plugin = "8.3.6"
 kubernetes-client = { group = "io.fabric8", name = "kubernetes-client", version.ref = "fabric8" }
 kubernetes-httpclient-okhttp = { group = "io.fabric8", name = "kubernetes-httpclient-okhttp", version.ref = "fabric8" }
 kubernetes-server-mock = { group = "io.fabric8", name = "kubernetes-server-mock", version.ref = "fabric8" }
-kube-api-test = {group = "io.fabric8", name = "kube-api-test-client-inject", version.ref = "fabric8"}
+kube-api-test-client-inject = {group = "io.fabric8", name = "kube-api-test-client-inject", version.ref = "fabric8"}
 crd-generator-apt = { group = "io.fabric8", name = "crd-generator-apt", version.ref = "fabric8" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ shadow-jar-plugin = "8.3.6"
 kubernetes-client = { group = "io.fabric8", name = "kubernetes-client", version.ref = "fabric8" }
 kubernetes-httpclient-okhttp = { group = "io.fabric8", name = "kubernetes-httpclient-okhttp", version.ref = "fabric8" }
 kubernetes-server-mock = { group = "io.fabric8", name = "kubernetes-server-mock", version.ref = "fabric8" }
+kube-api-test = {group = "io.fabric8", name = "kube-api-test-client-inject", version.ref = "fabric8"}
 crd-generator-apt = { group = "io.fabric8", name = "crd-generator-apt", version.ref = "fabric8" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -80,7 +80,7 @@ dependencies {
   testRuntimeOnly(libs.junit.platform.launcher)
 
   testImplementation(libs.mockito.core)
-  testImplementation(libs.kube.api.test)
+  testImplementation(libs.kube.api.test.client.inject)
 }
 
 test {

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -80,6 +80,7 @@ dependencies {
   testRuntimeOnly(libs.junit.platform.launcher)
 
   testImplementation(libs.mockito.core)
+  testImplementation(libs.kube.api.test)
 }
 
 test {

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -128,9 +128,7 @@ public class SparkOperator {
         confSelector);
     op.register(
         new SparkOperatorConfigMapReconciler(
-            this::updateWatchingNamespaces,
-            SparkOperatorConf.OPERATOR_NAMESPACE.getValue(),
-            unused -> getWatchedNamespaces()),
+            this::updateWatchingNamespaces, unused -> getWatchedNamespaces()),
         c -> {
           c.withRateLimiter(SparkOperatorConf.getOperatorRateLimiter());
           c.settingNamespaces(operatorNamespace);

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java
@@ -19,22 +19,17 @@
 
 package org.apache.spark.k8s.operator.config;
 
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.javaoperatorsdk.operator.api.config.informer.Informer;
-import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
-import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconciler.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.javaoperatorsdk.operator.api.config.informer.Informer;
-import io.javaoperatorsdk.operator.api.reconciler.Constants;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
@@ -38,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
  * is located in given config map. It would keep watch the config map and apply changes when update
  * is detected.
  */
-@ControllerConfiguration(informer = @Informer(name = Constants.WATCH_CURRENT_NAMESPACE))
+@ControllerConfiguration
 @RequiredArgsConstructor
 @Slf4j
 public class SparkOperatorConfigMapReconciler implements Reconciler<ConfigMap> {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -1,0 +1,63 @@
+package org.apache.spark.k8s.operator.config;
+
+import static org.apache.spark.k8s.operator.config.SparkOperatorConf.RECONCILER_INTERVAL_SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.Operator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@EnableKubeAPIServer
+class SparkOperatorConfigMapReconcilerTest {
+
+  public static final Long TARGET_RECONCILER_INTERVAL = 60L;
+  static KubernetesClient client;
+
+  Operator operator;
+
+  @BeforeEach
+  void startController() {
+    var namespaceUpdater = mock(Function.class);
+    var watchedNamespaceGetter = mock(Function.class);
+
+    var reconciler = new SparkOperatorConfigMapReconciler(namespaceUpdater, watchedNamespaceGetter);
+    operator = new Operator(o -> o.withKubernetesClient(client));
+    operator.register(reconciler);
+    operator.start();
+  }
+
+  @AfterEach
+  void stopController() {
+    operator.stop();
+  }
+
+  @Test
+  void sanityTest() {
+    client.resource(testConfigMap()).create();
+
+    await()
+        .untilAsserted(
+            () -> {
+              assertThat(RECONCILER_INTERVAL_SECONDS.getValue()).isEqualTo(60L);
+            });
+  }
+
+  ConfigMap testConfigMap() {
+    ConfigMap configMap = new ConfigMap();
+    configMap.setMetadata(
+        new ObjectMetaBuilder().withName("spark-conf").withNamespace("default").build());
+    configMap.setData(
+        Map.of(RECONCILER_INTERVAL_SECONDS.getKey(), TARGET_RECONCILER_INTERVAL.toString()));
+    return configMap;
+  }
+}

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import java.util.Map;
 import java.util.function.Function;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
@@ -17,20 +18,22 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@SuppressFBWarnings(
+    value = {"UWF_UNWRITTEN_FIELD"},
+    justification = "Unwritten fields are covered by Kubernetes mock client")
 @EnableKubeAPIServer
 class SparkOperatorConfigMapReconcilerTest {
 
   public static final Long TARGET_RECONCILER_INTERVAL = 60L;
-  static KubernetesClient client;
+
+  private static KubernetesClient client;
 
   Operator operator;
 
   @BeforeEach
   void startController() {
-    var namespaceUpdater = mock(Function.class);
-    var watchedNamespaceGetter = mock(Function.class);
-
-    var reconciler = new SparkOperatorConfigMapReconciler(namespaceUpdater, watchedNamespaceGetter);
+    var reconciler =
+        new SparkOperatorConfigMapReconciler(mock(Function.class), mock(Function.class));
     operator = new Operator(o -> o.withKubernetesClient(client));
     operator.register(reconciler);
     operator.start();

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -31,6 +31,7 @@ class SparkOperatorConfigMapReconcilerTest {
   Operator operator;
 
   @BeforeEach
+  @SuppressWarnings("unchecked")
   void startController() {
     var reconciler =
         new SparkOperatorConfigMapReconciler(mock(Function.class), mock(Function.class));
@@ -53,6 +54,8 @@ class SparkOperatorConfigMapReconcilerTest {
             () -> {
               assertThat(RECONCILER_INTERVAL_SECONDS.getValue()).isEqualTo(60L);
             });
+    // adding this here to make pmd happy
+    assertThat(RECONCILER_INTERVAL_SECONDS.getValue()).isEqualTo(60L);
   }
 
   ConfigMap testConfigMap() {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -65,6 +65,7 @@ class SparkOperatorConfigMapReconcilerTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
   void sanityTest() {
     client.resource(testConfigMap()).create();
 
@@ -73,8 +74,6 @@ class SparkOperatorConfigMapReconcilerTest {
             () -> {
               assertThat(RECONCILER_INTERVAL_SECONDS.getValue()).isEqualTo(60L);
             });
-    // adding this here to make pmd happy
-    assertThat(RECONCILER_INTERVAL_SECONDS.getValue()).isEqualTo(60L);
   }
 
   ConfigMap testConfigMap() {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.spark.k8s.operator.config;
 
 import static org.apache.spark.k8s.operator.config.SparkOperatorConf.RECONCILER_INTERVAL_SECONDS;


### PR DESCRIPTION
### What changes were proposed in this pull request?

PR removes unnecessary informer for the configuration `SparkOperatorConfigMapReconciler`.
It adds a sanity test using `KubeApiTest`.

### Why are the changes needed?

Having additional informer might effect performance, memory consumption, also maintains an additiona websocket connection to Kubernetes API.

### Does this PR introduce _any_ user-facing change?

No, but introduces new way of testing.


### How was this patch tested?

With an integration test.

### Was this patch authored or co-authored using generative AI tooling?

No
