### PR TITLE
[SPARK-52827] Add `pi-with-template.yaml` example

### DIFF
--- a/examples/pi-with-template.yaml
+++ b/examples/pi-with-template.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-with-template
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.0-scala"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  driverSpec:
+    podTemplateSpec:
+      spec:
+        priorityClassName: system-cluster-critical
+        terminationGracePeriodSeconds: 0
+  executorSpec:
+    podTemplateSpec:
+      spec:
+        priorityClassName: system-cluster-critical
+        terminationGracePeriodSeconds: 0
+  runtimeVersions:
+    sparkVersion: "4.0.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi-with-template.yaml` example to illustrate `podTemplateSpec` in addition to the docs.

### Why are the changes needed?

This is frequently used to specify `priorityClassName` and other K8s spec like the following.

```yaml
  driverSpec:
    podTemplateSpec:
      spec:
        priorityClassName: system-cluster-critical
        terminationGracePeriodSeconds: 0
  executorSpec:
    podTemplateSpec:
      spec:
        priorityClassName: system-cluster-critical
        terminationGracePeriodSeconds: 0
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test.

### Was this patch authored or co-authored using generative AI tooling?

No.