### PR TITLE
[SPARK-52831] Revise the default logging layout to include only name & namespace MDC Keys

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -176,7 +176,7 @@ operatorConfiguration:
     appender.console.name = console
     appender.console.target = SYSTEM_ERR
     appender.console.layout.type = PatternLayout
-    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X %C{1.} [%t] %m%n%ex
+    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X{resource.name} %X{resource.namespace} %C{1.} %m%n%ex
   spark-operator.properties: |+
     # Property Overrides. e.g.
     # spark.kubernetes.operator.reconciler.intervalSeconds=60


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the default layout in operator helm chart, to make it include only the resource name and namespace MDC keys instead of all

### Why are the changes needed?

The current logging is extremely verbose by default:

```
25/07/16 22:47:03 INFO {resource.apiVersion=spark.apache.org/v1, resource.app.attemptId=0, resource.generation=2, resource.kind=SparkApplication, resource.name=test-00553, resource.namespace=default, resource.resourceVersion=77206, resource.uid=c8c40a69-7397-4230-8bef-701c25436b54} o.a.s.k.o.r.SparkAppReconciler [ReconcilerExecutor-sparkappreconciler-73] Cleaning up resources for SparkApp:test-00553
25/07/16 22:47:03 INFO {resource.apiVersion=spark.apache.org/v1, resource.app.attemptId=0, resource.generation=2, resource.kind=SparkApplication, resource.name=test-00554, resource.namespace=default, resource.resourceVersion=77208, resource.uid=e007ca5f-94c0-4c30-8e1e-543aafb65c67} o.a.s.k.o.r.SparkAppReconciler [ReconcilerExecutor-sparkappreconciler-52] Cleaning up resources for SparkApp:test-00554
25/07/16 22:47:03 INFO {resource.apiVersion=spark.apache.org/v1, resource.app.attemptId=0, resource.generation=2, resource.kind=SparkApplication, resource.name=test-00555, resource.namespace=default, resource.resourceVersion=77211, resource.uid=7ea87cb4-6dca-43be-be08-ac9dca335912} o.a.s.k.o.r.SparkAppReconciler [ReconcilerExecutor-sparkappreconciler-69] Cleaning up resources for SparkApp:test-00555

```

With this patch, logging would include only resource name and namespace (which are most critical)

```
25/07/16 16:18:35 INFO {resource.name=pi, resource.namespace=default} o.a.s.k.o.r.SparkAppReconciler Cleaning up resources for SparkApp:pi
```

users may still override the values to include more keys as needed. This is to make sure we have informational and concise logging by default.

### Does this PR introduce _any_ user-facing change?

Logging enhancements expected for operator

### How was this patch tested?

CIs for lint, and validated logging in dev environments

### Was this patch authored or co-authored using generative AI tooling?

No

