### PR TITLE
[SPARK-52834] Improve `ProbeService` to show the port number

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/probe/ProbeService.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/probe/ProbeService.java
@@ -53,7 +53,7 @@ public class ProbeService {
   }
 
   public void start() {
-    log.info("Probe service started");
+    log.info("Probe service started at " + OPERATOR_PROBE_PORT.getValue());
     server.start();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `ProbeService` to show the port number.

### Why are the changes needed?

We had better show the live port number because a user can customize the port number with `spark.kubernetes.operator.health.probePort`.

### Does this PR introduce _any_ user-facing change?

No, this is only a log info.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.