### PR TITLE
[SPARK-52915] Support TTL for Spark apps

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/crds/sparkapplications.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/crds/sparkapplications.spark.apache.org-v1.yaml
@@ -17434,6 +17434,9 @@ spec:
                             - OnInfrastructureFailure
                           type: string
                       type: object
+                    ttlAfterStopMillis:
+                      default: -1
+                      type: integer
                   type: object
                 configMapSpecs:
                   items:

--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -293,6 +293,8 @@ applicationTolerations:
   resourceRetainPolicy: OnFailure
   # Secondary resources would be garbage collected 10 minutes after app termination 
   resourceRetainDurationMillis: 600000
+  # Garbage collect the SparkApplication custom resource itself 30 minutes after termination
+  ttlAfterStopMillis: 1800000
 ```
 
 to avoid operator attempt to delete driver pod and driver resources if app fails. Similarly,
@@ -302,7 +304,11 @@ possible to configure `resourceRetainDurationMillis` to define the maximal retai
 these resources. Note that this applies only to operator-created resources (driver pod, SparkConf
 configmap .etc). You may also want to tune `spark.kubernetes.driver.service.deleteOnTermination`
 and `spark.kubernetes.executor.deleteOnTermination` to control the behavior of driver-created
-resources.
+resources. `ttlAfterStopMillis` controls the garbage collection behavior at the SparkApplication
+level after it stops. When set to a non-negative value, Spark operator would garbage collect the
+application (and therefore all its associated resources) after given timeout. If the application
+is configured to restart, `resourceRetainPolicy`, `resourceRetainDurationMillis` and
+`ttlAfterStopMillis` would be applied only to the last attempt.
 
 ## Spark Cluster
 

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationTolerationsTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationTolerationsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.spec;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ApplicationTolerationsTest {
+  private final ApplicationTolerations withRetainDurationOnly =
+      ApplicationTolerations.builder().resourceRetainDurationMillis(10L).build();
+  private final ApplicationTolerations withTTLOnly =
+      ApplicationTolerations.builder().ttlAfterStopMillis(10L).build();
+  private final ApplicationTolerations withNeitherRetainDurationNorTtl =
+      ApplicationTolerations.builder().build();
+  private final ApplicationTolerations withRetainDurationGreaterThanTtl =
+      ApplicationTolerations.builder()
+          .resourceRetainDurationMillis(20L)
+          .ttlAfterStopMillis(10L)
+          .build();
+  private final ApplicationTolerations withRetainDurationShorterThanTtl =
+      ApplicationTolerations.builder()
+          .resourceRetainDurationMillis(10L)
+          .ttlAfterStopMillis(20L)
+          .build();
+
+  @Test
+  void computeEffectiveRetainDurationMillis() {
+    assertEquals(10L, withRetainDurationOnly.computeEffectiveRetainDurationMillis());
+    assertEquals(10L, withTTLOnly.computeEffectiveRetainDurationMillis());
+    assertEquals(-1, withNeitherRetainDurationNorTtl.computeEffectiveRetainDurationMillis());
+    assertEquals(10L, withRetainDurationGreaterThanTtl.computeEffectiveRetainDurationMillis());
+    assertEquals(10L, withRetainDurationShorterThanTtl.computeEffectiveRetainDurationMillis());
+  }
+
+  @Test
+  void isRetainDurationEnabled() {
+    assertTrue(withRetainDurationOnly.isRetainDurationEnabled());
+    assertTrue(withTTLOnly.isRetainDurationEnabled());
+    assertFalse(withNeitherRetainDurationNorTtl.isRetainDurationEnabled());
+    assertTrue(withRetainDurationGreaterThanTtl.isRetainDurationEnabled());
+    assertTrue(withRetainDurationShorterThanTtl.isRetainDurationEnabled());
+  }
+
+  @Test
+  void isTTLEnabled() {
+    assertFalse(withRetainDurationOnly.isTTLEnabled());
+    assertTrue(withTTLOnly.isTTLEnabled());
+    assertFalse(withNeitherRetainDurationNorTtl.isTTLEnabled());
+    assertTrue(withRetainDurationGreaterThanTtl.isTTLEnabled());
+    assertTrue(withRetainDurationShorterThanTtl.isTTLEnabled());
+  }
+}

--- a/tests/e2e/resource-retain-duration/chainsaw-test.yaml
+++ b/tests/e2e/resource-retain-duration/chainsaw-test.yaml
@@ -41,6 +41,14 @@ spec:
             value: default
         timeout: 120s
         file: "../assertions/spark-application/spark-state-transition-with-retain-check.yaml"
+    - wait:
+        apiVersion: spark.apache.org/v1
+        kind: SparkApplication
+        namespace: default
+        name: ($SPARK_APPLICATION_NAME)
+        for:
+          deletion: {}
+        timeout: 60s
     catch:
     - describe:
         apiVersion: spark.apache.org/v1
@@ -53,4 +61,4 @@ spec:
             value: ($SPARK_APPLICATION_NAME)
         timeout: 120s
         content: |
-          kubectl delete sparkapplication $SPARK_APPLICATION_NAME
+          kubectl delete sparkapplication $SPARK_APPLICATION_NAME --ignore-not-found=true 

--- a/tests/e2e/resource-retain-duration/spark-example-retain-duration.yaml
+++ b/tests/e2e/resource-retain-duration/spark-example-retain-duration.yaml
@@ -26,6 +26,7 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: Always
     resourceRetainDurationMillis: 10000
+    ttlAfterStopMillis: 30000
   sparkConf:
     spark.executor.instances: "1"
     spark.kubernetes.container.image: "apache/spark:4.0.0-java21-scala"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for configuring the ttl for Spark apps after it stops. Working with the `resourceRetainPolicy` and `resourceRetainDurationMillis`, it enhances the garbage collection mechanism at the custom resource level.

### Why are the changes needed?

Introducing TTL helps user to more effectively configure the garbage collection for apps.

### Does this PR introduce _any_ user-facing change?

New configurable field spec.applicationTolerations.ttlAfterStopMillis added to SparkApplication CRD

### How was this patch tested?

CIs - including new unit test and revised e2e scenario

### Was this patch authored or co-authored using generative AI tooling?

No

