### PR TITLE
[SPARK-53026] Fix deserialize error for spec with DriverServiceIngressSpec field

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/DriverServiceIngressSpec.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/DriverServiceIngressSpec.java
@@ -25,13 +25,17 @@ import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressSpec;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /** Spec for a driver service ingress. */
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DriverServiceIngressSpec {
   @Required protected ObjectMeta serviceMetadata;

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
@@ -22,7 +22,11 @@ package org.apache.spark.k8s.operator.spec;
 import static org.apache.spark.k8s.operator.spec.DeploymentMode.ClusterMode;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 class ApplicationSpecTest {
   @Test
@@ -45,5 +49,23 @@ class ApplicationSpecTest {
     assertEquals(0, tolerations.instanceConfig.initExecutors);
     assertEquals(0, tolerations.instanceConfig.minExecutors);
     assertEquals(0, tolerations.instanceConfig.maxExecutors);
+  }
+
+  @Test
+  void testSpecWithDriverServiceIngressList() throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    InputStream inputStream =
+                 getClass().getClassLoader().getResourceAsStream("spark-job-with-driver-service" +
+                         "-ingress.json");
+    ApplicationSpec spec = objectMapper.readValue(inputStream, ApplicationSpec.class);
+    assertNotNull(spec.getDriverServiceIngressList());
+    assertEquals(1, spec.getDriverServiceIngressList().size());
+
+    DriverServiceIngressSpec driverServiceIngress = spec.getDriverServiceIngressList().get(0);
+    assertNotNull(driverServiceIngress.getIngressMetadata());
+    assertNotNull(driverServiceIngress.getIngressSpec());
+    assertNotNull(driverServiceIngress.getServiceSpec());
+    assertNotNull(driverServiceIngress.getServiceMetadata());
   }
 }

--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
@@ -22,11 +22,11 @@ package org.apache.spark.k8s.operator.spec;
 import static org.apache.spark.k8s.operator.spec.DeploymentMode.ClusterMode;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.io.InputStream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 
 class ApplicationSpecTest {
   @Test
@@ -56,8 +56,9 @@ class ApplicationSpecTest {
     ObjectMapper objectMapper = new ObjectMapper();
 
     InputStream inputStream =
-                 getClass().getClassLoader().getResourceAsStream("spark-job-with-driver-service" +
-                         "-ingress.json");
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream("spark-job-with-driver-service" + "-ingress.json");
     ApplicationSpec spec = objectMapper.readValue(inputStream, ApplicationSpec.class);
     assertNotNull(spec.getDriverServiceIngressList());
     assertEquals(1, spec.getDriverServiceIngressList().size());

--- a/spark-operator-api/src/test/resources/spark-job-with-driver-service-ingress.json
+++ b/spark-operator-api/src/test/resources/spark-job-with-driver-service-ingress.json
@@ -1,0 +1,59 @@
+{
+  "mainClass": "org.apache.spark.examples.SparkPi",
+  "jars": "local:///opt/spark/examples/jars/spark-examples.jar",
+  "sparkConf": {
+    "spark.kubernetes.driver.master": "local[10]",
+    "spark.kubernetes.driver.request.cores": "5",
+    "spark.kubernetes.driver.limit.cores": "5",
+    "spark.kubernetes.authenticate.driver.serviceAccountName": "spark",
+    "spark.kubernetes.container.image": "apache/spark:4.0.0"
+  },
+  "runtimeVersions": {
+    "sparkVersion": "4.0.0"
+  },
+  "driverServiceIngressList": [
+    {
+      "serviceMetadata": {
+        "name": "spark-ui-service"
+      },
+      "serviceSpec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 4040
+          }
+        ]
+      },
+      "ingressMetadata": {
+        "name": "spark-ui-ingress",
+        "annotations": {
+          "nginx.ingress.kubernetes.io/rewrite-target": "/"
+        }
+      },
+      "ingressSpec": {
+        "ingressClassName": "nginx-example",
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/",
+                  "pathType": "Prefix",
+                  "backend": {
+                    "service": {
+                      "name": "spark-ui-service",
+                      "port": {
+                        "number": 80
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
Add two annotations for DriverServiceIngressSpec constructor


### Why are the changes needed?
Without the annotation, when applying the spec with DriverServiceIngressSpec, deserialization failed.



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
unit test

### Was this patch authored or co-authored using generative AI tooling?
no
