### PR TITLE
[SPARK-53159] Declare metrics port for operator in helm chart

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl
+++ b/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl
@@ -114,6 +114,7 @@ Default property overrides
 spark.kubernetes.operator.namespace={{ .Release.Namespace }}
 spark.kubernetes.operator.name={{- include "spark-operator.name" . }}
 spark.kubernetes.operator.dynamicConfig.enabled={{ .Values.operatorConfiguration.dynamicConfig.enable }}
+spark.kubernetes.operator.metrics.port={{ include "spark-operator.metricsPort" . }}
 {{- if .Values.workloadResources.namespaces.overrideWatchedNamespaces }}
 spark.kubernetes.operator.watchedNamespaces={{ include "spark-operator.workloadNamespacesStr" . | trim }}
 {{- end }}
@@ -144,4 +145,11 @@ Readiness Probe property overrides
 */}}
 {{- define "spark-operator.probePort" -}}
 {{- default 19091 .Values.operatorDeployment.operatorPod.operatorContainer.probes.port }}
+{{- end }}
+
+{{/*
+Port for metrics
+*/}}
+{{- define "spark-operator.metricsPort" -}}
+{{- default 19090 .Values.operatorDeployment.operatorPod.operatorContainer.metrics.port }}
 {{- end }}

--- a/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
@@ -80,6 +80,8 @@ spec:
           ports:
             - containerPort: {{ include "spark-operator.probePort" . }}
               name: probe-port
+            - containerPort: {{ include "spark-operator.metricsPort" . }}
+              name: metrics-port
           env:
             - name: OPERATOR_NAMESPACE
               valueFrom:

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -64,6 +64,8 @@ operatorDeployment:
         startupProbe:
           failureThreshold: 30
           periodSeconds: 10
+      metrics:
+        port: 19090
       # By default, operator container is configured to comply restricted standard
       # https://kubernetes.io/docs/concepts/security/pod-security-standards/
       securityContext:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Spark Operator provides prometheus format metrics by default. This PR adds metrics port spec to the operator helm chart.

### Why are the changes needed?

Declaring the port in spec for better clarity and maintainability.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CIs, helm lint, and local testing

### Was this patch authored or co-authored using generative AI tooling?

No

