### PR TITLE
[SPARK-53186] Fix probe port override from helm chart

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl
+++ b/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl
@@ -115,6 +115,7 @@ spark.kubernetes.operator.namespace={{ .Release.Namespace }}
 spark.kubernetes.operator.name={{- include "spark-operator.name" . }}
 spark.kubernetes.operator.dynamicConfig.enabled={{ .Values.operatorConfiguration.dynamicConfig.enable }}
 spark.kubernetes.operator.metrics.port={{ include "spark-operator.metricsPort" . }}
+spark.kubernetes.operator.health.probePort={{ include "spark-operator.probePort" . }}
 {{- if .Values.workloadResources.namespaces.overrideWatchedNamespaces }}
 spark.kubernetes.operator.watchedNamespaces={{ include "spark-operator.workloadNamespacesStr" . | trim }}
 {{- end }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a bug fix to apply the health probe port from helm chart value override onto operator config

### Why are the changes needed?

Without this patch, the port override - if  set in value.yaml - is only applied to operator container spec but not applied in config, would cause probe failures thereafter

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CIs, helm lint, and local testing

### Was this patch authored or co-authored using generative AI tooling?

No

