### PR TITLE
[SPARK-53245] Update Java Operator SDK version to 5.1.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.3.1"
 lombok = "1.18.38"
-operator-sdk = "5.1.1"
+operator-sdk = "5.1.2"
 okhttp = "4.12.0"
 dropwizard-metrics = "4.2.30"
 spark = "4.0.0"


### PR DESCRIPTION
Bumps JOSDK version to 5.1.2

contains an important fix for
https://github.com/operator-framework/java-operator-sdk/issues/2869

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

default test suit


### Was this patch authored or co-authored using generative AI tooling?

No
