### PR TITLE
[SPARK-53405] Add metrics recording for latency of Spark app state transition

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,20 @@ via [Codahale JVM Metrics](https://javadoc.io/doc/com.codahale.metrics/metrics-j
 | kubernetes.client.`ResourceName`.`Method`                 | Meter      | Tracking the rates of HTTP request for a combination of one Kubernetes resource and one http method                      |
 | kubernetes.client.`NamespaceName`.`ResourceName`.`Method` | Meter      | Tracking the rates of HTTP request for a combination of one namespace-scoped Kubernetes resource and one http method     |
 
+### Latency for State Transition
+
+Spark Operator also measures the latency between each state transition for apps, in the format of
+
+| Metrics Name                                         | Type  | Description                                                      |
+|------------------------------------------------------|-------|------------------------------------------------------------------|
+| sparkapp.latency.from.`<fromState>`.to.`<toState>`   | Timer | Tracking latency for app of transition from one state to another |
+
+The latency metrics can be used to provide insights about time spent in each state. For example, a
+long latency between `DriverRequested` and `DriverStarted` indicates overhead for driver pod to be
+scheduled. Latency between `DriverStarted` and `DriverReady` indicates overhead to pull image, to
+run init containers and to start SparkSession. These metrics can be used to analyze the overhead
+from multiple dimensions.
+
 ### Forward Metrics to Prometheus
 
 In this section, we will show you how to forward Spark Operator metrics

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -46,6 +46,7 @@ import org.apache.spark.k8s.operator.config.SparkOperatorConfigMapReconciler;
 import org.apache.spark.k8s.operator.metrics.MetricsService;
 import org.apache.spark.k8s.operator.metrics.MetricsSystem;
 import org.apache.spark.k8s.operator.metrics.MetricsSystemFactory;
+import org.apache.spark.k8s.operator.metrics.SparkAppStatusRecorderSource;
 import org.apache.spark.k8s.operator.metrics.healthcheck.SentinelManager;
 import org.apache.spark.k8s.operator.metrics.source.KubernetesMetricsInterceptor;
 import org.apache.spark.k8s.operator.metrics.source.OperatorJosdkMetrics;
@@ -83,7 +84,10 @@ public class SparkOperator {
         KubernetesClientFactory.buildKubernetesClient(getClientInterceptors(metricsSystem));
     this.appSubmissionWorker = new SparkAppSubmissionWorker();
     this.clusterSubmissionWorker = new SparkClusterSubmissionWorker();
-    this.sparkAppStatusRecorder = new SparkAppStatusRecorder(getAppStatusListener());
+    SparkAppStatusRecorderSource recorderSource = new SparkAppStatusRecorderSource();
+    this.metricsSystem.registerSource(recorderSource);
+    this.sparkAppStatusRecorder =
+        new SparkAppStatusRecorder(getAppStatusListener(), recorderSource);
     this.sparkClusterStatusRecorder = new SparkClusterStatusRecorder(getClusterStatusListener());
     this.registeredSparkControllers = new HashSet<>();
     this.watchedNamespaces = getWatchedNamespaces();

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/BaseOperatorSource.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/BaseOperatorSource.java
@@ -37,8 +37,9 @@ public class BaseOperatorSource {
   protected final Map<String, Gauge<?>> gauges = new ConcurrentHashMap<>();
   protected final Map<String, Timer> timers = new ConcurrentHashMap<>();
 
-  protected Histogram getHistogram(String metricName) {
+  protected Histogram getHistogram(String metricNamePrefix, String... names) {
     Histogram histogram;
+    String metricName = MetricRegistry.name(metricNamePrefix, names).toLowerCase();
     if (histograms.containsKey(metricName)) {
       histogram = histograms.get(metricName);
     } else {
@@ -48,8 +49,9 @@ public class BaseOperatorSource {
     return histogram;
   }
 
-  protected Counter getCounter(String metricName) {
+  protected Counter getCounter(String metricNamePrefix, String... names) {
     Counter counter;
+    String metricName = MetricRegistry.name(metricNamePrefix, names).toLowerCase();
     if (counters.containsKey(metricName)) {
       counter = counters.get(metricName);
     } else {
@@ -59,8 +61,9 @@ public class BaseOperatorSource {
     return counter;
   }
 
-  protected Gauge<?> getGauge(Gauge<?> defaultGauge, String metricName) {
+  protected Gauge<?> getGauge(Gauge<?> defaultGauge, String metricNamePrefix, String... names) {
     Gauge<?> gauge;
+    String metricName = MetricRegistry.name(metricNamePrefix, names).toLowerCase();
     if (gauges.containsKey(metricName)) {
       gauge = gauges.get(metricName);
     } else {
@@ -70,8 +73,9 @@ public class BaseOperatorSource {
     return gauge;
   }
 
-  protected Timer getTimer(String metricName) {
+  protected Timer getTimer(String metricNamePrefix, String... names) {
     Timer timer;
+    String metricName = MetricRegistry.name(metricNamePrefix, names).toLowerCase();
     if (timers.containsKey(metricName)) {
       timer = timers.get(metricName);
     } else {
@@ -81,7 +85,7 @@ public class BaseOperatorSource {
     return timer;
   }
 
-  public String getMetricName(Class<?> klass, String... names) {
-    return MetricRegistry.name(klass.getSimpleName(), names).toLowerCase();
+  protected String getMetricNamePrefix(Class<?> klass) {
+    return klass.getSimpleName();
   }
 }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/BaseOperatorSource.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/BaseOperatorSource.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.metrics;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BaseOperatorSource {
+  protected final MetricRegistry metricRegistry;
+  protected final Map<String, Histogram> histograms = new ConcurrentHashMap<>();
+  protected final Map<String, Counter> counters = new ConcurrentHashMap<>();
+  protected final Map<String, Gauge<?>> gauges = new ConcurrentHashMap<>();
+  protected final Map<String, Timer> timers = new ConcurrentHashMap<>();
+
+  protected Histogram getHistogram(String metricName) {
+    Histogram histogram;
+    if (histograms.containsKey(metricName)) {
+      histogram = histograms.get(metricName);
+    } else {
+      histogram = metricRegistry.histogram(metricName);
+      histograms.put(metricName, histogram);
+    }
+    return histogram;
+  }
+
+  protected Counter getCounter(String metricName) {
+    Counter counter;
+    if (counters.containsKey(metricName)) {
+      counter = counters.get(metricName);
+    } else {
+      counter = metricRegistry.counter(metricName);
+      counters.put(metricName, counter);
+    }
+    return counter;
+  }
+
+  protected Gauge<?> getGauge(Gauge<?> defaultGauge, String metricName) {
+    Gauge<?> gauge;
+    if (gauges.containsKey(metricName)) {
+      gauge = gauges.get(metricName);
+    } else {
+      gauge = defaultGauge;
+      gauges.put(metricName, defaultGauge);
+    }
+    return gauge;
+  }
+
+  protected Timer getTimer(String metricName) {
+    Timer timer;
+    if (timers.containsKey(metricName)) {
+      timer = timers.get(metricName);
+    } else {
+      timer = metricRegistry.timer(metricName);
+      timers.put(metricName, timer);
+    }
+    return timer;
+  }
+
+  public String getMetricName(Class<?> klass, String... names) {
+    return MetricRegistry.name(klass.getSimpleName(), names).toLowerCase();
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSource.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSource.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.metrics;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.apache.spark.k8s.operator.status.ApplicationState;
+import org.apache.spark.k8s.operator.status.ApplicationStatus;
+import org.apache.spark.metrics.source.Source;
+
+public class SparkAppStatusRecorderSource extends BaseOperatorSource implements Source {
+
+  public static final String RESOURCE_TYPE = "sparkapp";
+  public static final String LATENCY_METRIC_FORMAT = "latency.from.%s.to.%s";
+
+  public SparkAppStatusRecorderSource() {
+    super(new MetricRegistry());
+  }
+
+  @Override
+  public String sourceName() {
+    return "SparkAppStatusRecorder";
+  }
+
+  @Override
+  public MetricRegistry metricRegistry() {
+    return metricRegistry;
+  }
+
+  public void recordStatusUpdateLatency(
+      final ApplicationStatus status, final ApplicationState newState) {
+    ApplicationState currentState = status.getCurrentState();
+    if (currentState != null) {
+      Duration duration =
+          Duration.between(
+              Instant.parse(currentState.getLastTransitionTime()),
+              Instant.parse(newState.getLastTransitionTime()));
+      String metricName =
+          MetricRegistry.name(
+              RESOURCE_TYPE,
+              String.format(
+                  LATENCY_METRIC_FORMAT,
+                  currentState.getCurrentStateSummary().name(),
+                  newState.getCurrentStateSummary().name()));
+      getTimer(metricName).update(duration);
+    }
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSource.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSource.java
@@ -55,14 +55,13 @@ public class SparkAppStatusRecorderSource extends BaseOperatorSource implements 
           Duration.between(
               Instant.parse(currentState.getLastTransitionTime()),
               Instant.parse(newState.getLastTransitionTime()));
-      String metricName =
-          MetricRegistry.name(
+      getTimer(
               RESOURCE_TYPE,
               String.format(
                   LATENCY_METRIC_FORMAT,
                   currentState.getCurrentStateSummary().name(),
-                  newState.getCurrentStateSummary().name()));
-      getTimer(metricName).update(duration);
+                  newState.getCurrentStateSummary().name()))
+          .update(duration);
     }
   }
 }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetrics.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetrics.java
@@ -23,12 +23,9 @@ import static io.javaoperatorsdk.operator.api.reconciler.Constants.CONTROLLER_NA
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
@@ -45,20 +42,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.k8s.operator.BaseResource;
 import org.apache.spark.k8s.operator.SparkApplication;
 import org.apache.spark.k8s.operator.SparkCluster;
+import org.apache.spark.k8s.operator.metrics.BaseOperatorSource;
 import org.apache.spark.metrics.source.Source;
 import org.apache.spark.util.Clock;
 import org.apache.spark.util.SystemClock;
 
 /** Metrics for the Java Operator SDK. */
 @Slf4j
-public class OperatorJosdkMetrics implements Source, Metrics {
+public class OperatorJosdkMetrics extends BaseOperatorSource implements Source, Metrics {
   public static final String FINISHED = "finished";
   public static final String CLEANUP = "cleanup";
   public static final String FAILED = "failed";
   public static final String RETRIES = "retries";
-  private final Map<String, Histogram> histograms = new ConcurrentHashMap<>();
-  private final Map<String, Counter> counters = new ConcurrentHashMap<>();
-  private final Map<String, Gauge<?>> gauges = new ConcurrentHashMap<>();
   private static final String RECONCILIATION = "reconciliation";
   private static final String RESOURCE = "resource";
   private static final String EVENT = "event";
@@ -72,11 +67,10 @@ public class OperatorJosdkMetrics implements Source, Metrics {
   private static final String SIZE = "size";
 
   private final Clock clock;
-  private final MetricRegistry metricRegistry;
 
   public OperatorJosdkMetrics() {
+    super(new MetricRegistry());
     this.clock = new SystemClock();
-    this.metricRegistry = new MetricRegistry();
   }
 
   @Override
@@ -104,14 +98,17 @@ public class OperatorJosdkMetrics implements Source, Metrics {
           getResourceClass(metadata);
       final Optional<String> namespaceOptional = event.getRelatedCustomResourceID().getNamespace();
       resource.ifPresent(
-          aClass -> getCounter(aClass, action.name().toLowerCase(), RESOURCE, EVENT).inc());
+          aClass ->
+              getCounter(getMetricName(aClass, action.name().toLowerCase(), RESOURCE, EVENT))
+                  .inc());
       if (resource.isPresent() && namespaceOptional.isPresent()) {
         getCounter(
-                resource.get(),
-                namespaceOptional.get(),
-                action.name().toLowerCase(),
-                RESOURCE,
-                EVENT)
+                getMetricName(
+                    resource.get(),
+                    namespaceOptional.get(),
+                    action.name().toLowerCase(),
+                    RESOURCE,
+                    EVENT))
             .inc();
       }
     }
@@ -133,18 +130,24 @@ public class OperatorJosdkMetrics implements Source, Metrics {
       T result = execution.execute();
       final String successType = execution.successTypeName(result);
       if (resourceClass.isPresent()) {
-        getHistogram(resourceClass.get(), name, execName, successType).update(toSeconds(startTime));
-        getCounter(resourceClass.get(), name, execName, SUCCESS, successType).inc();
+        String histogramName = getMetricName(resourceClass.get(), name, execName, successType);
+        getHistogram(histogramName).update(toSeconds(startTime));
+        String counterName =
+            getMetricName(resourceClass.get(), name, execName, SUCCESS, successType);
+        getCounter(counterName).inc();
         if (namespaceOptional.isPresent()) {
-          getHistogram(resourceClass.get(), namespaceOptional.get(), name, execName, successType)
+          getHistogram(
+                  getMetricName(
+                      resourceClass.get(), namespaceOptional.get(), name, execName, successType))
               .update(toSeconds(startTime));
           getCounter(
-                  resourceClass.get(),
-                  namespaceOptional.get(),
-                  name,
-                  execName,
-                  SUCCESS,
-                  successType)
+                  getMetricName(
+                      resourceClass.get(),
+                      namespaceOptional.get(),
+                      name,
+                      execName,
+                      SUCCESS,
+                      successType))
               .inc();
         }
       }
@@ -154,19 +157,25 @@ public class OperatorJosdkMetrics implements Source, Metrics {
           "Controller execution failed for resource {}, metadata {}", resourceID, metadata, e);
       final String exception = e.getClass().getSimpleName();
       if (resourceClass.isPresent()) {
-        getHistogram(resourceClass.get(), name, execName, FAILURE).update(toSeconds(startTime));
-        getCounter(resourceClass.get(), name, execName, FAILURE, EXCEPTION, exception).inc();
+        getHistogram(getMetricName(resourceClass.get(), name, execName, FAILURE))
+            .update(toSeconds(startTime));
+        getCounter(
+                getMetricName(resourceClass.get(), name, execName, FAILURE, EXCEPTION, exception))
+            .inc();
         if (namespaceOptional.isPresent()) {
-          getHistogram(resourceClass.get(), namespaceOptional.get(), name, execName, FAILURE)
+          getHistogram(
+                  getMetricName(
+                      resourceClass.get(), namespaceOptional.get(), name, execName, FAILURE))
               .update(toSeconds(startTime));
           getCounter(
-                  resourceClass.get(),
-                  namespaceOptional.get(),
-                  name,
-                  execName,
-                  FAILURE,
-                  EXCEPTION,
-                  exception)
+                  getMetricName(
+                      resourceClass.get(),
+                      namespaceOptional.get(),
+                      name,
+                      execName,
+                      FAILURE,
+                      EXCEPTION,
+                      exception))
               .inc();
         }
       }
@@ -184,11 +193,14 @@ public class OperatorJosdkMetrics implements Source, Metrics {
         metadata);
     if (retryInfo != null) {
       final String namespace = resource.getMetadata().getNamespace();
-      getCounter(resource.getClass(), RECONCILIATION, RETRIES).inc();
-      getCounter(resource.getClass(), namespace, RECONCILIATION, RETRIES).inc();
+      getCounter(getMetricName(resource.getClass(), RECONCILIATION, RETRIES)).inc();
+      getCounter(getMetricName(resource.getClass(), namespace, RECONCILIATION, RETRIES)).inc();
     }
     getCounter(
-            resource.getClass(), (String) metadata.get(CONTROLLER_NAME), RECONCILIATIONS_QUEUE_SIZE)
+            getMetricName(
+                resource.getClass(),
+                (String) metadata.get(CONTROLLER_NAME),
+                RECONCILIATIONS_QUEUE_SIZE))
         .inc();
   }
 
@@ -197,26 +209,32 @@ public class OperatorJosdkMetrics implements Source, Metrics {
       HasMetadata resource, Exception exception, Map<String, Object> metadata) {
     log.error(
         "Failed reconciliation for resource {} with metadata {}", resource, exception, exception);
-    getCounter(resource.getClass(), RECONCILIATION, FAILED).inc();
-    getCounter(resource.getClass(), resource.getMetadata().getNamespace(), RECONCILIATION, FAILED)
+    getCounter(getMetricName(resource.getClass(), RECONCILIATION, FAILED)).inc();
+    getCounter(
+            getMetricName(
+                resource.getClass(), resource.getMetadata().getNamespace(), RECONCILIATION, FAILED))
         .inc();
   }
 
   @Override
   public void finishedReconciliation(HasMetadata resource, Map<String, Object> metadata) {
     log.debug("Finished reconciliation for resource {} with metadata {}", resource, metadata);
-    getCounter(resource.getClass(), RECONCILIATION, FINISHED).inc();
+    getCounter(getMetricName(resource.getClass(), RECONCILIATION, FINISHED)).inc();
     getCounter(
-        resource.getClass(), resource.getMetadata().getNamespace(), RECONCILIATION, FINISHED);
+        getMetricName(
+            resource.getClass(), resource.getMetadata().getNamespace(), RECONCILIATION, FINISHED));
   }
 
   @Override
   public void cleanupDoneFor(ResourceID resourceID, Map<String, Object> metadata) {
     log.debug("Cleanup Done for resource {} with metadata {}", resourceID, metadata);
-    getCounter(resourceID.getClass(), RECONCILIATION, CLEANUP).inc();
+    getCounter(getMetricName(resourceID.getClass(), RECONCILIATION, CLEANUP)).inc();
     resourceID
         .getNamespace()
-        .ifPresent(ns -> getCounter(resourceID.getClass(), ns, RECONCILIATION, CLEANUP).inc());
+        .ifPresent(
+            ns ->
+                getCounter(getMetricName(resourceID.getClass(), ns, RECONCILIATION, CLEANUP))
+                    .inc());
   }
 
   @Override
@@ -238,13 +256,17 @@ public class OperatorJosdkMetrics implements Source, Metrics {
     log.debug("Reconciliation execution started");
     String namespace = resource.getMetadata().getNamespace();
     getCounter(
-            resource.getClass(), (String) metadata.get(CONTROLLER_NAME), RECONCILIATIONS_EXECUTIONS)
+            getMetricName(
+                resource.getClass(),
+                (String) metadata.get(CONTROLLER_NAME),
+                RECONCILIATIONS_EXECUTIONS))
         .inc();
     getCounter(
-            resource.getClass(),
-            namespace,
-            (String) metadata.get(CONTROLLER_NAME),
-            RECONCILIATIONS_EXECUTIONS)
+            getMetricName(
+                resource.getClass(),
+                namespace,
+                (String) metadata.get(CONTROLLER_NAME),
+                RECONCILIATIONS_EXECUTIONS))
         .inc();
   }
 
@@ -253,45 +275,28 @@ public class OperatorJosdkMetrics implements Source, Metrics {
     log.debug("Reconciliation execution finished");
     String namespace = resource.getMetadata().getNamespace();
     getCounter(
-            resource.getClass(), (String) metadata.get(CONTROLLER_NAME), RECONCILIATIONS_EXECUTIONS)
+            getMetricName(
+                resource.getClass(),
+                (String) metadata.get(CONTROLLER_NAME),
+                RECONCILIATIONS_EXECUTIONS))
         .dec();
     getCounter(
-            resource.getClass(),
-            namespace,
-            (String) metadata.get(CONTROLLER_NAME),
-            RECONCILIATIONS_EXECUTIONS)
+            getMetricName(
+                resource.getClass(),
+                namespace,
+                (String) metadata.get(CONTROLLER_NAME),
+                RECONCILIATIONS_EXECUTIONS))
         .dec();
     getCounter(
-            resource.getClass(), (String) metadata.get(CONTROLLER_NAME), RECONCILIATIONS_QUEUE_SIZE)
+            getMetricName(
+                resource.getClass(),
+                (String) metadata.get(CONTROLLER_NAME),
+                RECONCILIATIONS_QUEUE_SIZE))
         .dec();
   }
 
   private long toSeconds(long startTimeInMilliseconds) {
     return TimeUnit.MILLISECONDS.toSeconds(clock.getTimeMillis() - startTimeInMilliseconds);
-  }
-
-  private Histogram getHistogram(Class<?> kclass, String... names) {
-    String name = MetricRegistry.name(kclass.getSimpleName(), names).toLowerCase();
-    Histogram histogram;
-    if (histograms.containsKey(name)) {
-      histogram = histograms.get(name);
-    } else {
-      histogram = metricRegistry.histogram(name);
-      histograms.put(name, histogram);
-    }
-    return histogram;
-  }
-
-  private Counter getCounter(Class<?> klass, String... names) {
-    String name = MetricRegistry.name(klass.getSimpleName(), names).toLowerCase();
-    Counter counter;
-    if (counters.containsKey(name)) {
-      counter = counters.get(name);
-    } else {
-      counter = metricRegistry.counter(name);
-      counters.put(name, counter);
-    }
-    return counter;
   }
 
   private Optional<Class<? extends BaseResource<?, ?, ?, ?, ?>>> getResourceClass(

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSourceTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSourceTest.java
@@ -56,16 +56,16 @@ class SparkAppStatusRecorderSourceTest {
 
     Map<String, Timer> timers = source.metricRegistry().getTimers();
     assertEquals(2, timers.size());
-    assertTrue(timers.containsKey("sparkapp.latency.from.Submitted.to.DriverRequested"));
+    assertTrue(timers.containsKey("sparkapp.latency.from.submitted.to.driverrequested"));
     assertTrue(
-        timers.get("sparkapp.latency.from.Submitted.to.DriverRequested").getSnapshot().getMin()
+        timers.get("sparkapp.latency.from.submitted.to.driverrequested").getSnapshot().getMin()
             > 0);
-    assertEquals(2, timers.get("sparkapp.latency.from.Submitted.to.DriverRequested").getCount());
-    assertTrue(timers.containsKey("sparkapp.latency.from.DriverRequested.to.DriverStarted"));
+    assertEquals(2, timers.get("sparkapp.latency.from.submitted.to.driverrequested").getCount());
+    assertTrue(timers.containsKey("sparkapp.latency.from.driverrequested.to.driverstarted"));
     assertEquals(
-        1, timers.get("sparkapp.latency.from.DriverRequested.to.DriverStarted").getCount());
+        1, timers.get("sparkapp.latency.from.driverrequested.to.driverstarted").getCount());
     assertTrue(
-        timers.get("sparkapp.latency.from.DriverRequested.to.DriverStarted").getSnapshot().getMin()
+        timers.get("sparkapp.latency.from.driverrequested.to.driverstarted").getSnapshot().getMin()
             > 0);
   }
 

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSourceTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/SparkAppStatusRecorderSourceTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import com.codahale.metrics.Timer;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import org.junit.jupiter.api.Test;
+
+import org.apache.spark.k8s.operator.SparkApplication;
+import org.apache.spark.k8s.operator.status.ApplicationState;
+import org.apache.spark.k8s.operator.status.ApplicationStateSummary;
+import org.apache.spark.k8s.operator.status.ApplicationStatus;
+
+class SparkAppStatusRecorderSourceTest {
+
+  @Test
+  void recordStatusUpdateLatency() {
+    SparkAppStatusRecorderSource source = new SparkAppStatusRecorderSource();
+    SparkApplication app1 = prepareApplication("foo-1", "bar-1");
+    SparkApplication app2 = prepareApplication("foo-2", "bar-2");
+
+    ApplicationState stateUpdate11 =
+        new ApplicationState(ApplicationStateSummary.DriverRequested, "foo");
+    ApplicationState stateUpdate12 =
+        new ApplicationState(ApplicationStateSummary.DriverRequested, "bar");
+    // record short latency
+    source.recordStatusUpdateLatency(app1.getStatus(), stateUpdate11);
+    source.recordStatusUpdateLatency(app2.getStatus(), stateUpdate12);
+    app1.setStatus(app1.getStatus().appendNewState(stateUpdate11));
+
+    ApplicationState stateUpdate2 =
+        new ApplicationState(ApplicationStateSummary.DriverStarted, "foo");
+    source.recordStatusUpdateLatency(app1.getStatus(), stateUpdate2);
+
+    Map<String, Timer> timers = source.metricRegistry().getTimers();
+    assertEquals(2, timers.size());
+    assertTrue(timers.containsKey("sparkapp.latency.from.Submitted.to.DriverRequested"));
+    assertTrue(
+        timers.get("sparkapp.latency.from.Submitted.to.DriverRequested").getSnapshot().getMin()
+            > 0);
+    assertEquals(2, timers.get("sparkapp.latency.from.Submitted.to.DriverRequested").getCount());
+    assertTrue(timers.containsKey("sparkapp.latency.from.DriverRequested.to.DriverStarted"));
+    assertEquals(
+        1, timers.get("sparkapp.latency.from.DriverRequested.to.DriverStarted").getCount());
+    assertTrue(
+        timers.get("sparkapp.latency.from.DriverRequested.to.DriverStarted").getSnapshot().getMin()
+            > 0);
+  }
+
+  protected SparkApplication prepareApplication(String name, String namespace) {
+    SparkApplication app = new SparkApplication();
+    app.setMetadata(new ObjectMetaBuilder().withName(name).withNamespace(namespace).build());
+    app.setStatus(new ApplicationStatus());
+    return app;
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds metrics tracking state transition latency for Spark Application in format of

```
sparkapp.latency.from.<fromState>.to.<toState>
```

### Why are the changes needed?

Latency measuring would be useful to analyze the performance from scheduling / orchestration perspective. For example, to analyze which state causes significant overhad and therefore optimize at cluster/app level.

### Does this PR introduce _any_ user-facing change?

More metrics becomes available.

### How was this patch tested?

CIs. New unit test added.

### Was this patch authored or co-authored using generative AI tooling?

No

