### PR TITLE
[SPARK-53407] Use `baseDirectory` instead of `baseDir`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ subprojects {
     spotbugs {
       toolVersion = libs.versions.spotbugs.tool.get()
       afterEvaluate {
-        reportsDir = file("${project.reporting.baseDir}/findbugs")
+        reportsDir = file("${project.reporting.baseDirectory}/findbugs")
       }
       excludeFilter = file("$rootDir/config/spotbugs/spotbugs_exclude.xml")
       ignoreFailures = false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `reporting.baseDirectory` instead of `reporting.baseDir`.

### Why are the changes needed?

`reporting.baseDir` was deprecated at Gradle 8 and removed at Gradle 9.

- https://docs.gradle.org/current/userguide/upgrading_version_8.html#reporting-base-dir
  > ReportingExtension.getBaseDir(), `ReportingExtension.setBaseDir(File), and ReportingExtension.setBaseDir(Object) were deprecated. They should be replaced with ReportingExtension.getBaseDirectory() property.

- https://docs.gradle.org/current/dsl/org.gradle.api.reporting.ReportingExtension.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.