### PR TITLE
[SPARK-53411] Upgrade the minimum K8s version to v1.32

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - "1.31.0"
+          - "1.32.0"
           - "1.33.0"
         mode:
           - dynamic


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the minimum K8s version to v1.32 in K8s test environment.

### Why are the changes needed?

K8s 1.31 entered maintenance mode Today (August 28, 2025) and will reach the `End of Life` date on Oct 28, 2025. We had better focus on K8s v1.32+.

- https://kubernetes.io/releases/patch-releases/#1-31

In addition, the default K8s versions of public cloud providers are already moving to K8s 1.32+ like the following.

- EKS: v1.32 (Default), v1.33 (Available)
- AKS: v1.32 (Default), v1.33 (GA)
- GKE: v1.32 (Stable), v1.32 (Regular), v1.33 (Rapid)

### Does this PR introduce _any_ user-facing change?

No because this is a test infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.