### PR TITLE
[SPARK-53430]Prevent unintended JSON serialization with @JsonIgnore

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ApplicationTolerations.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ApplicationTolerations.java
@@ -21,6 +21,7 @@ package org.apache.spark.k8s.operator.spec;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.generator.annotation.Default;
@@ -110,6 +111,7 @@ public class ApplicationTolerations {
    * @return true if `resourceRetainDurationMillis` or `ttlAfterStopMillis` is set to non-negative
    *     value
    */
+  @JsonIgnore
   public boolean isRetainDurationEnabled() {
     return resourceRetainDurationMillis >= 0L || ttlAfterStopMillis >= 0L;
   }
@@ -119,6 +121,7 @@ public class ApplicationTolerations {
    *
    * @return true if `ttlAfterStopMillis` is set to non-negative value
    */
+  @JsonIgnore
   public boolean isTTLEnabled() {
     return ttlAfterStopMillis >= 0L;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds @JsonIgnore to helper methods in API to avoid unintentional serialization.

### Why are the changes needed?

Some non-field heler methods in our API POJO classes can be unintentionally serialized as Jackson treat them as getters.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CIs

### Was this patch authored or co-authored using generative AI tooling?

No

