### PR TITLE
[SPARK-53468] Update `setup-minikube` to v0.0.20

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,7 +105,7 @@ jobs:
           distribution: 'adopt'
           cache: 'gradle'
       - name: Set up Minikube
-        uses: medyagh/setup-minikube@v0.0.19
+        uses: medyagh/setup-minikube@v0.0.20
         with:
           cache: true
           kubernetes-version: ${{ matrix.kubernetes-version }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `setup-minikube` to the latest version v0.0.20.

### Why are the changes needed?

Currently, we use `v0.0.19` (2025-01-22). We had better use the latest one.
- https://github.com/medyagh/setup-minikube/releases/tag/v0.0.20 (2025-07-08)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.