### PR TITLE
[SPARK-53495] Remove unused 'persistentVolume' access from operator rbac

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
@@ -25,7 +25,6 @@ rules:
       - services
       - configmaps
       - persistentvolumeclaims
-      - persistentvolumes
       - events
     verbs:
       - '*'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes 'persistentVolume' access from operator in Helm chart

### Why are the changes needed?

Operator and Spark workload manages persistentVolumeClaims but not persistenVolumes - this removes the unnecessary access according to the principle of least priviledge

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Helm lint and CIs

### Was this patch authored or co-authored using generative AI tooling?

No

