### PR TITLE
[SPARK-53542] Update CI to test K8s 1.34

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         kubernetes-version:
           - "1.32.0"
-          - "1.33.0"
+          - "1.34.0"
         mode:
           - dynamic
           - static


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the maximum K8s test version to 1.34

### Why are the changes needed?

To improve the test coverage because K8s 1.34.0 was released on 2025-08-27.
- https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/
- https://kubernetes.io/releases/#release-v1-34

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

<img width="709" height="188" alt="Screenshot 2025-09-09 at 15 44 41" src="https://github.com/user-attachments/assets/bd658c6a-d896-44b8-ad6a-6a8329caee81" />

```
  Kubelet Version:            v1.34.0
```

### Was this patch authored or co-authored using generative AI tooling?

No.