### PR TITLE
[SPARK-53613] Upgrade `google-java-format` to 1.28.0 to support Java 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ subprojects {
   spotless {
     java {
       endWithNewline()
-      googleJavaFormat('1.22.0')
+      googleJavaFormat('1.28.0')
       importOrder(
         'java',
         'javax',


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `google-java-format` to 1.28.0 to support Java 25.

### Why are the changes needed?

The latest one is `1.28.0` as of now.

- https://github.com/google/google-java-format/releases/tag/v1.28.0 (2025-07-09)
- https://github.com/google/google-java-format/releases/tag/v1.27.0 (2025-05-06)
    - [Improved compatibility with JDK 24 early access builds](https://github.com/google/google-java-format/commit/96f114c37c02fcfdfa0d4bc25b6e122d11afc485)

### Does this PR introduce _any_ user-facing change?

No behavior change because this is used in `spotless` during building.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.