### PR TITLE
[SPARK-53624] Use `bitnamisecure/kubectl:latest` for Helm Chart testing

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/tests/test-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/tests/test-rbac.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   containers:
     - name: kubectl
-      image: bitnami/kubectl:latest
+      image: bitnamisecure/kubectl:latest
       command: ['bash', '-c' ]
       args: [
         'kubectl auth can-i list sparkapplications --all-namespaces',
@@ -52,7 +52,7 @@ metadata:
 spec:
   containers:
     - name: kubectl
-      image: bitnami/kubectl:latest
+      image: bitnamisecure/kubectl:latest
       command: ['bash', '-c' ]
       args: [
         'kubectl auth can-i create pods -n {{ .Release.Namespace }}',


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `bitnamisecure/kubectl:latest` for Helm Chart testing instead of `bitnami/kubectl:latest`

```yaml
- image: bitnami/kubectl:latest
+ image: bitnamisecure/kubectl:latest
```

### Why are the changes needed?

The existing `Bitnami` Docker images are removed. As a result, we need to use one of `bitnamisecure` or `bitnamilegacy`.
- https://github.com/bitnami/containers/issues/83267

Apache Spark K8s Operator repository is impacted Today. The `main` branch CI starts to fail Today. At the same commit,
- https://github.com/apache/spark-kubernetes-operator/actions/runs/17790264075 (This is the second attempt, Failed)
- https://github.com/apache/spark-kubernetes-operator/actions/runs/17790264075/attempts/1 (Succeed)

<img width="367" height="211" alt="Screenshot 2025-09-17 at 14 20 52" src="https://github.com/user-attachments/assets/8c52f8ac-6c40-4547-b671-98d61710f17b" />

### Does this PR introduce _any_ user-facing change?

Yes, the existing Helm Chart testing command, `helm test`, will not work.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.