### PR TITLE
[SPARK-53627] Update docs to recommend K8s 1.32+

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/README.md
+++ b/build-tools/helm/spark-kubernetes-operator/README.md
@@ -33,7 +33,7 @@ cluster using the [Helm](https://helm.sh) package manager. With this, you can la
 
 ## Requirements
 
-- Kubernetes 1.30+ cluster
+- Kubernetes 1.32+ cluster
 - Helm 3.0+
 
 ## Features

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -23,7 +23,7 @@ under the License.
 
 - Java 17, 21 and 24
 - Kubernetes version compatibility:
-  - k8s version >= 1.30 is recommended. Operator attempts to be API compatible as possible, but
+  - k8s version >= 1.32 is recommended. Operator attempts to be API compatible as possible, but
       patch support will not be performed on k8s versions that reached EOL.
 - Spark versions 3.5 or above.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update documentations to recommend K8s v1.32+.

### Why are the changes needed?

K8s 1.31 entered maintenance mode already on August 28, 2025 and will reach the `End of Life` date on Oct 28, 2025. We had better recommend users to use K8s v1.32+.

- https://kubernetes.io/releases/patch-releases/#1-31

In addition, the default K8s versions of public cloud providers are already moving to K8s 1.32+ like the following.

- EKS: v1.32 (Default), v1.33 (Available)
- AKS: v1.32 (Default), v1.33 (Available), v1.34 (Preview, will be GA on October 2025)
- GKE: v1.33 (Stable), v1.34 (Regular on 9/30), v1.34 (Rapid)

### Does this PR introduce _any_ user-facing change?

No because this is a documentation-only change.

### How was this patch tested?

Manual review because the result of CIs is irrelevant.

### Was this patch authored or co-authored using generative AI tooling?

No.