### PR TITLE
[SPARK-53628] Upgrade `PMD/SpotBugs` and enable checking on Java 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,24 +71,22 @@ subprojects {
     showViolations = true
   }
 
-  if (JavaVersion.current() < JavaVersion.VERSION_25) {
-    apply plugin: 'pmd'
-    pmd {
-      ruleSetFiles = files("$rootDir/config/pmd/ruleset.xml")
-      toolVersion = libs.versions.pmd.get()
-      consoleOutput = true
-      ignoreFailures = false
-    }
+  apply plugin: 'pmd'
+  pmd {
+    ruleSetFiles = files("$rootDir/config/pmd/ruleset.xml")
+    toolVersion = libs.versions.pmd.get()
+    consoleOutput = true
+    ignoreFailures = false
+  }
 
-    apply plugin: 'com.github.spotbugs'
-    spotbugs {
-      toolVersion = libs.versions.spotbugs.tool.get()
-      afterEvaluate {
-        reportsDir = file("${project.reporting.baseDirectory}/findbugs")
-      }
-      excludeFilter = file("$rootDir/config/spotbugs/spotbugs_exclude.xml")
-      ignoreFailures = false
+  apply plugin: 'com.github.spotbugs'
+  spotbugs {
+    toolVersion = libs.versions.spotbugs.tool.get()
+    afterEvaluate {
+      reportsDir = file("${project.reporting.baseDirectory}/findbugs")
     }
+    excludeFilter = file("$rootDir/config/spotbugs/spotbugs_exclude.xml")
+    ignoreFailures = false
   }
 
   apply plugin: 'jacoco'

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -41,6 +41,7 @@
     <exclude name="TooManyStaticImports" />
     <exclude name="UseExplicitTypes" />
     <exclude name="UseUnderscoresInNumericLiterals" />
+    <exclude name="TypeParameterNamingConventions" />
   </rule>
   <rule ref="category/java/design.xml">
     <exclude name="AbstractClassWithoutAnyMethod" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,9 +30,9 @@ mockito = "5.18.0"
 
 # Build Analysis
 checkstyle = "10.23.1"
-pmd = "7.13.0"
-spotbugs-tool = "4.9.3"
-spotbugs-plugin = "6.1.13"
+pmd = "7.17.0"
+spotbugs-tool = "4.9.6"
+spotbugs-plugin = "6.4.2"
 spotless-plugin = "6.25.0"
 
 # Packaging

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 
 import org.apache.spark.k8s.operator.utils.ProbeUtil;
 
-@SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
 class ReadinessProbeTest {
   KubernetesClient client;
   HttpExchange httpExchange;

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/StatusRecorderTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/StatusRecorderTest.java
@@ -86,7 +86,8 @@ class StatusRecorderTest {
             any());
   }
 
-  private static @NotNull SparkApplication getSparkApplication(String resourceVersion) {
+  @NotNull
+  private static SparkApplication getSparkApplication(String resourceVersion) {
     var updated = TestUtils.createMockApp(DEFAULT_NS);
     updated.getMetadata().setResourceVersion(resourceVersion);
     return updated;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `pmd` and `spotbugs` test dependency and enable it on Java 25.

### Why are the changes needed?

Previously, `PMD` and `SpotBugs` check are enabled only on Java 17 and 21.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a code quality check during building.

### How was this patch tested?

Pass the CIs. Java 25 test pipeline will cover this.

### Was this patch authored or co-authored using generative AI tooling?

No.