### PR TITLE
[SPARK-53639] Use `spark` consistently for `release-name` of Helm installation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -125,8 +125,8 @@ jobs:
         run: |
           eval $(minikube docker-env)
           ./gradlew buildDockerImage
-          helm install spark-kubernetes-operator --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
-          helm test spark-kubernetes-operator
+          helm install spark --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
+          helm test spark
           # Use remote host' s docker image
           minikube docker-env --unset
       - name: Run E2E Test with Dynamic Configuration Disabled
@@ -138,7 +138,7 @@ jobs:
         run: |
           eval $(minikube docker-env)
           ./gradlew buildDockerImage
-          helm install spark-kubernetes-operator --create-namespace -f \
+          helm install spark --create-namespace -f \
           build-tools/helm/spark-kubernetes-operator/values.yaml -f \
           tests/e2e/helm/dynamic-config-values.yaml \
           build-tools/helm/spark-kubernetes-operator/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,7 +122,7 @@ sink.PrometheusPullModelSink
 * Install Spark Operator
 
 ```bash
-helm install spark-kubernetes-operator -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
+helm install spark -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
 ```
 
 * Install Prometheus via Helm Chart

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -50,7 +50,7 @@ You can also provide multiple custom values file by using the `-f` flag, the lat
 higher precedence:
 
 ```bash
-helm install spark-kubernetes-operator \
+helm install spark \
    -f build-tools/helm/spark-kubernetes-operator/values.yaml \
    -f my_values.yaml \
    build-tools/helm/spark-kubernetes-operator/

--- a/tests/e2e/watched-namespaces/chainsaw-test.yaml
+++ b/tests/e2e/watched-namespaces/chainsaw-test.yaml
@@ -76,7 +76,7 @@ spec:
       - script:
           content: |
             echo "Installing another spark operator in default-2 namespaces, watching on namespace: spark-3"
-            helm install spark-kubernetes-operator -n default-2 --create-namespace -f \
+            helm install spark -n default-2 --create-namespace -f \
             ../../../build-tools/helm/spark-kubernetes-operator/values.yaml -f \
             ../helm/dynamic-config-values-2.yaml \
             ../../../build-tools/helm/spark-kubernetes-operator/


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `spark` consistently for `release-name` of Helm installation.

### Why are the changes needed?

Although we use `spark` in `README.md` and website like the following, old legacy names still exist.

https://github.com/apache/spark-kubernetes-operator/blob/cfd5063c595c445eee3d9d94e5dc9d17590ed5d4/README.md?plain=1#L49

We need to unify this. Otherwise, `INSTALLATION FAILED` occurs due to the mismatch of `meta.helm.sh/release-name`.

```
$ helm install sparkx --create-namespace -f build-tools/helm/spark-kubernetes-operator/values.yaml build-tools/helm/spark-kubernetes-operator/
Error: INSTALLATION FAILED: Unable to continue with install: ServiceAccount "spark-operator" in namespace "default" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "sparkx": current value is "spark"
```

### Does this PR introduce _any_ user-facing change?

No for the clean installations.

For the users who have the existing installation, they need to remove old K8s objects before installation.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.