### PR TITLE
[SPARK-53646] Improve `KubernetesMetricsInterceptorTest` to verify `http.request` metric

### DIFF
--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptorTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptorTest.java
@@ -97,6 +97,7 @@ class KubernetesMetricsInterceptorTest {
                 Meter metric = (Meter) metrics2.get(name);
                 Assertions.assertEquals(metric.getCount(), 1);
               });
+      Assertions.assertEquals(((Meter) metrics2.get("http.request")).getCount(), 2);
       client.resource(sparkApplication).delete();
     }
   }
@@ -122,6 +123,7 @@ class KubernetesMetricsInterceptorTest {
       Assertions.assertEquals(12, map.size());
       Meter metric = (Meter) map.get("failed");
       Assertions.assertEquals(metric.getCount(), retry + 1);
+      Assertions.assertEquals(((Meter) map.get("http.request")).getCount(), retry + 1);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `KubernetesMetricsInterceptorTest` to verify `http.request` metric additionally.

### Why are the changes needed?

`http.request` metric is also important.

### Does this PR introduce _any_ user-facing change?

No, this is a test-only improvement.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.