### PR TITLE
[SPARK-53670] Use `Gradle Java Toolchain`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,13 @@ subprojects {
   apply plugin: 'java'
 
   java {
-    sourceCompatibility = 17
-    targetCompatibility = 17
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(17)
+    }
+  }
+
+  tasks.withType(JavaCompile).configureEach {
+    options.release = 17
   }
 
   repositories {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Gradle Java Toolchain` to ensure to use JDK 17 API Compatibility.

### Why are the changes needed?

In addition to `sourceCompatibility` and `targetCompatibility`, `Toolchain` will ensure `--release` too.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.