### PR TITLE
[SPARK-53701] Use Java 25 toolchain while supporting Java 17+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,8 @@ subprojects {
 
   java {
     toolchain {
-      languageVersion = JavaLanguageVersion.of(17)
+      languageVersion = JavaLanguageVersion.of(25)
+      vendor = JvmVendorSpec.AZUL
     }
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+  id "org.gradle.toolchains.foojay-resolver-convention" version "1.0.0"
+}
 rootProject.name = 'apache-spark-kubernetes-operator'
 include 'spark-operator-api'
 include 'spark-submission-worker'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to start to use `Java 25 (Azul Zulu JDK)` toolchain while supporting Java 17+ from `Apache K8s Operator v0.5`.

### Why are the changes needed?

After this PR, we can take advantage of Java 25 compiler improvements while supporting all Java 17+ versions via `options.release = 17`.

https://github.com/apache/spark-kubernetes-operator/blob/db7e6403fd14ab86c302532423e26d3799a6e4c8/build.gradle#L59

### Does this PR introduce _any_ user-facing change?

- There is no behavior change for users.
- There is no developer experience change in general.
   - For the system without Java 25, `Gradle` will automatically download and use it.
   - Since we assume that `Gradle Wrapper` downloads `Gradle` itself, most of developers should get Java 25 without any issues.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.