### PR TITLE
[MINOR] Remove unnecesary string splits in test code

### DIFF
--- a/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
+++ b/spark-operator-api/src/test/java/org/apache/spark/k8s/operator/spec/ApplicationSpecTest.java
@@ -58,7 +58,7 @@ class ApplicationSpecTest {
     InputStream inputStream =
         getClass()
             .getClassLoader()
-            .getResourceAsStream("spark-job-with-driver-service" + "-ingress.json");
+            .getResourceAsStream("spark-job-with-driver-service-ingress.json");
     ApplicationSpec spec = objectMapper.readValue(inputStream, ApplicationSpec.class);
     assertNotNull(spec.getDriverServiceIngressList());
     assertEquals(1, spec.getDriverServiceIngressList().size());

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java
@@ -52,10 +52,10 @@ class SparkAppDriverConfTest {
             + "but different values are detected");
     assertTrue(
         sparkAppDriverConf.configMapNameDriver().contains(resourcePrefix),
-        "ConfigMap name" + " should include secondary resource prefix");
+        "ConfigMap name should include secondary resource prefix");
     assertTrue(
         sparkAppDriverConf.driverServiceName().contains(resourcePrefix),
-        "Driver service " + "name should include secondary resource prefix");
+        "Driver service name should include secondary resource prefix");
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unnenesary string splits in the test code.

### Why are the changes needed?

There are three instances which looks like mistakes.

```java
- "ConfigMap name" + " should include secondary resource prefix");
+ "ConfigMap name should include secondary resource prefix");
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.