### PR TITLE
[SPARK-53713] Remove `org.jetbrains.annotations` test code dependency from `spark-operator`

### DIFF
--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/StatusRecorderTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/StatusRecorderTest.java
@@ -33,7 +33,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.k8s.operator.SparkApplication;
@@ -86,7 +85,6 @@ class StatusRecorderTest {
             any());
   }
 
-  @NotNull
   private static SparkApplication getSparkApplication(String resourceVersion) {
     var updated = TestUtils.createMockApp(DEFAULT_NS);
     updated.getMetadata().setResourceVersion(resourceVersion);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `org.jetbrains.annotations` test code dependency from `spark-operator`.

### Why are the changes needed?

To simply `spark-operator` dependency.

**BEFORE**

```
$ git grep org.jetbrains | wc -l
       1
```

**AFTER**

```
$ git grep org.jetbrains | wc -l
       0
```

### Does this PR introduce _any_ user-facing change?

No behavior change. This annotation was used only for the test code.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.