### PR TITLE
[SPARK-53721] Fix `HelmChart` template to use Spark-version agnostic `SentinelResource`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -173,8 +173,7 @@ metadata:
     {{- template "spark-operator.workloadAnnotations" $ }}
 spec:
   runtimeVersions:
-    sparkVersion: 4.0.0
-    scalaVersion: "2.13"
+    sparkVersion: "dummy"
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `HelmChart` template to use Spark-version agnostic `SentinelResource`.

### Why are the changes needed?

Although we use `SparkApplication` for a sentinel resource, we don't need a specific Spark version or Scala version.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.