### PR TITLE
[SPARK-53739] Add `pi-preview-with-eventlog.yaml` example

### DIFF
--- a/examples/pi-preview-with-eventlog.yaml
+++ b/examples/pi-preview-with-eventlog.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-preview-with-eventlog
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.2"
+    spark.jars.ivy: "/tmp/.ivy2.5.2"
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
+    spark.eventLog.enabled: "true"
+    spark.eventLog.dir: "s3a://spark-events/"
+    spark.hadoop.fs.s3a.endpoint: "http://localstack:4566"
+    spark.hadoop.fs.s3a.path.style.access: "true"
+    spark.hadoop.fs.s3a.access.key: "test"
+    spark.hadoop.fs.s3a.secret.key: "test"
+    spark.driver.memory: "2g"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    sparkVersion: "4.1.0-preview2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `pi-preview-with-eventlog.yaml` example.

### Why are the changes needed?

To show how to use `Apache Spark 4.1.0-preview2` properly. Mainly, we have three difference.

1. Hadoop versions are different.
```
- spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.1"
+ spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.2"
```

2. Spark 4.1.0-preview2 with Hadoop 3.4.2 requires more memory.

```
spark.driver.memory: "2g"
```

3. Docker images are different.

```
- spark.kubernetes.container.image: "apache/spark:4.0.1-java21-scala"
+ spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is an example.

### How was this patch tested?

Manually because this is an example.

Since `4.1.0-preview2` image is not published yet, I built the image locally and used it.

```
$ ./bin/docker-image-tool.sh -r docker.io/apache -t 4.1.0-preview2-java21-scala build
```

### Was this patch authored or co-authored using generative AI tooling?

No.