### PR TITLE
[SPARK-53740] Update `(pi|spark-history-server)-preview.yaml` to use `4.1.0-preview2`

### DIFF
--- a/examples/pi-preview.yaml
+++ b/examples/pi-preview.yaml
@@ -24,8 +24,8 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.0-preview1-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview1"
+    sparkVersion: "4.1.0-preview2"

--- a/examples/spark-history-server-preview.yaml
+++ b/examples/spark-history-server-preview.yaml
@@ -19,11 +19,11 @@ metadata:
 spec:
   mainClass: "org.apache.spark.deploy.history.HistoryServer"
   sparkConf:
-    spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.1"
+    spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.2"
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.driver.memory: "2g"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.0-preview1-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
     spark.ui.port: "18080"
     spark.history.fs.logDirectory: "s3a://spark-events"
     spark.history.fs.cleaner.enabled: "true"
@@ -36,7 +36,7 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.0-preview1"
+    sparkVersion: "4.1.0-preview2"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update two examples to use `4.1.0-preview2`.
- `pi-preview.yaml`
- `spark-history-server-preview.yaml`

### Why are the changes needed?

To help the users access the latest preview version features more easily.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is an example update.

### How was this patch tested?

Manually.

Since 4.1.0-preview2 image is not published yet, I built the image locally and used it.

```
$ ./bin/docker-image-tool.sh -r docker.io/apache -t 4.1.0-preview2-java21-scala build
```

### Was this patch authored or co-authored using generative AI tooling?

No.