### PR TITLE
[SPARK-53767] Upgrade `Dropwizard` metrics to 4.2.33

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 fabric8 = "7.4.0"
 lombok = "1.18.38"
 operator-sdk = "5.1.3"
-dropwizard-metrics = "4.2.30"
+dropwizard-metrics = "4.2.33"
 spark = "4.0.1"
 log4j = "2.24.3"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Dropwizard` metrics to 4.2.33.

### Why are the changes needed?

To match with Apache Spark 4.1.0-preview2 for now.
- https://github.com/apache/spark/pull/51944

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.