### PR TITLE
[SPARK-53768] Upgrade `lombok` to 1.18.42

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@
 # under the License.
 [versions]
 fabric8 = "7.4.0"
-lombok = "1.18.38"
+lombok = "1.18.42"
 operator-sdk = "5.1.3"
 dropwizard-metrics = "4.2.30"
 spark = "4.0.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `lombok` to 1.18.42.

### Why are the changes needed?

To support JDK 25 better and apply the latest breaking changes before opening the libraries:

> IMPROBABLE BREAKING CHANGE: From versions 1.18.16 to 1.18.38, lombok automatically copies certain Jackson annotations (e.g., @JsonProperty) from fields to the corresponding accessors (getters/setters). However, it turned out to be harmful in certain situations. Thus, Lombok does not automatically copy those annotations any more. You can restore the old behavior using the [config key](https://projectlombok.org/features/configuration) lombok.copyJacksonAnnotationsToAccessors = true.

- https://projectlombok.org/changelog
  - v1.18.42
    - https://github.com/projectlombok/lombok/issues/3940
    - https://github.com/projectlombok/lombok/issues/2280
  - v1.18.40
    - https://github.com/projectlombok/lombok/issues/3859
    - https://github.com/projectlombok/lombok/issues/3886

### Does this PR introduce _any_ user-facing change?

No `Spark K8s Operator` behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.