### PR TITLE
[SPARK-53769] Enable `Annotation Processing` during Java compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ subprojects {
 
   tasks.withType(JavaCompile).configureEach {
     options.release = 17
+    options.compilerArgs.add("-proc:full")
   }
 
   repositories {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ensure `Annotation Processing` in Java compilation.

### Why are the changes needed?

Since JDK 23, `Annotation Processing` is disabled by default. We need to enable it explicitly in Java 25 to use it.

- [JDK 23: Changes Default Annotation Processing Policy](https://inside.java/2024/06/18/quality-heads-up/)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.