### PR TITLE
[SPARK-53778] Use JDK25 Gradle Image as builder images

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM gradle:9.1.0-jdk17-noble AS builder
+FROM gradle:9.1.0-jdk25-noble AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use JDK25 Gradle Image instead of JDK17.

### Why are the changes needed?

Since SPARK-53701, Apache Spark K8s Operator has been using JDK25 Toolchain which means it downloads JDK 25 inside JDK 17 Docker image. By using JDK25 Gradle Image, we can eliminate this redundancy and save resources during Docker images.

- #336 

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.