### PR TITLE
[SPARK-53782] Use `slf4j-api` as a direct dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ operator-sdk = "5.1.3"
 dropwizard-metrics = "4.2.33"
 spark = "4.0.1"
 log4j = "2.24.3"
+slf4j = "2.0.17"
 
 # Test
 junit = "5.13.4"
@@ -50,6 +51,7 @@ log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.
 log4j-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version.ref = "log4j" }
 log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
 log4j-layout-template-json = { group = "org.apache.logging.log4j", name = "log4j-layout-template-json", version.ref = "log4j" }
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 operator-framework = { group = "io.javaoperatorsdk", name = "operator-framework", version.ref = "operator-sdk"}
 operator-framework-junit5 = { group = "io.javaoperatorsdk", name = "operator-framework-junit-5", version.ref = "operator-sdk"}
 spotbugs-annotations = { group = "com.github.spotbugs", name = "spotbugs-annotations", version.ref = "spotbugs-tool"}

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -27,8 +27,11 @@ dependencies {
   annotationProcessor(libs.lombok)
 
   // logging
-  implementation(libs.log4j.slf4j.impl)
+  implementation(libs.log4j.slf4j.impl) {
+    exclude group: 'org.slf4j'
+  }
   implementation(libs.log4j.core)
+  implementation(libs.slf4j.api)
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -31,9 +31,12 @@ dependencies {
   // logging
   implementation(libs.log4j.api)
   implementation(libs.log4j.core)
-  implementation(libs.log4j.slf4j.impl)
+  implementation(libs.log4j.slf4j.impl) {
+    exclude group: 'org.slf4j'
+  }
   implementation(libs.log4j.api12)
   implementation(libs.log4j.layout.template.json)
+  implementation(libs.slf4j.api)
 
   // metrics
   implementation(libs.metrics.core)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `slf4j-api` as a direct dependency.

### Why are the changes needed?

Previously, `slf4j-api` is implicitly determined by the transitive dependecies. We had better control directly by simplifying the dependency relationship with `slf4j-api`.

**BEFORE**

```
$ gradle spark-operator:dependencies --configuration compileClasspath | grep slf4j-api
|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
|    |    \--- org.slf4j:slf4j-api:2.0.17
|    \--- org.slf4j:slf4j-api:2.0.17
|    |    |    |    +--- org.slf4j:slf4j-api:2.0.17
|    |    +--- org.slf4j:slf4j-api:2.0.17
|    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
```

**AFTER**

```
$ gradle spark-operator:dependencies --configuration compileClasspath | grep slf4j-api
|    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
|    |    \--- org.slf4j:slf4j-api:2.0.17
|    \--- org.slf4j:slf4j-api:2.0.17
|    |    |    |    +--- org.slf4j:slf4j-api:2.0.17
|    |    +--- org.slf4j:slf4j-api:2.0.17
+--- org.slf4j:slf4j-api:2.0.17
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.