### PR TITLE
[SPARK-53783] Use `log4j2` instead of `log4j`

### DIFF
--- a/build-tools/docs-utils/build.gradle
+++ b/build-tools/docs-utils/build.gradle
@@ -25,7 +25,7 @@ ext {
 dependencies {
     implementation project(":spark-operator")
     implementation(libs.log4j.core)
-    implementation(libs.log4j.slf4j.impl)
+    implementation(libs.log4j.slf4j2.impl)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,8 +48,7 @@ crd-generator-apt = { group = "io.fabric8", name = "crd-generator-apt", version.
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
-log4j-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version.ref = "log4j" }
-log4j-api12 = { group = "org.apache.logging.log4j", name = "log4j-1.2-api", version.ref = "log4j" }
+log4j-slf4j2-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "log4j" }
 log4j-layout-template-json = { group = "org.apache.logging.log4j", name = "log4j-layout-template-json", version.ref = "log4j" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 operator-framework = { group = "io.javaoperatorsdk", name = "operator-framework", version.ref = "operator-sdk"}

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -27,9 +27,7 @@ dependencies {
   annotationProcessor(libs.lombok)
 
   // logging
-  implementation(libs.log4j.slf4j.impl) {
-    exclude group: 'org.slf4j'
-  }
+  implementation(libs.log4j.slf4j2.impl)
   implementation(libs.log4j.core)
   implementation(libs.slf4j.api)
 

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -31,10 +31,7 @@ dependencies {
   // logging
   implementation(libs.log4j.api)
   implementation(libs.log4j.core)
-  implementation(libs.log4j.slf4j.impl) {
-    exclude group: 'org.slf4j'
-  }
-  implementation(libs.log4j.api12)
+  implementation(libs.log4j.slf4j2.impl)
   implementation(libs.log4j.layout.template.json)
   implementation(libs.slf4j.api)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `log4j2` instead of `log4j` by 
- Use `log4j-slf4j2-impl` instead of `log4j-slf4j-impl`
- Remove `log4j-1.2-api`

### Why are the changes needed?

Apache Spark main repository has been using `log4j-slf4j2-impl` instead of `log4j-slf4j-impl` in order to use `Log4J2`.

- https://github.com/apache/spark/pull/37844

Apache Spark K8s Operator repository seems to use `log4j-slf4j2-impl` mistakenly at the initial implementation.
- #8

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.