### PR TITLE
[SPARK-53787] Upgrade Spark to `4.1.0-preview2`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ fabric8 = "7.4.0"
 lombok = "1.18.42"
 operator-sdk = "5.1.3"
 dropwizard-metrics = "4.2.33"
-spark = "4.0.1"
+spark = "4.1.0-preview2"
 log4j = "2.24.3"
 slf4j = "2.0.17"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to `4.1.0-preview2` for `4.0.1`.

### Why are the changes needed?

Since Apache Spark 4.1.0 is planned next month, we had better prepare to use new features via using `4.1.0-preview2` (September) and `4.1.0-preview2 (October)` gradually.
- https://github.com/apache/spark/pull/51678
- https://github.com/apache/spark/pull/51522
- https://github.com/apache/spark/pull/50925

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.