### PR TITLE
[SPARK-53813] Recover `Publish Snapshot Chart` GitHub Action Job by using GitHash

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -49,7 +49,7 @@ jobs:
         helm repo index tmp/$DIR --url https://nightlies.apache.org/spark/$DIR
         helm show chart tmp/$DIR/spark-kubernetes-operator-*.tgz
     - name: Upload
-      uses: burnett01/rsync-deployments@5.2
+      uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
       with:
         switches: -avzr
         path: build-tools/helm/tmp/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `Publish Snapshot Chart` GitHub Action Job by using `Git Hash` instead of the expired `Git Tag`.

### Why are the changes needed?

Since ASF Infra team removed expired refs, [Publish Snapshot Chart](https://github.com/apache/spark-kubernetes-operator/actions/workflows/publish_snapshot_chart.yml) Daily GitHub Action job is currently broken. We need to use `Git Hash` instead.
- https://github.com/apache/infrastructure-actions/commit/f65b1b9f5c4a50a7559fed2773a00f6361e1fe56

```yaml
burnett01/rsync-deployments:
-  '5.2':
-    expires_at: 2025-08-01
   0dc935cdecc5f5e571865e60d2a6cdc673704823:
     expires_at: 2050-01-01
     tag: '5.2'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.