### PR TITLE
[SPARK-53815] Remove `branch-0.4` from daily `publish_snapshot_*` GitHub Action jobs

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main", "branch-0.4"]'
+        default: '["main"]'
 
 jobs:
   publish-snapshot-chart:

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -10,7 +10,7 @@ on:
         description: 'list of branches to publish (JSON)'
         required: true
         # keep in sync with default value of strategy matrix 'branch'
-        default: '["main", "branch-0.4"]'
+        default: '["main"]'
 
 jobs:
   publish-snapshot-image:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `branch-0.4` from daily `publish_snapshot_*` GitHub Action jobs.

### Why are the changes needed?

Historically, this snapshot publish GitHub Action jobs are supposed to help the new releases, but we don't use it in these days like `branch-0.5` preparation and release.

We had better remove the legacy branch value, `branch-0.4` from `publish_snapshot_*` jobs and start to focus on new development of `v0.6` on `main` branch from now.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.