### PR TITLE
[SPARK-53817] Use `o.a.s.util.Pair` instead of `o.a.commons.lang3.tuple.Pair`

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -204,6 +204,7 @@
       <property name="illegalPkgs" value="org.apache.log4j"/>
       <property name="illegalPkgs" value="org.apache.commons.lang"/>
       <property name="illegalPkgs" value="org.apache.commons.collections"/>
+      <property name="illegalPkgs" value="org.apache.commons.lang3.tuple" />
     </module>
   </module>
 </module>

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptor.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/source/KubernetesMetricsInterceptor.java
@@ -35,9 +35,9 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import io.fabric8.kubernetes.client.http.*;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.spark.metrics.source.Source;
+import org.apache.spark.util.Pair;
 
 /** Interceptor for Kubernetes client to collect metrics. */
 @Slf4j
@@ -174,9 +174,9 @@ public class KubernetesMetricsInterceptor implements Interceptor, Source {
         parseNamespaceScopedResource(request.uri().getPath());
     resourceNamePairOptional.ifPresent(
         pair -> {
-          getMeterByRequestMethodAndResourceName(pair.getValue(), request.method()).mark();
+          getMeterByRequestMethodAndResourceName(pair.getRight(), request.method()).mark();
           getMeterByRequestMethodAndResourceName(
-                  pair.getKey() + "." + pair.getValue(), request.method())
+                  pair.getLeft() + "." + pair.getRight(), request.method())
               .mark();
         });
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to
- Use `org.apache.spark.util.Pair` class instead of `org.apache.commons.lang3.tuple.Pair`
- Add a Checkstyle rule to ban `org.apache.commons.lang3.tuple` package

### Why are the changes needed?

To be consistent with the Apache Spark main repository.
- apache/spark#51568

Since Java 16, we can use `Records` officially in Java and Spark supports `Pair` via Java Record.

| VERSION | JEP |
| - | - |
| Java 14 | [JEP 359: Records (Preview)](https://openjdk.org/jeps/359) |
| Java 15 | [JEP 384: Records (Second Preview)](https://openjdk.org/jeps/384) |
| Java 16 | [JEP 395: Records](https://openjdk.org/jeps/395) |

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.