### PR TITLE
[SPARK-53818] Improve `SentinelResourceState.toString` by JEP-280 instead of `ToStringBuilder`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManager.java
@@ -34,7 +34,6 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import org.apache.spark.k8s.operator.BaseResource;
 import org.apache.spark.k8s.operator.Constants;
@@ -240,11 +239,13 @@ public class SentinelManager<CR extends BaseResource<?, ?, ?, ?, ?>> {
      */
     @Override
     public String toString() {
-      return new ToStringBuilder(this)
-          .append("resource", resource)
-          .append("previousGeneration", previousGeneration)
-          .append("isHealthy", isHealthy)
-          .toString();
+      return "SentinelResourceState[resource="
+          + resource
+          + ",previousGeneration="
+          + previousGeneration
+          + ",isHealthy="
+          + isHealthy
+          + "]";
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SentinelResourceState.toString` by JEP-280 instead of `ToStringBuilder`.

### Why are the changes needed?

This is aligned with Apache Spark main repository improvement.
- https://github.com/apache/spark/pull/51572

Since Java 9, `String Concatenation` has been handled better by default.

| ID | DESCRIPTION |
| - | - |
| JEP-280 | [Indify String Concatenation](https://openjdk.org/jeps/280) |

For example, `SentinelResourceState.toString` is changed like the following by this PR.

**BEFORE**

```
  public java.lang.String toString();
    Code:
         0: new           #43                 // class org/apache/commons/lang3/builder/ToStringBuilder
         3: dup
         4: aload_0
         5: invokespecial #45                 // Method org/apache/commons/lang3/builder/ToStringBuilder."<init>":(Ljava/lang/Object;)V
         8: ldc           #48                 // String resource
        10: aload_0
        11: getfield      #17                 // Field resource:Lorg/apache/spark/k8s/operator/BaseResource;
        14: invokevirtual #49                 // Method org/apache/commons/lang3/builder/ToStringBuilder.append:(Ljava/lang/String;Ljava/lang/Object;)Lorg/apache/commons/lang3/builder/ToStringBuilder;
        17: ldc           #53                 // String previousGeneration
        19: aload_0
        20: getfield      #39                 // Field previousGeneration:J
        23: invokevirtual #54                 // Method org/apache/commons/lang3/builder/ToStringBuilder.append:(Ljava/lang/String;J)Lorg/apache/commons/lang3/builder/ToStringBuilder;
        26: ldc           #57                 // String isHealthy
        28: aload_0
        29: getfield      #13                 // Field isHealthy:Z
        32: invokevirtual #58                 // Method org/apache/commons/lang3/builder/ToStringBuilder.append:(Ljava/lang/String;Z)Lorg/apache/commons/lang3/builder/ToStringBuilder;
        35: invokevirtual #61                 // Method org/apache/commons/lang3/builder/ToStringBuilder.toString:()Ljava/lang/String;
        38: areturn
```

**AFTER**

```
  public java.lang.String toString();
    Code:
         0: aload_0
         1: getfield      #17                 // Field resource:Lorg/apache/spark/k8s/operator/BaseResource;
         4: invokestatic  #43                 // Method java/lang/String.valueOf:(Ljava/lang/Object;)Ljava/lang/String;
         7: aload_0
         8: getfield      #39                 // Field previousGeneration:J
        11: aload_0
        12: getfield      #13                 // Field isHealthy:Z
        15: invokedynamic #49,  0             // InvokeDynamic #0:makeConcatWithConstants:(Ljava/lang/String;JZ)Ljava/lang/String;
        20: areturn
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.