### PR TITLE
[SPARK-53821] Ban `org.apache.commons.lang3` package

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -204,7 +204,7 @@
       <property name="illegalPkgs" value="org.apache.log4j"/>
       <property name="illegalPkgs" value="org.apache.commons.lang"/>
       <property name="illegalPkgs" value="org.apache.commons.collections"/>
-      <property name="illegalPkgs" value="org.apache.commons.lang3.tuple" />
+      <property name="illegalPkgs" value="org.apache.commons.lang3" />
     </module>
   </module>
 </module>

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java
@@ -23,10 +23,10 @@ import static org.apache.spark.k8s.operator.Constants.API_GROUP;
 import static org.apache.spark.k8s.operator.Constants.API_VERSION;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import org.apache.commons.lang3.reflect.FieldUtils;
 
 import org.apache.spark.k8s.operator.Constants;
 import org.apache.spark.k8s.operator.SparkApplication;
@@ -66,9 +66,15 @@ public final class TestUtils {
     return System.currentTimeMillis() - startTime;
   }
 
+  @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   public static <T> void setConfigKey(ConfigOption<T> configKey, T newValue) {
     try {
-      FieldUtils.writeField(configKey, "defaultValue", newValue, true);
+      Class<?> targetClass = configKey.getClass();
+      Field field = targetClass.getDeclaredField("defaultValue");
+      field.setAccessible(true);
+      field.set(configKey, newValue);
+    } catch (NoSuchFieldException e) {
+      throw new IllegalStateException(e);
     } catch (IllegalAccessException e) {
       throw new UnsupportedOperationException(e);
     }

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 
 import scala.Option;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
@@ -63,7 +62,7 @@ class SparkAppDriverConfTest {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("foo", "bar");
     sparkConf.set("spark.executor.instances", "1");
-    String appId = RandomStringUtils.randomAlphabetic(1000);
+    String appId = "a".repeat(1000);
     SparkAppDriverConf sparkAppDriverConf =
         SparkAppDriverConf.create(
             sparkConf, appId, mock(JavaMainAppResource.class), "foo", null, Option.empty());

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 
@@ -209,8 +208,8 @@ class SparkAppSubmissionWorkerTest {
 
   @Test
   void generatedSparkAppIdShouldComplyLengthLimit() {
-    String namespaceName = RandomStringUtils.randomAlphabetic(253);
-    String appName = RandomStringUtils.randomAlphabetic(253);
+    String namespaceName = "n".repeat(253);
+    String appName = "a".repeat(253);
 
     SparkApplication mockApp = mock(SparkApplication.class);
     ObjectMeta appMeta =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `org.apache.commons.lang3` package.

### Why are the changes needed?

To be independent from 3rd party library as much as possible.

Currently, we only use 3 places in test code.

```
$ git grep org.apache.commons.lang3 | grep -v checkstyle
spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/TestUtils.java:import org.apache.commons.lang3.reflect.FieldUtils;
spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java:import org.apache.commons.lang3.RandomStringUtils;
spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java:import org.apache.commons.lang3.RandomStringUtils;
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.