### PR TITLE
[SPARK-53826] Use Java 25 in GitHub Action jobs consistently

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,10 +55,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: 'zulu'
           cache: 'gradle'
       - name: Build Operator Image
@@ -98,10 +98,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'gradle'
       - name: Set up Minikube
@@ -163,10 +163,10 @@ jobs:
           DEFAULT_BRANCH: main
           VALIDATE_MARKDOWN: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: 'zulu'
           cache: 'gradle'
       - name: Linters

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -26,10 +26,10 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{ matrix.branch }}
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 25
         distribution: 'zulu'
         cache: 'gradle'
     - name: Build Operator


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 25 in `GitHub Action` jobs consistently.
- https://github.com/apache/spark-kubernetes-operator/actions/workflows/build_and_test.yml
- https://github.com/apache/spark-kubernetes-operator/actions/workflows/publish_snapshot_chart.yml

### Why are the changes needed?

We had better use Java 25 by default because our tool chain is `Java 25`.
- #336

**BEFORE**

```
$ git grep 'java-version: 17' | wc -l
       3
$ git grep 'java-version: 21' | wc -l
       1
```

**AFTER**

```
$ git grep 'java-version: 17' | wc -l
       0
$ git grep 'java-version: 21' | wc -l
       0
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.