### PR TITLE
[SPARK-53830] Exclude `.idea` directory from `Spotless` check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ apply plugin: 'com.diffplug.spotless'
 spotless {
   format 'misc', {
     target '*.md', '*.gradle', '**/*.properties', '**/*.xml', '**/*.yaml', '**/*.yml'
+    targetExclude "**/.idea/**"
     endWithNewline()
     trimTrailingWhitespace()
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `.idea` directory from `Spotless` check.

### Why are the changes needed?

Currently, `Spotless` complains at `IntelliJ` files like the following. We should ignore these auto-generated files.

```
Execution failed for task ':spotlessMiscCheck'.
> The following files had format violations:
      .idea/codeStyles/Project.xml
          @@ -4,4 +4,4 @@
           ······<option·name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE"·value="true"·/>
           ····</ScalaCodeStyleSettings>
           ··</code_scheme>
          -</component>
          +</component>
      .idea/codeStyles/codeStyleConfig.xml
          @@ -2,4 +2,4 @@
           ··<state>
           ····<option·name="PREFERRED_PROJECT_CODE_STYLE"·value="Default"·/>
           ··</state>
          -</component>
          +</component>
      .idea/compiler.xml
          @@ -28,4 +28,4 @@
           ······<module·name="apache-spark-kubernetes-operator.spark-submission-worker.test"·options="-proc:full"·/>
           ····</option>
           ··</component>
          -</project>
          +</project>
      .idea/gradle.xml
          @@ -17,4 +17,4 @@
           ······</GradleProjectSettings>
           ····</option>
           ··</component>
          -</project>
          +</project>
      .idea/misc.xml
          @@ -2,4 +2,4 @@
           <project·version="4">
           ··<component·name="ExternalStorageConfigurationManager"·enabled="true"·/>
           ··<component·name="ProjectRootManager"·version="2"·languageLevel="JDK_X"·project-jdk-name="25"·project-jdk-type="JavaSDK"·/>
          -</project>
          +</project>
      .idea/vcs.xml
          @@ -3,4 +3,4 @@
           ··<component·name="VcsDirectoryMappings">
           ····<mapping·directory=""·vcs="Git"·/>
           ··</component>
          -</project>
          +</project>
      .idea/workspace.xml
          @@ -60,4 +60,4 @@
           ··<component·name="TypeScriptGeneratedFilesManager">
           ····<option·name="version"·value="3"·/>
           ··</component>
          -</project>
          +</project>
  Run './gradlew :spotlessApply' to fix these violations.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.