### PR TITLE
[SPARK-53851] Set `io.netty.noUnsafe` to `true` to avoid JEP-498 warnings

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -41,7 +41,7 @@ operatorDeployment:
     # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     topologySpreadConstraints: [ ]
     operatorContainer:
-      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80"
+      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80 -Dio.netty.noUnsafe=true"
       env:
         - name: "SPARK_USER"
           value: "spark"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `io.netty.noUnsafe` to `true` to avoid JEP-498 warnings.

### Why are the changes needed?

Java 24 has started to print warnings when `sub.misc.Unsafe` is used to access memory.
- https://openjdk.org/jeps/498

Since Netty 4.1.120.Final, we can use `io.netty.noUnsafe` setting.
- https://github.com/netty/netty/pull/14943

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manually tests.

**BEFORE**

```
Starting Operator...
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::allocateMemory has been called by io.netty.util.internal.PlatformDependent0$2 (file:/opt/spark-operator/operator/spark-kubernetes-operator.jar)
WARNING: Please consider reporting this to the maintainers of class io.netty.util.internal.PlatformDependent0$2
WARNING: sun.misc.Unsafe::allocateMemory will be removed in a future release
25/10/09 03:35:46 INFO   o.a.s.k.o.SparkOperator Configuring operator with 50 reconciliation threads.
```

**AFTER**

```
Starting Operator...
25/10/09 03:32:21 INFO   o.a.s.k.o.SparkOperator Configuring operator with 50 reconciliation threads.
```

### Was this patch authored or co-authored using generative AI tooling?

No.