### PR TITLE
[SPARK-53863] Remove `Java 17` requirement from `deploy.gradle`

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-if (project.hasProperty('release') && JavaVersion.current().getMajorVersion().toString() != '17') {
-  throw new GradleException("Releases must be built with Java 17")
-}
-
 subprojects {
   apply plugin: 'org.cyclonedx.bom'
   apply plugin: 'maven-publish'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Java 17` requirement from `deploy.gradle`.

### Why are the changes needed?

After the following, Java 17 requirement is not required because our tool chain will use Java 25 always with `release: 17`.
- #336 

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.