### PR TITLE
[SPARK-53869] Support multiple files in `pyFiles` field

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -139,6 +139,12 @@ public class SparkAppSubmissionWorker {
     if (StringUtils.isNotEmpty(applicationSpec.getJars())) {
       primaryResource = new JavaMainAppResource(Option.apply(applicationSpec.getJars()));
       effectiveSparkConf.setIfMissing("spark.jars", applicationSpec.getJars());
+    } else if ("org.apache.spark.deploy.PythonRunner".equals(applicationSpec.getMainClass())) {
+      String[] files = applicationSpec.getPyFiles().split(",", 2);
+      primaryResource = new PythonMainAppResource(files[0]);
+      if (files.length > 1 && !files[1].isBlank()) {
+        effectiveSparkConf.setIfMissing("spark.submit.pyFiles", files[1]);
+      }
     } else if (StringUtils.isNotEmpty(applicationSpec.getPyFiles())) {
       primaryResource = new PythonMainAppResource(applicationSpec.getPyFiles());
       effectiveSparkConf.setIfMissing("spark.submit.pyFiles", applicationSpec.getPyFiles());


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support multiple files in `SparkApplication`'s `pyFiles` field.

### Why are the changes needed?

Currently, `pyFiles` is mapped to the main resource directly because it assumes a single Python file.

https://github.com/apache/spark-kubernetes-operator/blob/75515c752086853b1676cff39c7fc84b99163dc0/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java#L143

However, it's supposed to be a comma-separated string. If users provide multiple files, t causes a failure like the following.

```
python3: can't open file '/opt/spark/examples/src/main/python/pi.py,local:///opt/spark/examples/src/main/python/sort.py': [Errno 2] │
```

This PR proposes a mitigation to handle the first file of `pyFiles` as the primary resource and the rest of files as the real `pyFiles`. Note that the previous logic works without any change and new logic is going to be applied only when `mainClass` is `org.apache.spark.deploy.PythonRunner` specified additionally.

**BEFORE**

```yaml
spec:
  pyFiles: "local:///opt/spark/examples/src/main/python/pi.py"
```

**AFTER**

```yaml
spec:
  mainClass: "org.apache.spark.deploy.PythonRunner"
  pyFiles: "local:///opt/spark/examples/src/main/python/pi.py,local:///opt/spark/examples/src/main/python/lib.py"
```

### Does this PR introduce _any_ user-facing change?

No behavior change because new logic works only when `mainClass` is `org.apache.spark.deploy.PythonRunner`.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.