### PR TITLE
[SPARK-53871] Upgrade `JUnit` to 6.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ log4j = "2.24.3"
 slf4j = "2.0.17"
 
 # Test
-junit = "5.13.4"
+junit = "6.0.0"
 jacoco = "0.8.13"
 mockito = "5.20.0"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `JUnit` to 6.0.0.

### Why are the changes needed?

JUnit 6 is released finally.
- https://docs.junit.org/6.0.0/release-notes/ (2025-09-30)
  - Minimum required Java version is 17.
  - Single version number for Platform, Jupiter, and Vintage

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a test dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.