### PR TITLE
[SPARK-53909] Fix RBAC to allow `Spark` driver to create `StatefulSet`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -27,6 +27,12 @@ rules:
       - persistentvolumeclaims
     verbs:
       - '*'
+  - apiGroups:
+      - "apps"
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix RBAC to allow `Spark` driver to create `StatefulSet`.

### Why are the changes needed?

We need to fix this to allow Apache Spark's `StatefulSetPodsAllocator` which was introduced at Apache Spark 3.3.0.
- https://github.com/apache/spark/pull/33508

### Does this PR introduce _any_ user-facing change?

No, this is an additional permission.

### How was this patch tested?

Manual review. 

### Was this patch authored or co-authored using generative AI tooling?

No.