### PR TITLE
[SPARK-53912] Add `cluster-preview.yaml` and `spark-connect-server-preview.yaml`

### DIFF
--- a/examples/cluster-preview.yaml
+++ b/examples/cluster-preview.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkCluster
+metadata:
+  name: cluster-preview
+spec:
+  runtimeVersions:
+    sparkVersion: "4.1.0-preview2"
+  clusterTolerations:
+    instanceConfig:
+      initWorkers: 3
+      minWorkers: 3
+      maxWorkers: 3
+  sparkConf:
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
+    spark.master.ui.title: "Prod Spark Cluster"
+    spark.master.rest.enabled: "true"
+    spark.master.rest.host: "0.0.0.0"
+    spark.ui.reverseProxy: "true"

--- a/examples/spark-connect-server-preview.yaml
+++ b/examples/spark-connect-server-preview.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: spark-connect-server-preview
+spec:
+  mainClass: "org.apache.spark.sql.connect.service.SparkConnectServer"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.minExecutors: "3"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    sparkVersion: "4.1.0-preview2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add two `Apache Spark 4.1.0-preview2`-based examples.
- `cluster-preview.yaml`: `4.1.0-preview2`-based SparkCluster
- `spark-connect-server-preview.yaml`: `4.1.0-preview2`-based Connect Server SparkApp.

### Why are the changes needed?

This has two goals.
1. Provide an easy way to access 4.1.0-preview2.
2. Provide the example of `apache/spark:{{SPARK_VERSION}}`.

### Does this PR introduce _any_ user-facing change?

No, these are new examples.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.