### PR TITLE
[SPARK-53984] Use CRD `v1` instead of `v1beta1` in `benchmark` script

### DIFF
--- a/tests/benchmark/sparkapps.sh
+++ b/tests/benchmark/sparkapps.sh
@@ -29,7 +29,7 @@ filename=$(mktemp)
 
 for i in $(seq -f "%05g" 1 $NUM); do
   cat << EOF >> $filename
-apiVersion: spark.apache.org/v1beta1
+apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
   name: test-${i}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use CRD `v1` instead of `v1beta1` in `benchmark` script.

### Why are the changes needed?

Since `v0.5`, CRD becomes `v1`.

Since we will compare the benchmark with `v0.5` since `v0.6`, we can update this to `v1` finally.

### Does this PR introduce _any_ user-facing change?

No, this is a test code change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.