### PR TITLE
[SPARK-53985] Suppress `StatusRecorder` warning messages

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
@@ -96,14 +96,14 @@ public class StatusRecorder<
     Exception err = null;
     long maxRetry = API_STATUS_PATCH_MAX_ATTEMPTS.getValue();
     for (long i = 0; i < maxRetry; i++) {
-      // We retry the status update 3 times to avoid some intermittent connectivity errors
+      // We retry the status update maxRetry times to avoid some intermittent connectivity errors
       try {
         CR updated = client.resource(resource).lockResourceVersion().updateStatus();
         resource.getMetadata().setResourceVersion(updated.getMetadata().getResourceVersion());
         err = null;
         break;
       } catch (KubernetesClientException e) {
-        log.warn("Error while patching status, retrying {}/{}...", i + 1, maxRetry, e);
+        log.debug("Error while patching status, retrying {}/{}...", i + 1, maxRetry, e);
         Thread.sleep(TimeUnit.SECONDS.toMillis(API_RETRY_ATTEMPT_AFTER_SECONDS.getValue()));
         err = e;
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to suppress `StatusRecorder` warning messages.

### Why are the changes needed?

Currently, `StatusRecorder` shows `WARN` messages too verbosely at most `spark.kubernetes.operator.api.statusPatchMaxAttempts` times. Then, it will show `ERROR` message at the end.
```
25/10/22 17:17:32 WARN test-00672 default o.a.s.k.o.u.StatusRecorder Error while patching status, retrying 2/3...
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PUT at: https://xxx:443/apis/spark.apache.org/v1/namespaces/default/sparkapplications/test-00672/status. Message: Operation cannot be fulfilled on sparkapplications.spark.apache.org "test-00672": the object has been modified; please apply your changes to the latest version and try again. Received status: Status(apiVersion=v1, code=409, details=StatusDetails(causes=[], group=spark.apache.org, kind=sparkapplications, name=test-00672, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=Operation cannot be fulfilled on sparkapplications.spark.apache.org "test-00672": the object has been modified; please apply your changes to the latest version and try again, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Conflict, status=Failure, additionalProperties={}).
	at io.fabric8.kubernetes.client.KubernetesClientException.copyAsCause(KubernetesClientException.java:205)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.waitForResult(OperationSupport.java:507)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleResponse(OperationSupport.java:524)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.handleUpdate(OperationSupport.java:358)
	at io.fabric8.kubernetes.client.dsl.internal.BaseOperation.handleUpdate(BaseOperation.java:759)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.update(HasMetadataOperation.java:138)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.update(HasMetadataOperation.java:121)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.updateStatus(HasMetadataOperation.java:126)
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.updateStatus(HasMetadataOperation.java:44)
	at org.apache.spark.k8s.operator.utils.StatusRecorder.patchAndStatusWithVersionLocked(StatusRecorder.java:101)
```

We can switch `WARN` to `DEBUG` during retrying `spark.kubernetes.operator.api.statusPatchMaxAttempts` times because it's recoverable.

### Does this PR introduce _any_ user-facing change?

No. This is a log message change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.