### PR TITLE
[SPARK-53987] Upgrade `JaCoCo` to 0.8.14 for official Java 25 support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ slf4j = "2.0.17"
 
 # Test
 junit = "6.0.0"
-jacoco = "0.8.13"
+jacoco = "0.8.14"
 mockito = "5.20.0"
 
 # Build Analysis


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `JaCoCo` to 0.8.14 for official Java 25 support (and Java 26 experimental support).

### Why are the changes needed?

`JaCoCo` 0.8.14 is the first version to support Java 25 officially and Java 26 experimentally.
- https://github.com/jacoco/jacoco/releases/tag/v0.8.14
  - https://github.com/jacoco/jacoco/issues/1950
  - https://github.com/jacoco/jacoco/issues/1965 (Java 26)

### Does this PR introduce _any_ user-facing change?

No. This is a test dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.