### PR TITLE
[SPARK-53989] Optimize `sparkapps.sh` to use `kubectl delete --all`

### DIFF
--- a/tests/benchmark/sparkapps.sh
+++ b/tests/benchmark/sparkapps.sh
@@ -19,7 +19,7 @@
 
 # 1. Clear the existing CRDs before staring the benchmark
 echo "CLEAN UP NAMESPACE FOR BENCHMARK"
-kubectl get sparkapplications.spark.apache.org -o name | xargs kubectl delete
+kubectl delete sparkapplications.spark.apache.org --all
 
 NUM="${1:-1000}"
 echo "START BENCHMARK WITH $NUM JOBS"
@@ -62,7 +62,7 @@ echo "FINISHED $NUM JOBS IN $completionTime SECONDS."
 
 # 3. Deletion Benchmark
 start=`date +%s`
-kubectl get sparkapplications.spark.apache.org -o name | xargs kubectl delete > /dev/null
+kubectl delete sparkapplications.spark.apache.org --all > /dev/null
 end=`date +%s`
 deletionTime=$((end - start))
 echo "DELETED $NUM JOBS IN $deletionTime SECONDS."


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to optimize `sparkapps.sh` to use `kubectl delete --all` instead of BASH pipelining.

### Why are the changes needed?

To use the K8s native features efficiently.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.