### PR TITLE
[SPARK-53992] Add `SparkOperatorConfManager.getAll` method

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/SparkOperatorConfManager.java
@@ -61,6 +61,21 @@ public class SparkOperatorConfManager {
   }
 
   /**
+   * Returns all properties.
+   *
+   * @return a Properties instance contains all properties.
+   */
+  public Properties getAll() {
+    synchronized (this) {
+      Properties properties = new Properties();
+      properties.putAll(initialConfig);
+      properties.putAll(metricsConfig);
+      properties.putAll(configOverrides);
+      return properties;
+    }
+  }
+
+  /**
    * Returns the current value for a given configuration key, considering dynamic overrides.
    *
    * @param key The configuration key.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `SparkOperatorConfManager.getAll` method to get all configurations.

### Why are the changes needed?

Like Apache Spark `SparkConf.getAll` API, we had better support `getAll` API.

https://github.com/apache/spark/blob/0be5f96e7a7d1b9fb9f96f1914019f79ef973a25/core/src/main/scala/org/apache/spark/SparkConf.scala#L197

```scala
/** Get all parameters as a list of pairs */
def getAll: Array[(String, String)]
```

### Does this PR introduce _any_ user-facing change?

No because this is a new API.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.