### PR TITLE
[SPARK-53994] Exclude `KerberosConfDriverFeatureStep` during benchmarking

### DIFF
--- a/tests/benchmark/sparkapps.sh
+++ b/tests/benchmark/sparkapps.sh
@@ -40,10 +40,11 @@ spec:
   sparkConf:
     spark.driver.memory: "256m"
     spark.driver.memoryOverhead: "0m"
-    spark.kubernetes.driver.request.cores: "100m"
-    spark.kubernetes.driver.master: "local[1]"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.1-java21-scala"
+    spark.kubernetes.driver.master: "local[1]"
+    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
+    spark.kubernetes.driver.request.cores: "100m"
   runtimeVersions:
     sparkVersion: "4.0.1"
 ---


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `KerberosConfDriverFeatureStep` during benchmarking because this is not used during `SparkApp` submission benchmark.

### Why are the changes needed?

To suppress irrelevant warning messages from Hadoop layer.

### Does this PR introduce _any_ user-facing change?

No. This is a test script change.

### How was this patch tested?

Manual review.

```
$ ./tests/benchmark/sparkapps.sh
CLEAN UP NAMESPACE FOR BENCHMARK
No resources found
START BENCHMARK WITH 1000 JOBS
FINISHED 1000 JOBS IN 193 SECONDS.
DELETED 1000 JOBS IN 254 SECONDS.
```

### Was this patch authored or co-authored using generative AI tooling?

No.