### PR TITLE
[SPARK-54070] Add `spark.logConf`  configuration to operator docs

### DIFF
--- a/docs/config_properties.md
+++ b/docs/config_properties.md
@@ -2,6 +2,7 @@
 # Spark Operator Config Properties
  | Key | Type | Default Value | Allow Hot Reloading | Description | 
  | --- | --- | --- | --- | --- | 
+ | spark.logConf | Boolean | false | true | When enabled, operator will print configurations | 
  | spark.kubernetes.operator.name | String | spark-kubernetes-operator | false | Name of the operator. | 
  | spark.kubernetes.operator.namespace | String | default | false | Namespace that operator is deployed within. | 
  | spark.kubernetes.operator.watchedNamespaces | String | default | true | Comma-separated list of namespaces that the operator would be watching for Spark resources. If set to '*', operator would watch all namespaces. | 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow up on SPARK-53993, adding the new config properties to documents

### Why are the changes needed?

To enhance the documents.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CIs

### Was this patch authored or co-authored using generative AI tooling?

No

