### PR TITLE
[SPARK-54081] Add `word-count-preview.yaml` Example

### DIFF
--- a/examples/word-count-preview.yaml
+++ b/examples/word-count-preview.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: word-count
+spec:
+  mainClass: "org.apache.spark.examples.JavaWordCount"
+  driverArgs: [ "/opt/spark/RELEASE" ]
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-java21-scala"
+    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    sparkVersion: "4.1.0-preview2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `word-count-preview.yaml` Example.

### Why are the changes needed?

To provide a Spark Job shuffle example.

<img width="396" height="212" alt="Screenshot 2025-10-29 at 21 14 08" src="https://github.com/user-attachments/assets/3945b010-7962-4c91-81f0-ed9199e65ab7" />

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a new example.

### How was this patch tested?

Manual review.

```
$ kubectl apply -f examples/word-count-preview.yaml
```

```
$ kubectl logs -f word-count-0-driver
...
25/10/29 23:48:04 INFO DAGScheduler: Job 0 finished: collect at JavaWordCount.java:53, took 3544.885793 ms
-Psparkr: 1
-B: 1
Spark: 1
-Pkubernetes: 1
-Pyarn: 1
revision: 1
Build: 1
built: 1
c5ff48cc2b2): 1
(git: 1
-Phadoop-3: 1
4.1.0-preview2: 1
flags:: 1
-Phive-thriftserver: 1
for: 1
-Phive: 1
3.4.2: 1
Hadoop: 1
```

```
$ k get sparkapp
NAME         CURRENT STATE      AGE
word-count   ResourceReleased   2m35s
```

### Was this patch authored or co-authored using generative AI tooling?

No.