### PR TITLE
[SPARK-54082] Upgrade Spark to `4.1.0-preview3`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ fabric8 = "7.4.0"
 lombok = "1.18.42"
 operator-sdk = "5.1.4"
 dropwizard-metrics = "4.2.33"
-spark = "4.1.0-preview2"
+spark = "4.1.0-preview3"
 log4j = "2.24.3"
 slf4j = "2.0.17"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to `4.1.0-preview3`.

### Why are the changes needed?

Apache Spark 4.1.0-preview3 arrived.
- https://spark.apache.org/docs/4.1.0-preview3/
- https://archive.apache.org/dist/spark/spark-4.1.0-preview3/

### Does this PR introduce _any_ user-facing change?

To be ready to use the latest Apache Spark 4.1.0 features.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.