### PR TITLE
[SPARK-54098] Set `--sun-misc-unsafe-memory-access=allow` for `JavaExec` Gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ subprojects {
     options.compilerArgs.add("-proc:full")
   }
 
+  tasks.withType(JavaExec).configureEach {
+    jvmArgs '--sun-misc-unsafe-memory-access=allow'
+  }
+
   repositories {
     // Google Mirror of Maven Central, placed first so that it's used instead of flaky Maven Central.
     // See https://storage-download.googleapis.com/maven-central/index.html


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `--sun-misc-unsafe-memory-access=allow` JVM option for `JavaExec`-type Gradle tasks.

### Why are the changes needed?

To suppress the following JVM warning messages

```
> Task :spark-operator-api:compileJava
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit
WARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs and manually check.

```
$ gradle spark-operator-api:compileJava
Starting a Gradle Daemon, 4 stopped Daemons could not be reused, use --status for details

> Configure project :spark-operator-api
Updating PrinterColumns for generated CRD
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit
WARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
...
```

### Was this patch authored or co-authored using generative AI tooling?

No.