### PR TITLE
[SPARK-54107] Use `4.1.0-preview3-java21-scala` image for preview examples

### DIFF
--- a/examples/cluster-preview.yaml
+++ b/examples/cluster-preview.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-preview
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/pi-preview-with-eventlog.yaml
+++ b/examples/pi-preview-with-eventlog.yaml
@@ -26,7 +26,7 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-java21-scala"
     spark.eventLog.enabled: "true"
     spark.eventLog.dir: "s3a://spark-events/"
     spark.hadoop.fs.s3a.endpoint: "http://localstack:4566"
@@ -37,4 +37,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"

--- a/examples/pi-preview.yaml
+++ b/examples/pi-preview.yaml
@@ -24,9 +24,9 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-java21-scala"
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"

--- a/examples/spark-connect-server-preview.yaml
+++ b/examples/spark-connect-server-preview.yaml
@@ -24,11 +24,11 @@ spec:
     spark.dynamicAllocation.minExecutors: "3"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-java21-scala"
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.executor.podNamePrefix: "spark-connect-server-preview"
     spark.scheduler.mode: "FAIR"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"

--- a/examples/spark-history-server-preview.yaml
+++ b/examples/spark-history-server-preview.yaml
@@ -23,7 +23,7 @@ spec:
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.driver.memory: "2g"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.0-preview2-java21-scala"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-java21-scala"
     spark.ui.port: "18080"
     spark.history.fs.logDirectory: "s3a://spark-events"
     spark.history.fs.cleaner.enabled: "true"
@@ -36,7 +36,7 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/spark-thrift-server-preview.yaml
+++ b/examples/spark-thrift-server-preview.yaml
@@ -29,7 +29,7 @@ spec:
     spark.kubernetes.executor.podNamePrefix: "spark-thrift-server-preview"
     spark.scheduler.mode: "FAIR"
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/word-count-preview.yaml
+++ b/examples/word-count-preview.yaml
@@ -29,4 +29,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview2"
+    sparkVersion: "4.1.0-preview3"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `4.1.0-preview3-java21-scala` image for all preview examples.

### Why are the changes needed?

To use the latest images via Apache Spark 4.1.0-preview3.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is only updating examples.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.