### PR TITLE
[SPARK-54432] Use `4.1.0-preview4-java21-scala` image for preview examples

### DIFF
--- a/examples/cluster-preview.yaml
+++ b/examples/cluster-preview.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-preview
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/pi-preview-with-eventlog.yaml
+++ b/examples/pi-preview-with-eventlog.yaml
@@ -37,4 +37,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"

--- a/examples/pi-preview.yaml
+++ b/examples/pi-preview.yaml
@@ -29,4 +29,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"

--- a/examples/spark-connect-server-preview.yaml
+++ b/examples/spark-connect-server-preview.yaml
@@ -31,4 +31,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"

--- a/examples/spark-history-server-preview.yaml
+++ b/examples/spark-history-server-preview.yaml
@@ -36,7 +36,7 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/spark-thrift-server-preview.yaml
+++ b/examples/spark-thrift-server-preview.yaml
@@ -29,7 +29,7 @@ spec:
     spark.kubernetes.executor.podNamePrefix: "spark-thrift-server-preview"
     spark.scheduler.mode: "FAIR"
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/word-count-preview.yaml
+++ b/examples/word-count-preview.yaml
@@ -29,4 +29,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.0-preview3"
+    sparkVersion: "4.1.0-preview4"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `4.1.0-preview4-java21-scala` image for all preview examples.

### Why are the changes needed?

To use the bug-fixed latest images via Apache Spark 4.1.0-preview4.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is only updating examples.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.