### PR TITLE
Change volumeMounts and volumes types to array

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.schema.json
+++ b/build-tools/helm/spark-kubernetes-operator/values.schema.json
@@ -162,7 +162,7 @@
                   }
                 },
                 "volumeMounts": {
-                  "type": "object",
+                  "type": "array",
                   "description": "Container volume mounts",
                   "additionalProperties": true
                 },
@@ -304,7 +304,7 @@
               "additionalProperties": true
             },
             "volumes": {
-              "type": "object",
+              "type": "array",
               "description": "Pod volumes",
               "additionalProperties": true
             },


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request updates the schema definitions in `build-tools/helm/spark-kubernetes-operator/values.schema.json` to improve compatibility with Kubernetes conventions. The main change is updating the types for `volumeMounts` and `volumes` from `object` to `array`, which better reflects how these fields are typically structured in Kubernetes manifests.

* Changed the `type` of `volumeMounts` from `object` to `array` to match standard Kubernetes configuration for container volume mounts.
* Changed the `type` of `volumes` from `object` to `array` to align with Kubernetes pod volume definitions.

### Why are the changes needed?
bug, cannot use volumes fields, the helm chart fall in error or for values.json validation, or in yaml rendering

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?


### Was this patch authored or co-authored using generative AI tooling?
No