### PR TITLE
[SPARK-54658] Add `Apache DataFusion Comet` example

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -20,20 +20,22 @@ spec:
   mainClass: "org.apache.spark.examples.SparkPi"
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
-    spark.executor.extraClassPath: "local:///comet/comet.jar"
-    spark.driver.extraClassPath: "local:///comet/comet.jar"
-    spark.plugins: "org.apache.spark.CometPlugin"
     spark.comet.enabled: "true"
     spark.comet.exec.enabled: "true"
     spark.comet.exec.shuffle.enabled: "true"
     spark.comet.exec.shuffle.mode: "auto"
-    spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
+    spark.driver.extraClassPath: "local:///comet/comet.jar"
     spark.dynamicAllocation.enabled: "true"
-    spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.executor.extraClassPath: "local:///comet/comet.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:3.5.7-java17"
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
+    spark.memory.offHeap.enabled: "true"
+    spark.memory.offHeap.size: "1g"
+    spark.plugins: "org.apache.spark.CometPlugin"
+    spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   driverSpec:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Apache DataFusion Comet` example.

### Why are the changes needed?

To illustrate how to accelerate Apache Spark via Comet project.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manually.

```
$ kubectl apply -f examples/pi-with-comet.yaml

$ kubectl logs -f pi-with-comet-0-driver | grep Comet
Defaulted container "spark-kubernetes-driver" out of: spark-kubernetes-driver, download-comet (init)
25/12/10 00:51:32 INFO CometDriverPlugin: CometDriverPlugin init
25/12/10 00:51:32 INFO CometDriverPlugin: Setting spark.sql.extensions=org.apache.comet.CometSparkSessionExtensions
25/12/10 00:51:32 INFO CometDriverPlugin: Comet is running in unified memory mode and sharing off-heap memory with Spark
25/12/10 00:51:32 INFO DriverPluginContainer: Initialized driver component for plugin org.apache.spark.CometPlugin.
25/12/10 00:51:40 INFO CometDriverPlugin: CometDriverPlugin shutdown

$ kubectl get sparkapp
NAME            CURRENT STATE      AGE
pi-with-comet   ResourceReleased   39s
```

### Was this patch authored or co-authored using generative AI tooling?

No.
