### PR TITLE
[SPARK-54671] Upgrade `operator-sdk` to 5.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.4.0"
 lombok = "1.18.42"
-operator-sdk = "5.1.4"
+operator-sdk = "5.2.1"
 dropwizard-metrics = "4.2.33"
 spark = "4.1.0-preview4"
 log4j = "2.24.3"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `operator-sdk` to 5.2.1

### Why are the changes needed?

To bring the latest improvements and bug fixes:
- https://javaoperatorsdk.io/blog/2025/11/25/version-5.2-released/
  - https://github.com/operator-framework/java-operator-sdk/releases/tag/v5.2.1
  - https://github.com/operator-framework/java-operator-sdk/releases/tag/v5.2.0
      - https://github.com/operator-framework/java-operator-sdk/pull/2937
      - https://github.com/operator-framework/java-operator-sdk/pull/2934
      - https://github.com/operator-framework/java-operator-sdk/pull/2917
      - https://github.com/operator-framework/java-operator-sdk/pull/2835

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.