### PR TITLE
[SPARK-54674] Fix `AppValidateStep` to prevent `ClientMode` deployment correctly

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppValidateStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppValidateStep.java
@@ -50,7 +50,7 @@ public class AppValidateStep extends AppReconcileStep {
       log.warn("Spark application found with empty status. Resetting to initial state.");
       return attemptStatusUpdate(context, statusRecorder, new ApplicationStatus(), proceed());
     }
-    if (ClientMode.equals(context.getResource().getSpec())) {
+    if (ClientMode.equals(context.getResource().getSpec().getDeploymentMode())) {
       ApplicationState failure =
           new ApplicationState(ApplicationStateSummary.Failed, "Client mode is not supported yet.");
       return attemptStatusUpdate(

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppInitStepTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/AppInitStepTest.java
@@ -50,6 +50,7 @@ import org.mockito.ArgumentCaptor;
 import org.apache.spark.k8s.operator.SparkApplication;
 import org.apache.spark.k8s.operator.context.SparkAppContext;
 import org.apache.spark.k8s.operator.reconciler.ReconcileProgress;
+import org.apache.spark.k8s.operator.spec.DeploymentMode;
 import org.apache.spark.k8s.operator.utils.SparkAppStatusRecorder;
 
 @EnableKubernetesMockClient(crud = true)
@@ -223,5 +224,20 @@ class AppInitStepTest {
         kubernetesClient.configMaps().inNamespace("default").withName("resource-configmap").get();
     Assertions.assertNotNull(createCM);
     Assertions.assertNotNull(createdPod);
+  }
+
+  @Test
+  void banClientMode() {
+    AppValidateStep appValidateStep = new AppValidateStep();
+    SparkAppContext mocksparkAppContext = mock(SparkAppContext.class);
+    SparkAppStatusRecorder recorder = mock(SparkAppStatusRecorder.class);
+    SparkApplication application = new SparkApplication();
+    application.setMetadata(applicationMetadata);
+    application.getSpec().setDeploymentMode(DeploymentMode.ClientMode);
+    when(mocksparkAppContext.getResource()).thenReturn(application);
+
+    appValidateStep.reconcile(mocksparkAppContext, recorder);
+    ReconcileProgress progress = appValidateStep.reconcile(mocksparkAppContext, recorder);
+    Assertions.assertEquals(ReconcileProgress.completeAndImmediateRequeue(), progress);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `AppValidateStep` to prevent `ClientMode` deployment.

### Why are the changes needed?

Unfortunately, this feature never works before because it didn't work from the initial implementation since v0.1.
- https://github.com/apache/spark-kubernetes-operator/pull/12

To protect users from invalid use cases.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.