### PR TITLE
[SPARK-54680] Upgrade `actions/checkout` to v6

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Check license header
         uses: apache/skywalking-eyes@main
         env:
@@ -38,7 +38,7 @@ jobs:
         java-version: [ 17, 21, 25 ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
@@ -97,7 +97,7 @@ jobs:
             test-group: watched-namespaces
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
@@ -154,7 +154,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Super-Linter

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
     if: github.repository == 'apache/spark-kubernetes-operator'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -23,7 +23,7 @@ jobs:
         branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         ref: ${{ matrix.branch }}
     - name: Set up JDK 25

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -32,7 +32,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         ref: ${{ matrix.branch }}
     - name: Build and push


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `actions/checkout` to v6.

### Why are the changes needed?

To use more secure version:
- https://github.com/actions/checkout/pull/2286

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.