### PR TITLE
[SPARK-54757] Update `SparkClusterResourceSpec` to use `apache/spark:4.1.0` as the default value of container image

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -65,7 +65,7 @@ public class SparkClusterResourceSpec {
     String clusterName = cluster.getMetadata().getName();
     String scheduler = conf.get(Config.KUBERNETES_SCHEDULER_NAME().key(), "default-scheduler");
     String namespace = conf.get(Config.KUBERNETES_NAMESPACE().key(), clusterNamespace);
-    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.0.1");
+    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.1.0");
     ClusterSpec spec = cluster.getSpec();
     String version = spec.getRuntimeVersions().getSparkVersion();
     StringBuilder options = new StringBuilder();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `SparkClusterResourceSpec` to use `apache/spark:4.1.0` as the default value of container image.

### Why are the changes needed?

Apache Spark 4.1.0 is released officially.

https://github.com/apache/spark/releases/tag/v4.1.0
https://spark.apache.org/docs/4.1.0/
https://dist.apache.org/repos/dist/release/spark/spark-4.1.0/

### Does this PR introduce _any_ user-facing change?

Yes if the user didn't specify the container image for Spark Cluster, but this is an expected change in that case.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.