### PR TITLE
[SPARK-54766] Update CI to test K8s 1.35

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         kubernetes-version:
           - "1.32.0"
-          - "1.34.0"
+          - "1.35.0"
         mode:
           - dynamic
           - static


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase the maximum K8s test version to 1.35

### Why are the changes needed?

To improve the test coverage because K8s 1.35.0 was released on 2025-12-17.
- https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/
- https://kubernetes.io/releases/#release-v1-35

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

<img width="363" height="186" alt="Screenshot 2025-12-18 at 16 40 31" src="https://github.com/user-attachments/assets/69814b79-5a32-4ece-aef8-8e9242d4a28d" />

### Was this patch authored or co-authored using generative AI tooling?

No.