### PR TITLE
[SPARK-54788] Upgrade the minimum K8s version to v1.33

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - "1.32.0"
+          - "1.33.0"
           - "1.35.0"
         mode:
           - dynamic


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the minimum K8s version to v1.33 in K8s test environment.

The following notable KEP became `Stable` since K8s v1.33.
- [KEP-3633: Introduce MatchLabelKeys to Pod Affinity and Pod Anti Affinity](https://github.com/kubernetes/enhancements/issues/3633)
- [KEP-4193: Bound service account token improvements](https://github.com/kubernetes/enhancements/issues/4193)
- [KEP-753: Sidecar Containers](https://github.com/kubernetes/enhancements/issues/753)
- [KEP-3857: Recursive Read-only (RRO) mounts](https://github.com/kubernetes/enhancements/issues/3857)

### Why are the changes needed?

**1. K8s v1.32 will enter the maintenance soon (2025-12-28) and will reach the end of support on 2026-02-28**
- https://kubernetes.io/releases/patch-releases/#1-32

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.33+ like the following.

- EKS: v1.34 (Default)
- AKS: v1.34 (Default)
- GKE: v1.33 (Stable, v1.34 will be stable on 2026/1)

**3. End Of Support**

In addition, K8s 1.32 will reach the end of standard support in a few months.
| K8s  |   EKS   |  AKE  |  GKE  |
| ---- | ------- | ------- | ------- |
| 1.32 | 2026-03 | 2026-03 | 2026-04 |

- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only change about K8s versions.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.