### PR TITLE
[SPARK-54791] Increase `setup-minikube` resources to 3 cores and 10240m

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,8 +109,8 @@ jobs:
         with:
           cache: true
           kubernetes-version: ${{ matrix.kubernetes-version }}
-          cpus: 2
-          memory: 6144m
+          cpus: 3
+          memory: 10240m
       - name: Set Up Go
         uses: actions/setup-go@v5
       - name: Set Up Chainsaw


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase `setup-minikube` resources
- CPU CORES: `2` -> `3`
- MEMORY: `6144m` -> `10240m`

### Why are the changes needed?

To make the K8s integration CI more robust by taking advantage of the full available GitHub Action runner resources (4 cores, 16GB).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.