### PR TITLE
[SPARK-54795] Suppress Hadoop warnings in History Server example

### DIFF
--- a/examples/spark-history-server.yaml
+++ b/examples/spark-history-server.yaml
@@ -35,6 +35,7 @@ spec:
     spark.hadoop.fs.s3a.path.style.access: "true"
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
+    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   runtimeVersions:
     sparkVersion: "4.1.0"
   applicationTolerations:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to suppress Hadoop warnings in History Server example.

### Why are the changes needed?

Since we don't use `KerberosConfDriverFeatureStep` in our example, we can skip this step to avoid irrelevant Hadoop warnings on Java 25 like the other examples.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.