### PR TITLE
[SPARK-54814] Set `parallel` to 1 for K8s integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Run E2E Test with Dynamic Configuration Disabled
         if: matrix.mode == 'static'
         run: |
-          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
+          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 1
       - name: Run Spark K8s Operator on K8S with Dynamic Configuration Enabled
         if: matrix.mode == 'dynamic'
         run: |
@@ -146,7 +146,7 @@ jobs:
       - name: Run E2E Test with Dynamic Configuration Enabled
         if: matrix.mode == 'dynamic'
         run: |
-          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
+          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 1
 
   lint:
     name: "Linter and documentation"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set parallel to 1 for K8s integration tests.

### Why are the changes needed?

To run a test individually to isolate its side-effect and help the debugging in case of failures.

**BEFORE**

```
$ git grep '\-\-parallel'
.github/workflows/build_and_test.yml:          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
.github/workflows/build_and_test.yml:          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 2
```

**AFTER**

```
$ git grep '\-\-parallel'
.github/workflows/build_and_test.yml:          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 1
.github/workflows/build_and_test.yml:          chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 1
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.