### PR TITLE
[SPARK-54926] Improve Helm chart for adding labels and annotations for operator config map

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -177,6 +177,47 @@ jobs:
         if: matrix.mode == 'selector'
         run: |
           chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 1
+  helm-tests:
+    name: "Helm Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version:
+          - "1.35.0"
+        test-group:
+          - configmap-metadata
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: 'zulu'
+          cache: 'gradle'
+      - name: Set up Minikube
+        uses: medyagh/setup-minikube@v0.0.21
+        with:
+          cache: true
+          kubernetes-version: ${{ matrix.kubernetes-version }}
+          cpus: 3
+          memory: 10240m
+      - name: Print K8S pods and nodes info
+        run: |
+          kubectl get pods -A
+          kubectl describe node
+      - name: Run Spark K8s Operator Helm Tests
+        run: |
+          eval $(minikube docker-env)
+          ./gradlew buildDockerImage
+          helm install spark --create-namespace -f \
+          build-tools/helm/spark-kubernetes-operator/values.yaml -f \
+          tests/e2e/helm/helm-test-values/${{ matrix.test-group }}/values.yaml \
+          build-tools/helm/spark-kubernetes-operator/
+          minikube docker-env --unset
+          helm test spark
   lint:
     name: "Linter and documentation"
     runs-on: ubuntu-latest

--- a/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
@@ -185,7 +185,7 @@ metadata:
     {{- if index (.Values.operatorConfiguration.configMap) "labels" }}
       {{- toYaml .Values.operatorConfiguration.configMap.labels | nindent 4 }}
     {{- end }}
-  {{- if index (.Values.operatorConfiguration.configMap) "labels" }}
+  {{- if index (.Values.operatorConfiguration.configMap) "annotations" }}
   annotations:
     {{- toYaml .Values.operatorConfiguration.configMap.annotations | nindent 4 }}
   {{- end }}
@@ -219,9 +219,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "spark-operator.dynamicConfigLabels" . | nindent 4 }}
-    {{- if .Values.operatorConfiguration.dynamicConfig.labels }}
-      {{- toYaml .Values.operatorConfiguration.dynamicConfig.labels | nindent 4 }}
-    {{- end}}
   annotations:
     {{- toYaml .Values.operatorConfiguration.dynamicConfig.annotations | nindent 4 }}
 {{- with .Values.operatorConfiguration.dynamicConfig.data }}

--- a/build-tools/helm/spark-kubernetes-operator/templates/tests/test-configmap-metadata.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/tests/test-configmap-metadata.yaml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.operatorConfiguration.configMap }}
+{{- if or (.Values.operatorConfiguration.configMap.labels) (.Values.operatorConfiguration.configMap.annotations) }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "spark-operator.name" . }}-test-configmap-metadata"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spark-operator.commonLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  containers:
+    - name: kubectl
+      image: bitnamisecure/kubectl:latest
+      command: ['bash', '-c']
+      args:
+        - |
+          set -e
+          echo "Testing ConfigMap labels and annotations..."
+
+          # Get the ConfigMap
+          CM_JSON=$(kubectl get configmap spark-kubernetes-operator-configuration -n {{ .Release.Namespace }} -o json)
+
+          {{- if .Values.operatorConfiguration.configMap.labels }}
+          # Validate custom labels
+          echo "Validating custom labels..."
+          {{- range $key, $value := .Values.operatorConfiguration.configMap.labels }}
+          LABEL_VALUE=$(echo "$CM_JSON" | jq -r '.metadata.labels["{{ $key }}"]')
+          if [ "$LABEL_VALUE" != "{{ $value }}" ]; then
+            echo "ERROR: Label {{ $key }} not found or has incorrect value. Expected: {{ $value }}, Got: $LABEL_VALUE"
+            exit 1
+          fi
+          echo "Label {{ $key }}={{ $value }} verified"
+          {{- end }}
+          {{- end }}
+
+          {{- if .Values.operatorConfiguration.configMap.annotations }}
+          # Validate custom annotations
+          echo "Validating custom annotations..."
+          {{- range $key, $value := .Values.operatorConfiguration.configMap.annotations }}
+          ANNOTATION_VALUE=$(echo "$CM_JSON" | jq -r '.metadata.annotations["{{ $key }}"]')
+          if [ "$ANNOTATION_VALUE" != "{{ $value }}" ]; then
+            echo "ERROR: Annotation {{ $key }} not found or has incorrect value. Expected: {{ $value }}, Got: $ANNOTATION_VALUE"
+            exit 1
+          fi
+          echo "Annotation {{ $key }}={{ $value }} verified"
+          {{- end }}
+          {{- end }}
+
+          echo "All ConfigMap metadata tests passed!"
+  restartPolicy: Never
+  serviceAccountName: {{ .Values.operatorRbac.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/build-tools/helm/spark-kubernetes-operator/values.schema.json
+++ b/build-tools/helm/spark-kubernetes-operator/values.schema.json
@@ -710,15 +710,8 @@
               "type": "boolean",
               "description": "Create ConfigMap for dynamic configuration"
             },
-            "labels": {
-              "type": ["object", "null"],
-              "description": "Labels for dynamic config ConfigMap",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
             "annotations": {
-              "type": ["object", "null"],
+              "type": "object",
               "description": "Annotations for dynamic config ConfigMap",
               "additionalProperties": {
                 "type": "string"

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -208,7 +208,6 @@ operatorConfiguration:
     enable: false
     # Enable this to create a config map for hot property loading
     create: false
-    labels:
     annotations:
       "helm.sh/resource-policy": keep
     data:

--- a/tests/e2e/helm/helm-test-values/configmap-metadata/values.yaml
+++ b/tests/e2e/helm/helm-test-values/configmap-metadata/values.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test values for validating ConfigMap labels and annotations feature
+#
+# Usage:
+#   helm install spark-operator . -f tests/test-values-configmap-metadata.yaml
+#   helm test spark-operator
+#
+# This file demonstrates the ConfigMap labels and annotations feature
+# and can be used to validate the Helm test for this functionality.
+
+operatorConfiguration:
+  append: true
+  configMap:
+    labels:
+      test.example.com/label: "test-value"
+      environment: "testing"
+      managed-by: "helm-test"
+    annotations:
+      test.example.com/annotation: "test-annotation-value"
+      description: "ConfigMap for Spark Kubernetes Operator"
+      team: "spark-team"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR allows user to config the labels and annotations for the operator configuration `ConfigMap`, which hold operator configuration properties files.

Also added schema validation for the new fields in `values.schema.json`.

### Why are the changes needed?

Users may need to add custom labels and annotations to the operator configuration ConfigMaps for various operational purposes, or need toolings that rely on labels or annotations on resources.

Currently, the Helm chart doesn't provide a good way to customize labels and annotations for the operator `ConfigMap` - it only support annotations for dynamic `ConfigMap`.

### Does this PR introduce _any_ user-facing change?

Users can now specify custom labels and annotations for the operator configuration ConfigMap in their `values.yaml`:

  ```yaml
  operatorConfiguration:
    configMap:
      annotations:
        example.com/annotation: "value"
      labels:
        example.com/label: "value"
```

### How was this patch tested?
Self-contained linters, also validated manually.

Without explicitly configured labels or annotations, the `ConfigMap` renders as

```yaml
# Source: spark-kubernetes-operator/templates/spark-operator.yaml apiVersion: v1
kind: ConfigMap
metadata:
  name: spark-kubernetes-operator-configuration
  namespace: spark-demo
  labels:
    app.kubernetes.io/name: spark-kubernetes-operator
    app.kubernetes.io/component: "operator-config"
    app.kubernetes.io/version: "0.7.0-SNAPSHOT"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: spark-kubernetes-operator-1.5.0-dev
    spark-role: operator
data:
  log4j2.properties: |+
# ...
```

With value override

```yaml
operatorConfiguration:
  configMap:
    annotations:
      foo1: bar1
      foo2: bar2
    labels:
      foo3: bar3
```

The `ConfigMap` renders as

```yaml
# Source: spark-kubernetes-operator/templates/spark-operator.yaml apiVersion: v1
kind: ConfigMap
metadata:
  name: spark-kubernetes-operator-configuration
  namespace: spark-demo
  labels:
    app.kubernetes.io/name: spark-kubernetes-operator
    app.kubernetes.io/component: "operator-config"
    app.kubernetes.io/version: "0.7.0-SNAPSHOT"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: spark-kubernetes-operator-1.5.0-dev
    spark-role: operator
    foo3: bar3
  annotations:
    foo1: bar1
    foo2: bar2
data:
  log4j2.properties: |+
# ...
```

### Was this patch authored or co-authored using generative AI tooling?

No

