### PR TITLE
[SPARK-54927] Add `Volcano` example

### DIFF
--- a/examples/pi-on-volcano.yaml
+++ b/examples/pi-on-volcano.yaml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-on-volcano
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  driverArgs: [ "20000" ]
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
+    # This requires SPARK-54916 (or an image with `volcano`-enabled distribution)
+    # spark.kubernetes.driver.pod.featureSteps: "org.apache.spark.deploy.k8s.features.VolcanoFeatureStep"
+    # spark.kubernetes.executor.pod.featureSteps: "org.apache.spark.deploy.k8s.features.VolcanoFeatureStep"
+    spark.kubernetes.scheduler.name: "volcano"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    sparkVersion: "4.1.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Volcano` example.

### Why are the changes needed?

To align with Apache Spark 4.2.0 (main repository) in order to support `Volcano` users.

- https://github.com/apache/spark/pull/53693

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Gemini 3 Pro` on `Antigravity`)