### PR TITLE
[SPARK-54931] Support `Pod Disruption Budget` for Spark cluster workers

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
@@ -52,6 +52,12 @@ rules:
       - ingresses
     verbs:
       - '*'
+  - apiGroups:
+      - "policy"
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
 {{- end }}
 
 {{/*

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/context/SparkClusterContext.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.api.model.policy.v1.PodDisruptionBudget;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.RequiredArgsConstructor;
@@ -109,6 +110,15 @@ public class SparkClusterContext extends BaseContext<SparkCluster> {
    */
   public Optional<HorizontalPodAutoscaler> getHorizontalPodAutoscalerSpec() {
     return getSecondaryResourceSpec().getHorizontalPodAutoscaler();
+  }
+
+  /**
+   * Returns the specification for the PodDisruptionBudget, if present.
+   *
+   * @return An Optional containing the PodDisruptionBudget object.
+   */
+  public Optional<PodDisruptionBudget> getPodDisruptionBudgetSpec() {
+    return getSecondaryResourceSpec().getPodDisruptionBudget();
   }
 
   /**

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
@@ -54,6 +54,9 @@ public final class SparkClusterResourceSpecFactory {
     if (spec.getHorizontalPodAutoscaler().isPresent()) {
       decorator.decorate(spec.getHorizontalPodAutoscaler().get());
     }
+    if (spec.getPodDisruptionBudget().isPresent()) {
+      decorator.decorate(spec.getPodDisruptionBudget().get());
+    }
     return spec;
   }
 }

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
@@ -85,6 +85,16 @@ public class ClusterInitStep extends ClusterReconcileStep {
             .resource(horizontalPodAutoscaler.get())
             .create();
       }
+      var podDisruptionBudget = context.getPodDisruptionBudgetSpec();
+      if (podDisruptionBudget.isPresent()) {
+        context
+            .getClient()
+            .policy()
+            .v1()
+            .podDisruptionBudget()
+            .resource(podDisruptionBudget.get())
+            .create();
+      }
 
       ClusterStatus updatedStatus =
           context


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Pod Disruption Budget` for Spark cluster workers.

### Why are the changes needed?

K8s offers features to help the users run highly available applications via [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) even when clusters introduce frequent voluntary disruptions.

We had better provide a better stability for `SparkCluster`.

### Does this PR introduce _any_ user-facing change?

A better worker management.

### How was this patch tested?

Pass the CIs with newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Gemini 3 Pro` on `Antigravity`)