### PR TITLE
[SPARK-54932] Use `(pi|pi-with-driver-timeout).yaml` to show `ttlAfterStopMillis` example

### DIFF
--- a/examples/pi-with-driver-timeout.yaml
+++ b/examples/pi-with-driver-timeout.yaml
@@ -30,5 +30,6 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
   runtimeVersions:
     sparkVersion: "4.1.0"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -28,5 +28,6 @@ spec:
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
   runtimeVersions:
     sparkVersion: "4.1.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `pi.yaml` and `pi-with-driver-timeout.yaml` to show `ttlAfterStopMillis` example.

### Why are the changes needed?

These examples are used frequently by the users for testing purposes. By using `ttlAfterStopMillis`, we can help users in two ways.
- Be aware of this configuration.
- By cleaning up these resources by K8s Operator, the users can submit the same examples easily and repeatedly (after the timeout). Usually, it could be the next manual tests.

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a change on examples.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.