### PR TITLE
[SPARK-54964] Bump Java Operator SDK to version 5.2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.4.0"
 lombok = "1.18.42"
-operator-sdk = "5.2.1"
+operator-sdk = "5.2.2"
 dropwizard-metrics = "4.2.33"
 spark = "4.1.0"
 log4j = "2.24.3"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump Java Operator SDK to version 5.2.2

### Why are the changes needed?

Updates JOSDK to newest version, that contains bug fixes.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Already covered with unit tests

### Was this patch authored or co-authored using generative AI tooling?

No