### PR TITLE
[SPARK-55067] Update Spark 3 examples and tests to use 3.5.8

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -30,7 +30,7 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.executor.extraClassPath: "local:///comet/comet.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:3.5.7-java17"
+    spark.kubernetes.container.image: "apache/spark:3.5.8-java17"
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
@@ -83,4 +83,4 @@ spec:
           emptyDir:
             sizeLimit: 100Mi
   runtimeVersions:
-    sparkVersion: "3.5.7"
+    sparkVersion: "3.5.8"

--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -23,11 +23,11 @@ spec:
   scenarios:
     - bindings:
         - name: "SPARK_VERSION"
-          value: "3.5.7"
+          value: "3.5.8"
         - name: "SCALA_VERSION"
           value: "2.12"
         - name: "IMAGE"
-          value: "apache/spark:3.5.7-scala2.12-java17-python3-ubuntu"
+          value: "apache/spark:3.5.8-scala2.12-java17-python3-ubuntu"
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -32,13 +32,13 @@ spec:
         value: "apache/spark:4.1.1-scala-java17"
   - bindings:
       - name: "SPARK_VERSION"
-        value: "3.5.7"
+        value: "3.5.8"
       - name: "SCALA_VERSION"
         value: "2.12"
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: 'apache/spark:3.5.7-scala2.12-java17-ubuntu'
+        value: 'apache/spark:3.5.8-scala2.12-java17-ubuntu'
   - bindings:
       - name: "SPARK_VERSION"
         value: "4.1.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Spark 3.5.8` for Spark 3 examples and tests.

### Why are the changes needed?

Since Apache Spark 3.5.8 is released, we had better use this stabler version than 3.5.7.
- https://github.com/apache/spark/releases/tag/v3.5.8

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.