### PR TITLE
[SPARK-55079] Log `Java Version`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -283,6 +283,7 @@ public class SparkOperator {
    * @param args Command line arguments (not used).
    */
   public static void main(String[] args) {
+    log.info("Java Version: " + Runtime.version().toString());
     SparkOperator sparkOperator = new SparkOperator();
     for (Operator operator : sparkOperator.registeredOperators) {
       operator.start();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to log `Java Version` during starting.

### Why are the changes needed?

To help the log analysis of `Spark Operator` by embedding Java Version explicitly into the logs.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

**BEFORE**
```
$ kubectl logs spark-kubernetes-operator-8dc69d96f-lpxk8 | head -n3
Starting Operator...
26/01/17 03:23:10 INFO   o.a.s.k.o.SparkOperator Configuring operator with 50 reconciliation threads.
```

**AFTER**
```
$ kubectl logs spark-kubernetes-operator-8dc69d96f-lpxk8 | head -n3
Starting Operator...
26/01/17 03:23:09 INFO   o.a.s.k.o.SparkOperator Java Version: 25.0.1+8-LTS
26/01/17 03:23:10 INFO   o.a.s.k.o.SparkOperator Configuring operator with 50 reconciliation threads.
```

### Was this patch authored or co-authored using generative AI tooling?

No.