### PR TITLE
[SPARK-55080] Improve `MANIFEST.MF` to include `Implementation-(Title|Version)`

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -88,16 +88,22 @@ jar {
   archiveVersion.set('')
 }
 
+base {
+  description = "Spark Kubernetes Operator"
+  def artifact = "spark-kubernetes-operator"
+  archivesName = artifact
+}
 
 shadowJar {
   zip64 = true
   mergeServiceFiles()
   transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
   exclude("org/apache/spark/ui/static/**")
+  manifest {
+    attributes(
+      'Implementation-Title': project.description,
+      'Implementation-Version': project.version
+    )
+  }
 }
 
-base {
-  description = "Spark Kubernetes Operator"
-  def artifact = "spark-kubernetes-operator"
-  archivesName = artifact
-}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `MANIFEST.MF` to include `Implementation-(Title|Version)`.

### Why are the changes needed?

To give the exact information explicitly to the JAR users.

**PROCEDURE**

```
$ kubectl cp spark-kubernetes-operator-59bf58cbbc-kfzpm:/opt/spark-operator/operator/spark-kubernetes-operator.jar spark-kubernetes-operator.jar
$ jar xvf spark-kubernetes-operator.jar META-INF/MANIFEST.MF
$ cat META-INF/MANIFEST.MF
```

**BEFORE**

```
Manifest-Version: 1.0
```

**AFTER**

```
Manifest-Version: 1.0
Implementation-Title: Spark Kubernetes Operator
Implementation-Version: 0.8.0-SNAPSHOT
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is only a build change.

### How was this patch tested?

Manually verified with the above procedure.

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Gemini 3 Pro` on `Antigravity`)