### PR TITLE
[SPARK-55081] Log `Version`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -283,6 +283,7 @@ public class SparkOperator {
    * @param args Command line arguments (not used).
    */
   public static void main(String[] args) {
+    log.info("Version: {}", SparkOperator.class.getPackage().getImplementationVersion());
     log.info("Java Version: " + Runtime.version().toString());
     SparkOperator sparkOperator = new SparkOperator();
     for (Operator operator : sparkOperator.registeredOperators) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to log `Apache Spark K8s Operator`'s `Version` during starting.

### Why are the changes needed?

A user can install multiple `Apache Spark K8s Operator`s and collects the logs into a single log collection system. We had better help the log analysis of `Spark Operator` by embedding its version explicitly into the logs.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review.

**BEFORE**
```
$ kubectl logs spark-kubernetes-operator-8dc69d96f-czn82 | head -n3
Starting Operator...
26/01/17 06:51:34 INFO   o.a.s.k.o.SparkOperator Java Version: 25.0.1+8-LTS
```

**AFTER**
```
$ kubectl logs spark-kubernetes-operator-8dc69d96f-czn82 | head -n3
Starting Operator...
26/01/17 06:51:34 INFO   o.a.s.k.o.SparkOperator Version: 0.8.0-SNAPSHOT
26/01/17 06:51:34 INFO   o.a.s.k.o.SparkOperator Java Version: 25.0.1+8-LTS
```

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Gemini 3 Pro` on `Antigravity`)