### PR TITLE
[SPARK-55082] Upgrade `Dropwizard` metrics to 4.2.37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 fabric8 = "7.5.1"
 lombok = "1.18.42"
 operator-sdk = "5.2.2"
-dropwizard-metrics = "4.2.33"
+dropwizard-metrics = "4.2.37"
 spark = "4.1.1"
 log4j = "2.24.3"
 slf4j = "2.0.17"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Dropwizard` metrics to 4.2.37 in order to match with Apache Spark 4.1.0.

- https://github.com/apache/spark/pull/53061

### Why are the changes needed?

4.2.37 is the latest 4.2.x line.
- https://github.com/dropwizard/metrics/releases/tag/v4.2.37
- https://github.com/dropwizard/metrics/releases/tag/v4.2.36
- https://github.com/dropwizard/metrics/releases/tag/v4.2.35
- https://github.com/dropwizard/metrics/releases/tag/v4.2.34

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.