### PR TITLE
[SPARK-55083] Upgrade `checkstyle` to 13.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ jacoco = "0.8.14"
 mockito = "5.21.0"
 
 # Build Analysis
-checkstyle = "10.23.1"
+checkstyle = "13.0.0"
 pmd = "7.19.0"
 spotbugs-tool = "4.9.8"
 spotbugs-plugin = "6.4.7"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `checkstyle` to 13.0.0.

### Why are the changes needed?

To use the latest one. Since we are using Java 25 toolchain, we can use `Checkstyle 13.0.0` whose minimum Java requirement is 21.
- https://checkstyle.org/releasenotes.html#Release_13.0.0 (2026-01-04, Java 21+)
- https://checkstyle.org/releasenotes.html#Release_12.3.0 (2025-12-13)
- https://checkstyle.org/releasenotes.html#Release_12.2.0 (2025-11-30)
- https://checkstyle.org/releasenotes.html#Release_12.1.0 (2025-10-19)
- https://checkstyle.org/releasenotes.html#Release_12.0.0 (2025-10-09)
- https://checkstyle.org/releasenotes.html#Release_11.1.0 (2025-09-28)
- https://checkstyle.org/releasenotes.html#Release_11.0.0 (2025-08-07, Java 17+)

### Does this PR introduce _any_ user-facing change?

No. This is a test dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.