### PR TITLE
[SPARK-55084] Update docs to recommend K8s 1.33+

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/README.md
+++ b/build-tools/helm/spark-kubernetes-operator/README.md
@@ -33,7 +33,7 @@ cluster using the [Helm](https://helm.sh) package manager. With this, you can la
 
 ## Requirements
 
-- Kubernetes 1.32+ cluster
+- Kubernetes 1.33+ cluster
 - Helm 3.0+
 
 ## Features

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -23,7 +23,7 @@ under the License.
 
 - Java 17, 21 and 25
 - Kubernetes version compatibility:
-  - k8s version >= 1.32 is recommended. Operator attempts to be API compatible as possible, but
+  - k8s version >= 1.33 is recommended. Operator attempts to be API compatible as possible, but
       patch support will not be performed on k8s versions that reached EOL.
 - Spark versions 3.5 or above.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update documentations to recommend K8s v1.33+.

### Why are the changes needed?

K8s v1.32 entered the maintenance on 2025-12-28 and will reach the end of life on 2026-02-28.
- https://kubernetes.io/releases/patch-releases/#1-32

Since we already updated the minimum requirement, we need to make the documentation up-to-date consistently.
- https://github.com/apache/spark-kubernetes-operator/pull/438 (Apache Spark K8s Operator 0.7)
- https://github.com/apache/spark/pull/53543 (Apache Spark 4.2.0)

### Does this PR introduce _any_ user-facing change?

No because this is a documentation-only change.

### How was this patch tested?

Manual review because the result of CIs is irrelevant.

### Was this patch authored or co-authored using generative AI tooling?

No.