### PR TITLE
[SPARK-55085] Support `NetworkPolicy` for `SparkApplication`

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
@@ -50,6 +50,7 @@ rules:
       - "networking.k8s.io"
     resources:
       - ingresses
+      - networkpolicies
     verbs:
       - '*'
   - apiGroups:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `NetworkPolicy` for `SparkApplication`.

### Why are the changes needed?

To enhance the security of `SparkApplication` executor pods.

`NetworkPolicy` is frequently used in the production to isolate Spark Applications.

- https://kubernetes.io/docs/concepts/services-networking/network-policies/

### Does this PR introduce _any_ user-facing change?

The executor pods of `SparkApplication` will allow ingress from the same `SparkApplication` driver or executors.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.