### PR TITLE
[SPARK-55095] Enable `spark.io.encryption.enabled` by default

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -166,6 +166,7 @@ public class SparkAppSubmissionWorker {
     String appId = generateSparkAppId(app);
     effectiveSparkConf.setIfMissing("spark.app.id", appId);
     effectiveSparkConf.setIfMissing("spark.authenticate", "true");
+    effectiveSparkConf.setIfMissing("spark.io.encryption.enabled", "true");
     return SparkAppDriverConf.create(
         effectiveSparkConf,
         sparkVersion,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable local disk I/O encryption by default via `spark.io.encryption.enabled=true`.

### Why are the changes needed?

To improve Apache Spark application security by default.

### Does this PR introduce _any_ user-facing change?

Spark will encrypt temporary data written to local disks. This covers shuffle files, shuffle spills and data blocks stored on disk (for both caching and broadcast variables).

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.