### PR TITLE
[SPARK-55102] Upgrade `com.gradleup.shadow` to 8.3.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ spotless-plugin = "8.1.0"
 
 # Packaging
 cyclonedx = "2.4.1"
-shadow-jar-plugin = "8.3.6"
+shadow-jar-plugin = "8.3.9"
 
 [libraries]
 kubernetes-client = { group = "io.fabric8", name = "kubernetes-client", version.ref = "fabric8" }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `com.gradleup.shadow` to 8.3.9.

### Why are the changes needed?

To bring the latest bug fixed versions.
- https://github.com/GradleUp/shadow/releases/tag/8.3.9
  - https://github.com/GradleUp/shadow/pull/1579
- https://github.com/GradleUp/shadow/releases/tag/8.3.8
  - https://github.com/GradleUp/shadow/pull/1493
  - https://github.com/GradleUp/shadow/pull/1488
- https://github.com/GradleUp/shadow/releases/tag/8.3.7
  - https://github.com/GradleUp/shadow/pull/1470

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.