### PR TITLE
[SPARK-55190] Improve `ClusterInitStep` to use Server-Side Apply APIs

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/reconcilesteps/ClusterInitStep.java
@@ -69,15 +69,33 @@ public class ClusterInitStep extends ClusterReconcileStep {
     }
     try {
       Service masterService = context.getMasterServiceSpec();
-      context.getClient().services().resource(masterService).create();
+      context.getClient().services().resource(masterService).forceConflicts().serverSideApply();
       Service workerService = context.getWorkerServiceSpec();
-      context.getClient().services().resource(workerService).create();
+      context.getClient().services().resource(workerService).forceConflicts().serverSideApply();
       StatefulSet masterStatefulSet = context.getMasterStatefulSetSpec();
-      context.getClient().apps().statefulSets().resource(masterStatefulSet).create();
+      context
+          .getClient()
+          .apps()
+          .statefulSets()
+          .resource(masterStatefulSet)
+          .forceConflicts()
+          .serverSideApply();
       StatefulSet workerStatefulSet = context.getWorkerStatefulSetSpec();
-      context.getClient().apps().statefulSets().resource(workerStatefulSet).create();
+      context
+          .getClient()
+          .apps()
+          .statefulSets()
+          .resource(workerStatefulSet)
+          .forceConflicts()
+          .serverSideApply();
       NetworkPolicy workerNetworkPolicy = context.getWorkerNetworkPolicySpec();
-      context.getClient().network().networkPolicies().resource(workerNetworkPolicy).create();
+      context
+          .getClient()
+          .network()
+          .networkPolicies()
+          .resource(workerNetworkPolicy)
+          .forceConflicts()
+          .serverSideApply();
       var horizontalPodAutoscaler = context.getHorizontalPodAutoscalerSpec();
       if (horizontalPodAutoscaler.isPresent()) {
         context
@@ -86,7 +104,8 @@ public class ClusterInitStep extends ClusterReconcileStep {
             .v2()
             .horizontalPodAutoscalers()
             .resource(horizontalPodAutoscaler.get())
-            .create();
+            .forceConflicts()
+            .serverSideApply();
       }
       var podDisruptionBudget = context.getPodDisruptionBudgetSpec();
       if (podDisruptionBudget.isPresent()) {
@@ -96,7 +115,8 @@ public class ClusterInitStep extends ClusterReconcileStep {
             .v1()
             .podDisruptionBudget()
             .resource(podDisruptionBudget.get())
-            .create();
+            .forceConflicts()
+            .serverSideApply();
       }
 
       ClusterStatus updatedStatus =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `ClusterInitStep` to use `Server-Side Apply` APIs instead of `Client-Side Apply` APIs to improve operational stability of `SparkCluster` resources.

```java
- .create();
+ .forceConflicts()
+ .serverSideApply();
```
### Why are the changes needed?

Since K8s v1.22, `Server-Side Apply` is stably enabled by default.
- https://kubernetes.io/docs/reference/using-api/server-side-apply/

### Does this PR introduce _any_ user-facing change?

No user-facing behavior changing.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.