### PR TITLE
[SPARK-55268] Fix `ConfigOption.getValue` not to invoke `resolveValue` twice

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java
@@ -59,7 +59,7 @@ public class ConfigOption<T> {
     if (log.isDebugEnabled()) {
       log.debug("Resolved value for property {}={}", key, resolvedValue);
     }
-    return resolveValue();
+    return resolvedValue;
   }
 
   private T resolveValue() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ConfigOption.getValue` method to invoke `resolveValue` only once.

### Why are the changes needed?

Previously, `resolveValue()` is invoked twice at line 58 and 62. We can remove the second one by reusing `resolvedValue` variable.

https://github.com/apache/spark-kubernetes-operator/blob/fea548118dc4e7daf192595e20cebd8fd5bc12c3/spark-operator/src/main/java/org/apache/spark/k8s/operator/config/ConfigOption.java#L57-L63

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Opus 4.5` on `Claude Code v2.1.5`)