### PR TITLE
[SPARK-55269] Fix a wrong comment of `testHandleSentinelResourceReconciliation`

### DIFF
--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java
@@ -96,7 +96,7 @@ class SentinelManagerTest {
   @Test
   @Order(3)
   void testHandleSentinelResourceReconciliation() throws InterruptedException {
-    // Reduce the SENTINEL_RESOURCE_RECONCILIATION_DELAY time to 0
+    // Reduce the SENTINEL_RESOURCE_RECONCILIATION_DELAY time to 10
     SparkOperatorConfManager.INSTANCE.refresh(
         Map.of(
             SparkOperatorConf.SENTINEL_RESOURCE_RECONCILIATION_DELAY.getKey(), "10"));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a wrong comment of `testHandleSentinelResourceReconciliation` to match with the actual test logic.

### Why are the changes needed?

According to the code, `SENTINEL_RESOURCE_RECONCILIATION_DELAY` is reduced to `10`, not `0`.

https://github.com/apache/spark-kubernetes-operator/blob/fea548118dc4e7daf192595e20cebd8fd5bc12c3/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java#L99-L102


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Opus 4.5` on `Claude Code v2.1.5`)