### PR TITLE
[SPARK-55270] Disallow all HTTP methods except `GET` and `HEAD`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/MetricsService.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/MetricsService.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executor;
 import com.sun.net.httpserver.HttpServer;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.spark.k8s.operator.utils.HttpMethodFilter;
+
 /** Start Http service at endpoint /prometheus, exposing operator metrics. */
 @Slf4j
 public class MetricsService {
@@ -53,7 +55,8 @@ public class MetricsService {
   /** Starts the HTTP server and exposes the Prometheus metrics endpoint. */
   public void start() {
     log.info("Starting Metrics Service for Prometheus ...");
-    server.createContext("/prometheus", metricsSystem.getPrometheusPullModelHandler());
+    server.createContext("/prometheus", metricsSystem.getPrometheusPullModelHandler())
+        .getFilters().add(new HttpMethodFilter());
     server.start();
   }
 

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/HttpMethodFilter.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/HttpMethodFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.utils;
+
+import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
+import static org.apache.spark.k8s.operator.utils.ProbeUtil.sendMessage;
+
+import java.io.IOException;
+import java.util.Set;
+
+import com.sun.net.httpserver.Filter;
+import com.sun.net.httpserver.HttpExchange;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A filter that only allows GET and HTTP requests and returns 405 Method Not Allowed for all
+ * other HTTP methods.
+ */
+@Slf4j
+public class HttpMethodFilter extends Filter {
+  @Override
+  public void doFilter(HttpExchange exchange, Chain chain) throws IOException {
+    if (!Set.of("GET", "HEAD").contains(exchange.getRequestMethod().toUpperCase())) {
+      sendMessage(exchange, HTTP_BAD_METHOD, "Method Not Allowed");
+      exchange.close();
+      return;
+    }
+    chain.doFilter(exchange);
+  }
+
+  @Override
+  public String description() {
+    return "Filter that only allows GET requests";
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disallow all HTTP methods except `GET` and `HEAD` method.

### Why are the changes needed?

Like Apache Spark Web UI, we had better response the exact HTTP requests. In `Apache Spark K8s Operator` operator, `GET` and `HEAD` is the only allowed method and other methods like `POST`, `PUT`, `POST`, `DELETE`, `TRACE`, and `OPTIONS` will be denied.
- https://github.com/apache/spark/pull/4765
- https://github.com/apache/spark/pull/44926

### Does this PR introduce _any_ user-facing change?

Yes for the security improvement.

### How was this patch tested?

Pass the CIs.

**BEFORE**

```
$ curl -s -I -XPOST http://localhost:19091/healthz | head -n1
HTTP/1.1 200 OK
```

**AFTER**
```
$ curl -s -I -XPOST http://localhost:19091/healthz | head -n1
HTTP/1.1 405 Method Not Allowed
```

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Opus 4.5` on `Claude Code v2.1.5`)