### PR TITLE
[SPARK-55274] Set `-XX:+AlwaysPreTouch` by default

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -41,7 +41,7 @@ operatorDeployment:
     # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     topologySpreadConstraints: [ ]
     operatorContainer:
-      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80 -Dio.netty.noUnsafe=true"
+      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80 -XX:+AlwaysPreTouch -Dio.netty.noUnsafe=true"
       env:
         - name: "SPARK_USER"
           value: "spark"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `-XX:+AlwaysPreTouch` by default to improve stability.

### Why are the changes needed?

To improve stability by ensuring **Physical Memory Availability**

In some environments where memory overcommitment is allowed by the OS or K8s node by SRE, the JVM might successfully reserve heap space that isn't physically available. `AlwaysPreTouch` ensures that the K8s operator actually gets the guarnteed physical RAM at startup and avoids random evictions due to the lack of memory.

### Does this PR introduce _any_ user-facing change?

Only JVM GC behavior changes.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.