### PR TITLE
[SPARK-55288] Upgrade Netty to `4.2.9.Final`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,14 @@ subprojects {
     mavenCentral()
   }
 
+  configurations.all {
+    resolutionStrategy.eachDependency {
+      if (requested.group == "io.netty" && !requested.name.startsWith("netty-tcnative")) {
+        useVersion(libs.versions.netty.get())
+      }
+    }
+  }
+
   apply plugin: 'checkstyle'
   checkstyle {
     toolVersion = libs.versions.checkstyle.get()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@
 [versions]
 fabric8 = "7.5.2"
 lombok = "1.18.42"
+netty = "4.2.9.Final"
 operator-sdk = "5.2.2"
 dropwizard-metrics = "4.2.37"
 spark = "4.1.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Netty to `4.2.9.Final` by overriding the transitive one from the Apache Spark 4.1.x.

### Why are the changes needed?

To bring the latest bug fixed version in Apache Spark K8s Operator like the Apache Spark 4.2.x.
- https://netty.io/news/2025/12/11/4-2-8.html
  - [CVE-2025-67735](https://github.com/netty/netty/security/advisories/GHSA-84h7-rjj3-6jx4)
- https://netty.io/news/2025/12/15/4-2-9.html
  - https://github.com/netty/netty/pull/16022

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

**BEFORE**
```
$ gradle spark-operator:dependencyInsight --configuration compileClasspath --dependency io.netty | grep '^io.netty' | awk -F: '{print $NF}' | sort | uniq -c
   2 4.1.119.Final -> 4.2.7.Final
   9 4.1.130.Final -> 4.2.7.Final
  50 4.2.7.Final
```

**AFTER**
```
$ gradle spark-operator:dependencyInsight --configuration compileClasspath --dependency io.netty | grep '^io.netty' | awk -F: '{print $NF}' | sort | uniq -c
   2 4.1.119.Final -> 4.2.9.Final
   9 4.1.130.Final -> 4.2.9.Final
   3 4.2.7.Final -> 4.2.9.Final
  22 4.2.9.Final
  25 4.2.9.Final (selected by rule)
```

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Opus 4.5` on `Claude Code v2.1.5`)