### PR TITLE
[SPARK-55329] Upgrade `Apache DataFusion Comet` to 0.13.0

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -47,7 +47,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.12.0/comet-spark-spark3.5_2.12-0.12.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.13.0/comet-spark-spark3.5_2.12-0.13.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -69,7 +69,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.12.0/comet-spark-spark3.5_2.12-0.12.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.13.0/comet-spark-spark3.5_2.12-0.13.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR aims to upgrade `Apache DataFusion Comet` to 0.13.0.

### Why are the changes needed?

To use the latest version of `Apache DataFusion Comet`.
- https://github.com/apache/datafusion-comet/releases/tag/0.13.0

### Does this PR introduce _any_ user-facing change?

No behavior change because this is an update in example.

### How was this patch tested?

Manually run the example and check.

```
$ kubectl apply -f examples/pi-with-comet.yaml
sparkapplication.spark.apache.org/pi-with-comet created

$ kubectl get sparkapp
NAME            CURRENT STATE     AGE
pi-with-comet   DriverRequested   7s

$ kubectl get sparkapp
NAME            CURRENT STATE   AGE
pi-with-comet   Succeeded       17s

$ kubectl describe sparkapp pi-with-comet | grep comet-spark
            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.13.0/comet-spark-spark3.5_2.12-0.13.0.jar"
            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.13.0/comet-spark-spark3.5_2.12-0.13.0.jar"
```

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Opus 4.5` on `Claude Code v2.1.5`)