### PR TITLE
[SPARK-55352] Use K8s Garbage Collection to delete executor pods

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -41,6 +41,7 @@ import org.apache.spark.deploy.k8s.submit.RMainAppResource;
 import org.apache.spark.k8s.operator.spec.ApplicationSpec;
 import org.apache.spark.k8s.operator.spec.ConfigMapSpec;
 import org.apache.spark.k8s.operator.spec.DriverServiceIngressSpec;
+import org.apache.spark.k8s.operator.spec.ResourceRetainPolicy;
 import org.apache.spark.k8s.operator.spec.RuntimeVersions;
 import org.apache.spark.k8s.operator.utils.ModelUtils;
 import org.apache.spark.k8s.operator.utils.StringUtils;
@@ -167,6 +168,11 @@ public class SparkAppSubmissionWorker {
     effectiveSparkConf.setIfMissing("spark.app.id", appId);
     effectiveSparkConf.setIfMissing("spark.authenticate", "true");
     effectiveSparkConf.setIfMissing("spark.io.encryption.enabled", "true");
+    // Use K8s Garbage Collection instead of explicit API invocations
+    if (applicationSpec.getApplicationTolerations().getResourceRetainPolicy() !=
+        ResourceRetainPolicy.Always) {
+      effectiveSparkConf.setIfMissing("spark.kubernetes.executor.deleteOnTermination", "false");
+    }
     return SparkAppDriverConf.create(
         effectiveSparkConf,
         sparkVersion,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use [K8s Garbage Collection](https://kubernetes.io/docs/concepts/architecture/garbage-collection/) to delete executor pods.

### Why are the changes needed?

To avoid massive API invocation overhead during explicit executor deletions.

### Does this PR introduce _any_ user-facing change?

There is a timing difference for executor pod deletions. However, eventually, all executor pods are garbage collected after driver pod is deleted.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.