### PR TITLE
[SPARK-55374] Remove `vendor` requirement from Java toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ subprojects {
   java {
     toolchain {
       languageVersion = JavaLanguageVersion.of(25)
-      vendor = JvmVendorSpec.AZUL
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `vendor` requirement from Java toolchain.

### Why are the changes needed?

To be robust in CIs by allowing all Java 25 vendors.

Previously, we use `Azul` in CI and Dockerfile like Apache Spark main repository. However, **Gradle docker image uses `Temurin`**. This mismatch causes the flakiness in CIs.

https://github.com/apache/spark-kubernetes-operator/blob/85edc4fbfef3541f0746636f461bead7bfa5fa06/build.gradle#L55

```
$ docker run -it --rm gradle:9.3.1-jdk25-noble java --version
openjdk 25.0.1 2025-10-21 LTS
OpenJDK Runtime Environment Temurin-25.0.1+8 (build 25.0.1+8-LTS)
OpenJDK 64-Bit Server VM Temurin-25.0.1+8 (build 25.0.1+8-LTS, mixed mode, sharing)
```

- https://github.com/apache/spark-kubernetes-operator/actions/runs/21719012717/job/62643084389

```
#14 35.25 Execution failed for task ':spark-operator-api:compileJava'.
#14 35.25 > Error while evaluating property 'javaCompiler' of task ':spark-operator-api:compileJava'.
#14 35.25    > Failed to calculate the value of task ':spark-operator-api:compileJava' property 'javaCompiler'.
#14 35.25       > Cannot find a Java installation on your machine (Linux 6.11.0-1018-azure amd64) matching: {languageVersion=25, vendor=Azul Zulu, implementation=vendor-specific, nativeImageCapable=false}. Some toolchain resolvers had internal failures: foojay (Requesting vendor list failed: <html>
#14 35.25         <head><title>503 Service Temporarily Unavailable</title></head>
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`