### PR TITLE
[SPARK-55380] Upgrade `Iceberg` example to use Spark 4.0.2

### DIFF
--- a/examples/spark-connect-server-iceberg.yaml
+++ b/examples/spark-connect-server-iceberg.yaml
@@ -30,7 +30,7 @@ spec:
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.1,org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.1"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.1"
+    spark.kubernetes.container.image: "apache/spark:4.0.2"
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.executor.podNamePrefix: "spark-connect-server-iceberg"
     spark.scheduler.mode: "FAIR"
@@ -42,4 +42,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.0.1"
+    sparkVersion: "4.0.2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Iceberg` example to use Spark 4.0.2.

### Why are the changes needed?

To use the latest bug fixed version of Spark in the example.

Since Apache Iceberg doesn't support Spark 4.1 yet, we need to use Spark 4.0.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manaully.

```
$ kubectl apply -f examples/spark-connect-server-iceberg.yaml
sparkapplication.spark.apache.org/spark-connect-server-iceberg created

$ kubectl get sparkapp
NAME                           CURRENT STATE    AGE
spark-connect-server-iceberg   RunningHealthy   7s
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`.