### PR TITLE
[SPARK-55419] Upgrade Netty to `4.2.10.Final`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.5.2"
 lombok = "1.18.42"
-netty = "4.2.9.Final"
+netty = "4.2.10.Final"
 operator-sdk = "5.2.2"
 dropwizard-metrics = "4.2.37"
 spark = "4.1.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Netty to `4.2.10.Final` by overriding the transitive one from the Apache Spark 4.1.x.

### Why are the changes needed?

To bring the latest bug fixed version in Apache Spark K8s Operator
- https://netty.io/news/2026/02/05/4-2-10.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

`Gemini 3 Pro (High)` on `Antigravity`.