### PR TITLE
[SPARK-55422] Fix the default value of `readinessProbe.failureThreshold` to 1

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl
+++ b/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl
@@ -128,7 +128,7 @@ spark.kubernetes.operator.leaderElection.enabled=true
 Readiness Probe properties overrides
 */}}
 {{- define "spark-operator.readinessProbe.failureThreshold" -}}
-{{- default 30 .Values.operatorDeployment.operatorPod.operatorContainer.probes.readinessProbe.failureThreshold }}
+{{- default 1 .Values.operatorDeployment.operatorPod.operatorContainer.probes.readinessProbe.failureThreshold }}
 {{- end }}
 {{- define "spark-operator.readinessProbe.periodSeconds" -}}
 {{- default 10 .Values.operatorDeployment.operatorPod.operatorContainer.probes.readinessProbe.periodSeconds }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the default value of `readinessProbe.failureThreshold` to 1.

### Why are the changes needed?

When SPARK-54328 changed `readinessProbe.failureThreshold` to 1, it didn't update the default value of `_helpers.tpl` file. We had better make it consistent.
- https://github.com/apache/spark-kubernetes-operator/pull/417

https://github.com/apache/spark-kubernetes-operator/blob/5836f15c91a85dd5f39a2e60bf46630ad1f3dc42/build-tools/helm/spark-kubernetes-operator/values.yaml#L69-L70

https://github.com/apache/spark-kubernetes-operator/blob/5836f15c91a85dd5f39a2e60bf46630ad1f3dc42/build-tools/helm/spark-kubernetes-operator/templates/_helpers.tpl#L131

### Does this PR introduce _any_ user-facing change?

No behavior changes because the behavior change happens in v0.7.0 already via SPARK-54328.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`