### PR TITLE
[SPARK-55425] Set `strategy.max-parrallel` to 20 for all GitHub Action jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         os: [ 'ubuntu-latest', 'ubuntu-24.04-arm' ]
         java-version: [ 17, 21, 25 ]
@@ -71,6 +72,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         kubernetes-version:
           - "1.33.0"
@@ -183,6 +185,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         kubernetes-version:
           - "1.35.0"

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
         branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         # keep in sync with default value of workflow_dispatch input 'branch'
         branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `strategy.max-parrallel` to 20 for all GitHub Action jobs.

### Why are the changes needed?

To be consistent with Apache Spark main repository.
- https://github.com/apache/spark/pull/54204

Here is `GitHub Action` syntax.
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymax-parallel

<img width="762" height="112" alt="Screenshot 2026-02-07 at 21 09 02" src="https://github.com/user-attachments/assets/770d1b81-390b-49d1-8518-70cb20eb93af" />

### Does this PR introduce _any_ user-facing change?

No Apache Spark behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`