### PR TITLE
[SPARK-55468] Log `Built-in Spark Version`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -285,7 +285,7 @@ public class SparkOperator {
   public static void main(String[] args) {
     log.info("Version: {}", SparkOperator.class.getPackage().getImplementationVersion());
     log.info("Java Version: " + Runtime.version().toString());
-    log.info("Built-in Spark Version: " + org.apache.spark.package$.MODULE$.SPARK_VERSION());
+    log.info("Built-in Spark Version: {}", org.apache.spark.package$.MODULE$.SPARK_VERSION());
     SparkOperator sparkOperator = new SparkOperator();
     for (Operator operator : sparkOperator.registeredOperators) {
       operator.start();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to log `Built-in Spark Version` explicitly.

### Why are the changes needed?

To provide more specific information.

```
$ kubectl logs spark-kubernetes-operator-67964b9b47-zlj8m | head -n4
Starting Operator...
26/02/10 05:09:55 INFO   o.a.s.k.o.SparkOperator Version: 0.8.0-SNAPSHOT
26/02/10 05:09:55 INFO   o.a.s.k.o.SparkOperator Java Version: 25.0.2+10-LTS
26/02/10 05:09:55 INFO   o.a.s.k.o.SparkOperator Built-in Spark Version: 4.1.1
```

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a simple one-line log addition.

### How was this patch tested?

Manual review. Launch the operator and check the log, `Built-in Spark Version: 4.1.1`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`.