### PR TITLE
[SPARK-55486] Fix `StatusRecorder.patchAndStatusWithVersionLocked` not to log errors

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java
@@ -93,7 +93,7 @@ public class StatusRecorder<
       return;
     }
 
-    Exception err = null;
+    KubernetesClientException err = null;
     long maxRetry = API_STATUS_PATCH_MAX_ATTEMPTS.getValue();
     for (long i = 1; i <= maxRetry; i++) {
       // We retry the status update maxRetry times to avoid some intermittent connectivity errors
@@ -110,7 +110,6 @@ public class StatusRecorder<
     }
 
     if (err != null) {
-      log.error("Fail to patch status.", err);
       throw err;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `StatusRecorder.patchAndStatusWithVersionLocked` not to log errors.

### Why are the changes needed?

The upper layer already shows the error properly like the following. So, we had better avoid repeating the same exception log.

https://github.com/apache/spark-kubernetes-operator/blob/bdbbbbe5725e619c6bdd79ddc7bc8c11ee156c7c/spark-operator/src/main/java/org/apache/spark/k8s/operator/utils/StatusRecorder.java#L132-L141

### Does this PR introduce _any_ user-facing change?

No behavior change because this is a removal of duplicated log.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.