### PR TITLE
[SPARK-55537] Check `spark.dynamicAllocation.enabled` before overriding deleteOnTermination

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -168,8 +168,9 @@ public class SparkAppSubmissionWorker {
     effectiveSparkConf.setIfMissing("spark.app.id", appId);
     effectiveSparkConf.setIfMissing("spark.authenticate", "true");
     effectiveSparkConf.setIfMissing("spark.io.encryption.enabled", "true");
-    // Use K8s Garbage Collection instead of explicit API invocations
-    if (applicationSpec.getApplicationTolerations().getResourceRetainPolicy() !=
+    // In case of static allocation, use K8s Garbage Collection instead of explicit API invocations
+    if (!"true".equalsIgnoreCase(effectiveSparkConf.get("spark.dynamicAllocation.enabled", "false"))
+        && applicationSpec.getApplicationTolerations().getResourceRetainPolicy() !=
         ResourceRetainPolicy.Always) {
       effectiveSparkConf.setIfMissing("spark.kubernetes.executor.deleteOnTermination", "false");
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to check `spark.dynamicAllocation.enabled` before overriding deleteOnTermination.

### Why are the changes needed?

For `Dynamic Allocation`, we had better respect the default clean-up behavior.
- #484

### Does this PR introduce _any_ user-facing change?

Yes, but SPARK-55352 is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`