### PR TITLE
[SPARK-55543] Change `SentinelManager.getSentinelResources` to `package private`

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManager.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
@@ -254,8 +253,7 @@ public class SentinelManager<CR extends BaseResource<?, ?, ?, ?, ?>> {
    *
    * @return A ConcurrentHashMap of ResourceID to SentinelResourceState.
    */
-  @VisibleForTesting
-  public ConcurrentHashMap<ResourceID, SentinelResourceState> getSentinelResources() {
+  ConcurrentHashMap<ResourceID, SentinelResourceState> getSentinelResources() {
     return sentinelResources;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to change `SentinelManager.getSentinelResources` to `package private` from `public`.

### Why are the changes needed?

This was designed to be `public` and marked as `VisibleForTesting`. However, `SentinelManagerTest` can test it as `package private`. So, we don't need to expose this as a `public` method.

### Does this PR introduce _any_ user-facing change?

No. This is supposed to be used internally by `Apache Spark K8s Operator`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`