### PR TITLE
[SPARK-55545] Improve `create_spark_jira.py` to support `-p` to set the parent JIRA ID

### DIFF
--- a/dev/create_spark_jira.py
+++ b/dev/create_spark_jira.py
@@ -48,7 +48,9 @@ def run_cmd(cmd):
         return subprocess.check_output(cmd.split(" ")).decode("utf-8")
 
 
-def create_jira_issue(title):
+import argparse
+
+def create_jira_issue(title, parent_jira_id=None):
     asf_jira = jira.client.JIRA(
         {"server": JIRA_API_BASE},
         token_auth=JIRA_ACCESS_TOKEN
@@ -66,10 +68,15 @@ def create_jira_issue(title):
         'project': {'key': 'SPARK'},
         'summary': title,
         'description': '',
-        'issuetype': {'name': 'Improvement'},
         'components': [{'name': 'Kubernetes'}],
         'versions': [{'name': versions[0].name}],
     }
+
+    if parent_jira_id:
+        issue_dict['issuetype'] = {'name': 'Sub-task'}
+        issue_dict['parent'] = {'key': parent_jira_id}
+    else:
+        issue_dict['issuetype'] = {'name': 'Improvement'}
 
     try:
         new_issue = asf_jira.create_issue(fields=issue_dict)
@@ -101,18 +108,19 @@ def main():
     if not JIRA_ACCESS_TOKEN:
         fail("The env-var JIRA_ACCESS_TOKEN is not set.")
 
-    if len(sys.argv) < 2:
-        fail("Usage: %s <JIRA title>" % sys.argv[0])
+    parser = argparse.ArgumentParser(description="Create a Spark JIRA issue.")
+    parser.add_argument("title", help="Title of the JIRA issue")
+    parser.add_argument("-p", "--parent", help="Parent JIRA ID for subtasks")
+    args = parser.parse_args()
 
-    title = sys.argv[1]
-    print("Creating JIRA issue with title: %s" % title)
+    print("Creating JIRA issue with title: %s" % args.title)
 
-    jira_id = create_jira_issue(title)
+    jira_id = create_jira_issue(args.title, args.parent)
     print("Created JIRA issue: %s" % jira_id)
 
     create_and_checkout_branch(jira_id)
 
-    create_commit(jira_id, title)
+    create_commit(jira_id, args.title)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `create_spark_jira.py` to support `-p` to set the parent JIRA ID.

```bash
$ dev/create_spark_jira.py -p SPARK-55000 'Improve `create_spark_jira.py` to support `-p` to set the parent JIRA ID'
```

### Why are the changes needed?

To reduce the number of steps because new JIRA issues belong to the umbrella JIRA issue, SPARK-55000, currently.

### Does this PR introduce _any_ user-facing change?

No. This is a dev script.

### How was this patch tested?

Manually tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`