### PR TITLE
[SPARK-55567] Remove `HttpServletRequest` usage

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/PrometheusPullModelHandler.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/PrometheusPullModelHandler.java
@@ -37,7 +37,6 @@ import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -95,8 +94,7 @@ public class PrometheusPullModelHandler extends PrometheusServlet implements Htt
           formatMetricsSnapshot(),
           Map.of("Content-Type", List.of("text/plain; charset=utf-8; version=0.0.4")));
     } else {
-      HttpServletRequest httpServletRequest = null;
-      String value = getMetricsSnapshot(httpServletRequest);
+      String value = getMetricsSnapshot(null);
       sendMessage(
           exchange,
           HTTP_OK,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `HttpServletRequest` usage.

### Why are the changes needed?

To remove unnecessary package reference which was added.
- #23

**BEFORE**

```
$ git grep HttpServletRequest | wc -l
       2
```

**AFTER**

```
$ git grep HttpServletRequest | wc -l
       0
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`