### PR TITLE
[SPARK-55598] Update `rsync-deployments` tag to 8.0.3

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -50,7 +50,7 @@ jobs:
         helm repo index tmp/$DIR --url https://nightlies.apache.org/spark/$DIR
         helm show chart tmp/$DIR/spark-kubernetes-operator-*.tgz
     - name: Upload
-      uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+      uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6
       with:
         switches: -avzr
         path: build-tools/helm/tmp/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `rsync-deployments` tag to 8.0.3.

### Why are the changes needed?

ASF Infra will expire the previous one on 2026-04-17 . We had better use the next approved pattern. Please note that the approved pattern is `Hash Value` for tag `8.0.3`
- https://github.com/apache/infrastructure-actions/commit/8344d35c92d243f907af60975dfa39a0e9ae4b38

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`