### PR TITLE
[SPARK-55602] Update `setup-java` to v5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'zulu'
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -117,7 +117,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -195,7 +195,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'
@@ -237,7 +237,7 @@ jobs:
           VALIDATE_MARKDOWN: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'zulu'

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
     - name: Set up JDK 25
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 25
         distribution: 'zulu'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `setup-java` to v5.

### Why are the changes needed?

To use the latest `setup-java` version:
- https://github.com/actions/setup-java/releases/tag/v5.2.0
  - https://github.com/actions/setup-java/pull/964
- https://github.com/actions/setup-java/releases/tag/v5.1.0
  - https://github.com/actions/setup-java/pull/927
- https://github.com/actions/setup-java/releases/tag/v5.0.0
  - https://github.com/actions/setup-java/pull/888

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`