### PR TITLE
[SPARK-55641] Add connection timeout to JIRA client to prevent hanging and enable retries

### DIFF
--- a/dev/create_spark_jira.py
+++ b/dev/create_spark_jira.py
@@ -53,7 +53,8 @@ import argparse
 def create_jira_issue(title, parent_jira_id=None, issue_type=None):
     asf_jira = jira.client.JIRA(
         {"server": JIRA_API_BASE},
-        token_auth=JIRA_ACCESS_TOKEN
+        token_auth=JIRA_ACCESS_TOKEN,
+        timeout=(3.05, 30)
     )
 
     versions = asf_jira.project_versions("SPARK")

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -559,7 +559,7 @@ def initialize_jira():
         print_error("ERROR finding jira library. Run 'pip3 install jira' to install.")
         continue_maybe("Continue without jira?")
     elif JIRA_ACCESS_TOKEN:
-        client = jira.client.JIRA(jira_server, token_auth=JIRA_ACCESS_TOKEN)
+        client = jira.client.JIRA(jira_server, token_auth=JIRA_ACCESS_TOKEN, timeout=(3.05, 30))
         try:
             # Eagerly check if the token is valid to align with the behavior of username/password
             # authn
@@ -578,7 +578,7 @@ def initialize_jira():
         print("You can use JIRA_ACCESS_TOKEN instead of JIRA_USERNAME/JIRA_PASSWORD.")
         print("Visit https://issues.apache.org/jira/secure/ViewProfile.jspa ")
         print("and click 'Personal Access Tokens' menu to manage your own tokens.")
-        asf_jira = jira.client.JIRA(jira_server, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD))
+        asf_jira = jira.client.JIRA(jira_server, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD), timeout=(3.05, 30))
     else:
         print("Neither JIRA_ACCESS_TOKEN nor JIRA_USERNAME/JIRA_PASSWORD are set.")
         continue_maybe("Continue without jira?")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a generic connection and read timeout parameter timeout=(3.05, 30) to the `jira.client.JIRA()` initializations in the dev/ scripts.

### Why are the changes needed?

By default, the `requests` library (used by the jira python package) can hang indefinitely when attempting to establish a connection if the server is unresponsive. Setting a short connection timeout of 3.05 seconds (slightly larger than a standard 3-second TCP packet retransmission window) ensures that the client will quickly fail the connection attempt and properly trigger its internal retry logic, rather than stalling the entire script. The 30-second read timeout allows sufficient time for normal API responses once the connection is successfully established.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`