### PR TITLE
[SPARK-55644] Add `instanceConfig` `SparkApplication` example

### DIFF
--- a/examples/pi-with-instanceconfig.yaml
+++ b/examples/pi-with-instanceconfig.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-with-instanceconfig
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  driverArgs: [ "20000" ]
+  sparkConf:
+    spark.executor.instances: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
+    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
+  applicationTolerations:
+    instanceConfig:
+      maxExecutors: 3
+      minExecutors: 3
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.1.1"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `InstanceConfig` example.

### Why are the changes needed?

To provide a simple `SparkApplication` example with `instanceConfig` property in addition to the existing documentation.

https://github.com/apache/spark-kubernetes-operator/blob/ec71ea8994ec580982d0c26dcd0d20304393b948/docs/spark_custom_resources.md?plain=1#L286-L292

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tests.

```
$ kubectl apply -f examples/pi-with-instanceconfig.yaml
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`