### PR TITLE
[SPARK-55676] Upgrade Hadoop to 3.4.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ subprojects {
       if (requested.group == "io.netty" && !requested.name.startsWith("netty-tcnative")) {
         useVersion(libs.versions.netty.get())
       }
+      if (requested.group == "org.apache.hadoop") {
+        useVersion(libs.versions.hadoop.get())
+      }
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ netty = "4.2.10.Final"
 operator-sdk = "5.2.2"
 dropwizard-metrics = "4.2.37"
 spark = "4.1.1"
+hadoop = "3.4.3"
 log4j = "2.24.3"
 slf4j = "2.0.17"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Hadoop to 3.4.3 instead of the transitive one from the Apache Spark 4.1.1.

### Why are the changes needed?

Apache Hadoop 3.4.3 supports Java 25 better.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

Manually check like the following.

**BEFORE**

```bash
$ gradle spark-operator:dependencyInsight --configuration compileClasspath --dependency org.apache.hadoop | grep '^org.apache.hadoop' | awk -F: '{print $NF}' | sort | uniq -c
   4 3.4.2
```

**AFTER**

```bash
$ gradle spark-operator:dependencyInsight --configuration compileClasspath --dependency org.apache.hadoop | grep '^org.apache.hadoop' | awk -F: '{print $NF}' | sort | uniq -c
   2 3.4.2 -> 3.4.3
   2 3.4.3 (selected by rule)
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`