### PR TITLE
[SPARK-55680] Remove `spark.kubernetes.driver.pod.excludedFeatureSteps` config from examples

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -31,7 +31,6 @@ spec:
     spark.executor.extraClassPath: "local:///comet/comet.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:3.5.8-java17"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
     spark.plugins: "org.apache.spark.CometPlugin"

--- a/examples/pi-with-instanceconfig.yaml
+++ b/examples/pi-with-instanceconfig.yaml
@@ -24,7 +24,6 @@ spec:
     spark.executor.instances: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   applicationTolerations:
     instanceConfig:
       maxExecutors: 3

--- a/examples/pi-with-on-demand-pvc.yaml
+++ b/examples/pi-with-on-demand-pvc.yaml
@@ -26,7 +26,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.path: "/data"
     spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.readOnly: "false"
     spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.claimName: "OnDemand"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -25,7 +25,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000

--- a/examples/spark-connect-server-iceberg.yaml
+++ b/examples/spark-connect-server-iceberg.yaml
@@ -31,7 +31,6 @@ spec:
     spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.1,org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.1"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.2"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.executor.podNamePrefix: "spark-connect-server-iceberg"
     spark.scheduler.mode: "FAIR"
     spark.sql.catalog.s3.type: "hadoop"

--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -25,7 +25,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.executor.podNamePrefix: "spark-connect-server"
     spark.scheduler.mode: "FAIR"
   applicationTolerations:

--- a/examples/spark-history-server-with-jws-filter.yaml
+++ b/examples/spark-history-server-with-jws-filter.yaml
@@ -35,7 +35,6 @@ spec:
     spark.hadoop.fs.s3a.path.style.access: "true"
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     # JWS Filter Configuration
     spark.ui.filters: "org.apache.spark.ui.JWSFilter"
     spark.org.apache.spark.ui.JWSFilter.param.secretKey: "VmlzaXQgaHR0cHM6Ly9zcGFyay5hcGFjaGUub3JnIHRvIGRvd25sb2FkIEFwYWNoZSBTcGFyay4="

--- a/examples/spark-history-server.yaml
+++ b/examples/spark-history-server.yaml
@@ -35,7 +35,6 @@ spec:
     spark.hadoop.fs.s3a.path.style.access: "true"
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   runtimeVersions:
     sparkVersion: "4.1.1"
   applicationTolerations:

--- a/examples/spark-thrift-server.yaml
+++ b/examples/spark-thrift-server.yaml
@@ -25,7 +25,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.executor.podNamePrefix: "spark-thrift-server"
     spark.scheduler.mode: "FAIR"
   runtimeVersions:

--- a/examples/word-count-celeborn.yaml
+++ b/examples/word-count-celeborn.yaml
@@ -28,7 +28,6 @@ spec:
     spark.kubernetes.container.image: "apache/spark:4.0.2-scala"
     spark.kubernetes.driver.limit.cores: "5"
     spark.kubernetes.driver.master: "local[10]"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.driver.request.cores: "5"
     spark.shuffle.manager: "org.apache.spark.shuffle.celeborn.SparkShuffleManager"
     spark.shuffle.service.enabled: "false"

--- a/examples/word-count.yaml
+++ b/examples/word-count.yaml
@@ -25,7 +25,6 @@ spec:
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
-    spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes unnecessary `spark.kubernetes.driver.pod.excludedFeatureSteps=org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep` config.

### Why are the changes needed?

Since SPARK-55676, `Apache Spark K8s Operator` doesn't need to exclude `KerberosConfDriverFeatureStep` because Apache Hadoop 3.4.3 supports Java 25.
- #521 

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manually tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`