### PR TITLE
[SPARK-55733] Upgrade PMD to 7.21.0 to support Java 26

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ mockito = "5.21.0"
 
 # Build Analysis
 checkstyle = "13.0.0"
-pmd = "7.19.0"
+pmd = "7.21.0"
 spotbugs-tool = "4.9.8"
 spotbugs-plugin = "6.4.7"
 spotless-plugin = "8.1.0"

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 @EnableKubeAPIServer
 class SparkOperatorConfigMapReconcilerTest {
 
-  public static final Long TARGET_RECONCILER_INTERVAL = 60L;
+  static final Long TARGET_RECONCILER_INTERVAL = 60L;
 
   private static KubernetesClient client;
 

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManagerTest.java
@@ -67,7 +67,7 @@ class SentinelManagerTest {
   private static final String SPARK_DEMO = "spark-demo";
   KubernetesClient kubernetesClient;
   KubernetesMockServer server;
-  public static final int SENTINEL_RESOURCE_RECONCILIATION_DELAY_SECONDS = 10;
+  static final int SENTINEL_RESOURCE_RECONCILIATION_DELAY_SECONDS = 10;
 
   @BeforeAll
   static void beforeAll() {

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetricsTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/metrics/source/OperatorJosdkMetricsTest.java
@@ -56,7 +56,7 @@ class OperatorJosdkMetricsTest {
   private OperatorJosdkMetrics operatorMetrics;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     operatorMetrics = new OperatorJosdkMetrics();
   }
 

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/HealthProbeTest.java
@@ -61,14 +61,14 @@ class HealthProbeTest {
       unhealthyEventSources2 = new HashMap<>();
 
   @BeforeAll
-  public static void beforeAll() {
+  static void beforeAll() {
     operator = mock(Operator.class);
     sparkConfMonitor = mock(Operator.class);
     operators = Arrays.asList(operator, sparkConfMonitor);
   }
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     isRunning = new AtomicBoolean(false);
     isRunning2 = new AtomicBoolean(false);
     RuntimeInfo runtimeInfo =

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/probe/ReadinessProbeTest.java
@@ -42,7 +42,7 @@ class ReadinessProbeTest {
   HttpExchange httpExchange;
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     OutputStream outputStream = mock(OutputStream.class);
     httpExchange = mock(HttpExchange.class);
     client = mock(KubernetesClient.class);

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkAppReconcilerTest.java
@@ -64,7 +64,7 @@ class SparkAppReconcilerTest {
       new SparkAppReconciler(mockWorker, mockRecorder, mockSentinelManager);
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     when(mockContext.getClient()).thenReturn(mockClient);
     doNothing().when(mockRecorder).removeCachedStatus(any(SparkApplication.class));
     doAnswer(

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkClusterReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/reconciler/SparkClusterReconcilerTest.java
@@ -58,7 +58,7 @@ class SparkClusterReconcilerTest {
       new SparkClusterReconciler(mockWorker, mockRecorder, mockSentinelManager);
 
   @BeforeEach
-  public void beforeEach() {
+  void beforeEach() {
     when(mockContext.getClient()).thenReturn(mockClient);
     doNothing().when(mockRecorder).removeCachedStatus(any(SparkCluster.class));
     doAnswer(

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/StatusRecorderTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/utils/StatusRecorderTest.java
@@ -46,7 +46,7 @@ import org.apache.spark.k8s.operator.status.ApplicationStatus;
     justification = "Unwritten fields are covered by Kubernetes mock client")
 class StatusRecorderTest {
 
-  public static final String DEFAULT_NS = "default";
+  static final String DEFAULT_NS = "default";
   KubernetesMockServer server;
   KubernetesClient client;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade PMD to 7.21.0 to support Java 26 and update the code according to the new rules.

### Why are the changes needed?

- [PMD 7.21.0 (Released January 30, 2026)](https://docs.pmd-code.org/pmd-doc-7.21.0/pmd_release_notes.html#30-january-2026---7210)
  - **Java 26 Support**: Added support for Java 26, including the preview feature for Primitive Types in Patterns, instanceof, and switch (JEP 530). You can use this by selecting the java-26-preview language version.
  - **New Rule - PublicMemberInNonPublicType**: Flags public members inside non-public types to prevent confusion regarding their effective visibility.
  - **New Rule - UnsupportedJdkApiUsage**: Identifies the use of unstable or non-portable JDK APIs (like sun.* packages or sun.misc.Unsafe), encouraging developers to migrate to official modern APIs like VarHandle or the Foreign Function & Memory API.

- [PMD 7.20.0 (Released December 30, 2025)](https://docs.pmd-code.org/pmd-doc-7.20.0/pmd_release_notes.html#30-december-2025---7200)
  - **Rule Update - OnlyOneReturn**: The Java rule OnlyOneReturn has been updated with a new property called ignoredMethodNames. By default, this is set to compareTo and equals, allowing multiple return statements in these specific standard methods without triggering a violation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`