### PR TITLE
[SPARK-55735] Upgrade `checkstyle` to 13.2.0 and `spotbugs-plugin` to 6.4.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,10 +31,10 @@ jacoco = "0.8.14"
 mockito = "5.21.0"
 
 # Build Analysis
-checkstyle = "13.0.0"
+checkstyle = "13.2.0"
 pmd = "7.21.0"
 spotbugs-tool = "4.9.8"
-spotbugs-plugin = "6.4.7"
+spotbugs-plugin = "6.4.8"
 spotless-plugin = "8.1.0"
 
 # Packaging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `checkstyle` to 13.2.0 and `spotbugs-plugin` to 6.4.8

### Why are the changes needed?

To use the latest tools:
- https://checkstyle.org/releasenotes.html#Release_13.2.0
  - https://github.com/checkstyle/checkstyle/issues/16678
- https://checkstyle.org/releasenotes.html#Release_13.1.0
  - https://github.com/checkstyle/checkstyle/issues/18329
  - https://github.com/checkstyle/checkstyle/issues/18368
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.4.8

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`