### PR TITLE
[SPARK-55737] Add Java 26-ea to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ 'ubuntu-latest', 'ubuntu-24.04-arm' ]
-        java-version: [ 17, 21, 25 ]
+        java-version: [ 17, 21, 25, '26-ea' ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Java 26-ea to GitHub Action as the runner environment.

### Why are the changes needed?

Apache Spark K8s Operator uses `Java 25` tool chain. This PR only aims to test `Java 26-ea` as the initial runner environment.
- #336

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.

- https://github.com/apache/spark-kubernetes-operator/actions/runs/22471589856/job/65089536362?pr=528

<img width="679" height="423" alt="Screenshot 2026-02-26 at 19 33 17" src="https://github.com/user-attachments/assets/7a7e40b9-ca8e-4926-8b46-5ab069a88116" />

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`