### PR TITLE
[SPARK-55738] Fix `ResourceRetainPolicy` javadoc location

### DIFF
--- a/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ResourceRetainPolicy.java
+++ b/spark-operator-api/src/main/java/org/apache/spark/k8s/operator/spec/ResourceRetainPolicy.java
@@ -19,20 +19,20 @@
 
 package org.apache.spark.k8s.operator.spec;
 
+/**
+ * Configure operator to delete / retain resources for an app after it terminates. This controls
+ * the resources created directly by Operator (spark-submit), including driver pod and its
+ * configmap. Resources created by driver are still controlled by driver (via SparkConf). Tuning
+ * 'spark.kubernetes.driver.service.deleteOnTermination' and `spark.kubernetes.executor
+ * .deleteOnTermination`in application for resource retaining policy is still necessary. Default
+ * to 'Never' so operator deletes all created Spark resources after app terminates. Setting this
+ * to 'Always' / 'OnFailure' to indicate operator not to delete resources based on app state, this
+ * can be helpful in dev phase to debug failed Spark pod behavior. Driver has owner reference
+ * configured to make sure it's garbage collected by k8s. Please be advised that resource would
+ * not be retained if application is configured to restart, this is to avoid resource quota usage
+ * increase unexpectedly or resource conflicts among multiple attempts.
+ */
 public enum ResourceRetainPolicy {
-  /**
-   * Configure operator to delete / retain resources for an app after it terminates. This controls
-   * the resources created directly by Operator (spark-submit), including driver pod and its
-   * configmap. Resources created by driver are still controlled by driver (via SparkConf). Tuning
-   * 'spark.kubernetes.driver.service.deleteOnTermination' and `spark.kubernetes.executor
-   * .deleteOnTermination`in application for resource retaining policy is still necessary. Default
-   * to 'Never' so operator deletes all created Spark resources after app terminates. Setting this
-   * to 'Always' / 'OnFailure' to indicate operator not to delete resources based on app state, this
-   * can be helpful in dev phase to debug failed Spark pod behavior. Driver has owner reference
-   * configured to make sure it's garbage collected by k8s. Please be advised that resource would
-   * not be retained if application is configured to restart, this is to avoid resource quota usage
-   * increase unexpectedly or resource conflicts among multiple attempts.
-   */
   Always,
   OnFailure,
   Never


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ResourceRetainPolicy` java location by moving the comment.

### Why are the changes needed?

The current location is misleading and wrong.

<img width="534" height="475" alt="Screenshot 2026-02-26 at 20 08 22" src="https://github.com/user-attachments/assets/91368fae-a945-4f5b-915a-6f4adf47240d" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`