### PR TITLE
[SPARK-55758] Use `ubuntu-slim` for GitHub Actions `license-check` job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   license-check:
     name: "License Check"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 20
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `ubuntu-slim` for GitHub Actions `license-check` job.

### Why are the changes needed?

`ubuntu-slim` is a new cost-efficient runner to fit small jobs like `license-check`. We had better use this to save ASF infra usage (if possible)
- https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/
- https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md

| Feature | `ubuntu-slim` | `ubuntu-latest` |
| :--- | :---: | :---: |
| **Cost (per minute)** | **$0.002** | **$0.012** |
| **Cost for 1,000 mins** | **$2.00** | **$12.00** |
| **CPU** | 1 vCPU | 4 vCPU |
| **Memory (RAM)** | 5 GB | 16 GB |
| **Storage (SSD)** | 14 GB | 14 GB |
| **Maximum Runtime** | **15 Minutes** | 6 Hours |
| **Isolation Type** | Container-based (L2) | Dedicated VM |

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`