### PR TITLE
[SPARK-55807] Use Java 25 Compact Object Headers

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -41,7 +41,7 @@ operatorDeployment:
     # https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
     topologySpreadConstraints: [ ]
     operatorContainer:
-      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80 -XX:+AlwaysPreTouch -Dio.netty.noUnsafe=true"
+      jvmArgs: "-Dfile.encoding=UTF8 -XX:+ExitOnOutOfMemoryError -XX:+UseParallelGC -XX:InitialRAMPercentage=80 -XX:MaxRAMPercentage=80 -XX:+AlwaysPreTouch -Dio.netty.noUnsafe=true -XX:+UseCompactObjectHeaders"
       env:
         - name: "SPARK_USER"
           value: "spark"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add `-XX:+UseCompactObjectHeaders` to the `operatorContainer.jvmArgs` in `build-tools/helm/spark-kubernetes-operator/values.yaml`.

Since `Apache Spark K8s Operator` uses Java 25, we are ready to use this feature.

https://github.com/apache/spark-kubernetes-operator/blob/5af667eb410e886f9180e124a14ec3241d57137c/build-tools/docker/Dockerfile#L25

### Why are the changes needed?
To use Java 25 Compact Object Headers (`-XX:+UseCompactObjectHeaders`) for the `spark-kubernetes-operator` container. This feature is known to reduce significantly the memory footprint of Java objects.
- https://openjdk.org/jeps/519

> In one setting, the SPECjbb2015 benchmark uses [22% less heap space and 8% less CPU time](https://github.com/rkennke/talks/blob/master/Lilliput-FOSDEM-2025.pdf).
> 
> In another setting, the number of garbage collections done by SPECjbb2015 is [reduced by 15%](https://bugs.openjdk.org/browse/JDK-8350457?focusedId=14766358&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14766358), with both the G1 and Parallel collectors.
> 
> A highly parallel JSON parser benchmark [runs in 10% less time](https://www.reddit.com/r/scala/comments/1jptiv3/xxusecompactobjectheaders_is_your_new_turbo/?rdt=40432).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`.
