### PR TITLE
[SPARK-55808] Use `-XX:+UseCompactObjectHeaders` for Java 25+ GitHub Actions `build-test` jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,6 +48,9 @@ jobs:
           cache: 'gradle'
       - name: Build with Gradle
         run: |
+          if [[ "${{ matrix.java-version }}" == "25" || "${{ matrix.java-version }}" == "26-ea" ]]; then
+            export JDK_JAVA_OPTIONS="-XX:+UseCompactObjectHeaders"
+          fi
           ./gradlew build
   build-image:
     name: "Build Operator Image CI"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `-XX:+UseCompactObjectHeaders` for Java 25+ GitHub Actions `build-test` jobs

### Why are the changes needed?
This feature is known to reduce significantly the memory footprint of Java objects.
- https://openjdk.org/jeps/519

> In one setting, the SPECjbb2015 benchmark uses [22% less heap space and 8% less CPU time](https://github.com/rkennke/talks/blob/master/Lilliput-FOSDEM-2025.pdf).
> 
> In another setting, the number of garbage collections done by SPECjbb2015 is [reduced by 15%](https://bugs.openjdk.org/browse/JDK-8350457?focusedId=14766358&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14766358), with both the G1 and Parallel collectors.
> 
> A highly parallel JSON parser benchmark [runs in 10% less time](https://www.reddit.com/r/scala/comments/1jptiv3/xxusecompactobjectheaders_is_your_new_turbo/?rdt=40432).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`.