### PR TITLE
[SPARK-56091] Upgrade `Apache DataFusion Comet` to 0.14.0

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -46,7 +46,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.13.0/comet-spark-spark3.5_2.12-0.13.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.14.0/comet-spark-spark3.5_2.12-0.14.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -68,7 +68,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.13.0/comet-spark-spark3.5_2.12-0.13.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.14.0/comet-spark-spark3.5_2.12-0.14.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `Apache DataFusion Comet` to 0.14.0 in `examples/pi-with-comet.yaml`.

### Why are the changes needed?

To use the latest version of Apache DataFusion Comet (0.14.0, released on 2026-03-16).
- https://github.com/apache/datafusion-comet/releases/tag/0.14.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)