### PR TITLE
[SPARK-56417] Consolidate `Lombok` and `JUnitPlatform` configurations into root `build.gradle`

### DIFF
--- a/build-tools/docs-utils/build.gradle
+++ b/build-tools/docs-utils/build.gradle
@@ -28,12 +28,6 @@ dependencies {
     implementation project(":spark-operator")
     implementation(libs.log4j.core)
     implementation(libs.log4j.slf4j2.impl)
-    compileOnly(libs.lombok)
-    annotationProcessor(libs.lombok)
-}
-
-test {
-    useJUnitPlatform()
 }
 
 tasks.register('generateConfPropsDoc', Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,16 @@ subprojects {
       removeUnusedImports()
     }
   }
+
+  // Lombok
+  dependencies {
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+  }
+
+  test {
+    useJUnitPlatform()
+  }
 }
 
 apply plugin: 'com.diffplug.spotless'

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -21,17 +21,9 @@ dependencies {
   implementation(libs.kubernetes.client)
   compileOnly(libs.crd.generator.annotations)
 
-  // utils
-  compileOnly(libs.lombok)
-  annotationProcessor(libs.lombok)
-
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)
-}
-
-test {
-  useJUnitPlatform()
 }
 
 // CRD Generator v2 - generates CRD YAML from compiled CustomResource classes

--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -51,9 +51,6 @@ dependencies {
     exclude group: "org.slf4j"
     exclude group: "org.xerial.snappy"
   }
-  compileOnly(libs.lombok)
-
-  annotationProcessor(libs.lombok)
   annotationProcessor(libs.spotbugs.annotations)
 
   testImplementation(libs.operator.framework.junit5) {
@@ -74,10 +71,6 @@ dependencies {
   testCompileOnly(libs.spotbugs.annotations)
   testImplementation(libs.mockito.core)
   testImplementation(libs.kube.api.test.client.inject)
-}
-
-test {
-  useJUnitPlatform()
 }
 
 jar.dependsOn shadowJar

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -40,15 +40,8 @@ dependencies {
     exclude group: "org.xerial.snappy"
   }
 
-  compileOnly(libs.lombok)
-  annotationProcessor(libs.lombok)
-
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.mockito.core)
   testImplementation(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)
-}
-
-test {
-  useJUnitPlatform()
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR consolidates the repeated `Lombok` and `useJUnitPlatform()` configurations from 4 subprojects into the root `build.gradle` `subprojects` block.

### Why are the changes needed?

The following configurations were duplicated across all 4 subprojects (`spark-operator-api`, `spark-operator`, `spark-submission-worker`, `build-tools-docs-utils`):
- `compileOnly(libs.lombok)`
- `annotationProcessor(libs.lombok)`
- `test { useJUnitPlatform() }`

Moving them to the `subprojects` block reduces duplication and ensures consistency.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)