### PR TITLE
[SPARK-56365] Remove hard-coded `APP_VERSION` from Dockerfile

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -24,9 +24,7 @@ RUN --mount=type=cache,target=/home/gradle/.gradle/caches gradle --no-daemon cle
 
 FROM azul/zulu-openjdk-alpine:26 AS jlink
 
-ARG APP_VERSION=0.9.0-SNAPSHOT
-
-COPY --from=builder /app/spark-operator/build/libs/spark-kubernetes-operator-${APP_VERSION}-all.jar /tmp/app.jar
+COPY --from=builder /app/spark-operator/build/libs/spark-kubernetes-operator-*-all.jar /tmp/app.jar
 
 RUN apk add --no-cache binutils && \
     MODULES=$(jdeps \
@@ -45,7 +43,7 @@ RUN apk add --no-cache binutils && \
 
 FROM alpine:3.23
 
-ARG APP_VERSION=0.9.0-SNAPSHOT
+ARG APP_VERSION
 ARG SPARK_UID=185
 
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
@@ -68,7 +66,7 @@ RUN apk add --no-cache libstdc++ && \
     adduser -S -h $SPARK_OPERATOR_HOME -u $SPARK_UID -G spark spark && \
     chown -R spark:spark $SPARK_OPERATOR_HOME
 
-COPY --from=builder --chown=spark:spark /app/spark-operator/build/libs/spark-kubernetes-operator-$APP_VERSION-all.jar $SPARK_OPERATOR_JAR
+COPY --from=builder --chown=spark:spark /app/spark-operator/build/libs/spark-kubernetes-operator-*-all.jar $SPARK_OPERATOR_JAR
 USER spark
 
 CMD ["java", "-cp", "./spark-kubernetes-operator.jar", "org.apache.spark.k8s.operator.SparkOperator"]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the hard-coded `APP_VERSION=0.9.0-SNAPSHOT` default value from `Dockerfile` and uses wildcard patterns for JAR file copying instead.

### Why are the changes needed?

Currently, `APP_VERSION=0.9.0-SNAPSHOT` is duplicated in both `build.gradle` (the single source of truth) and `Dockerfile`. When the version changes, both files need to be updated manually. By using wildcard patterns in `COPY` commands, the `Dockerfile` no longer needs to know the exact version string. The `ARG APP_VERSION` (without default) is retained for the OCI image version label, which is passed dynamically from `build.gradle` via `--build-arg`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-6)