### PR TITLE
[SPARK-56433] Upgrade `operator-sdk` to 5.3.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 fabric8 = "7.6.1"
 lombok = "1.18.44"
 netty = "4.2.12.Final"
-operator-sdk = "5.3.2"
+operator-sdk = "5.3.3"
 dropwizard-metrics = "4.2.38"
 spark = "4.1.1"
 hadoop = "3.5.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `operator-sdk` to 5.3.3.

### Why are the changes needed?

To bring the latest bug fixes of Java Operator SDK.
- https://github.com/operator-framework/java-operator-sdk/releases/tag/v5.3.3
  - https://github.com/operator-framework/java-operator-sdk/pull/3273

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6