### PR TITLE
[SPARK-56434] Add `Deployment Topology` diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,50 @@ The Operator is built with the [Java Operator SDK](https://javaoperatorsdk.io/) 
 launching Spark deployments and submitting jobs under the hood. It also uses
 [fabric8](https://fabric8.io/) client to interact with Kubernetes API Server.
 
+## Deployment Topology
+
+A typical installation places the Operator pod in one dedicated namespace while it watches
+Spark custom resources in one or more workload namespaces. RBAC is scoped by the Helm chart:
+the Operator ServiceAccount is bound to the permissions required to manage
+`SparkApplication` / `SparkCluster` resources and their child Kubernetes objects.
+
+```mermaid
+flowchart LR
+    user([User / CI]) -->|kubectl apply| api[Kubernetes API Server]
+
+    subgraph operatorNs[Operator Namespace]
+        op[Spark Operator Pod]
+        sa[ServiceAccount + Role/ClusterRole Bindings]
+        op -.uses.- sa
+    end
+
+    subgraph workloadA[Workload Namespace A]
+        crA1[SparkApplication CR]
+        crA2[SparkCluster CR]
+        drvA[Driver Pod / Master Pod]
+        execA[Executor / Worker Pods]
+    end
+
+    subgraph workloadB[Workload Namespace B]
+        crB[SparkApplication CR]
+        drvB[Driver Pod]
+        execB[Executor Pods]
+    end
+
+    api <-->|watch / patch| op
+    op -->|reconcile| crA1
+    op -->|reconcile| crA2
+    op -->|reconcile| crB
+    op ==>|create driver / master| drvA
+    op ==>|create driver| drvB
+    drvA -->|spawns| execA
+    drvB -->|spawns| execB
+```
+
+Multiple Operator instances can coexist on the same cluster (for example one per region or per
+tenant) as long as each uses a distinct ServiceAccount / RoleBinding name and a disjoint set of
+watched namespaces. See [operations.md](operations.md) for a concrete multi-instance example.
+
 ## Application State Transition
 
 ```mermaid


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Deployment Topology` diagram.

<img width="1157" height="618" alt="Screenshot 2026-04-10 at 07 10 41" src="https://github.com/user-attachments/assets/c1e6225b-7117-40a5-b512-876d8ee81113" />

### Why are the changes needed?

To improve the documentation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. Visit the PR branch.

https://github.com/dongjoon-hyun/spark-kubernetes-operator/blob/SPARK-56434/docs/architecture.md

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.6)