### PR TITLE
[SPARK-56442] Use Java-friendly APIs of `JavaMainAppResource`

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -143,9 +143,9 @@ public class SparkAppSubmissionWorker {
       }
     }
     effectiveSparkConf.set("spark.kubernetes.namespace", app.getMetadata().getNamespace());
-    MainAppResource primaryResource = new JavaMainAppResource(Option.empty());
+    MainAppResource primaryResource = JavaMainAppResource.create();
     if (StringUtils.isNotEmpty(applicationSpec.getJars())) {
-      primaryResource = new JavaMainAppResource(Option.apply(applicationSpec.getJars()));
+      primaryResource = JavaMainAppResource.of(applicationSpec.getJars());
       effectiveSparkConf.setIfMissing("spark.jars", applicationSpec.getJars());
     } else if ("org.apache.spark.deploy.PythonRunner".equals(applicationSpec.getMainClass())) {
       String[] files = applicationSpec.getPyFiles().split(",", 2);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the Java-friendly factory methods `JavaMainAppResource.of` and `JavaMainAppResource.create` in `SparkAppSubmissionWorker` instead of constructing `JavaMainAppResource` directly with a wrapped Scala `Option`.

```java
- MainAppResource primaryResource = new JavaMainAppResource(Option.empty());
+ MainAppResource primaryResource = JavaMainAppResource.create();
  if (StringUtils.isNotEmpty(applicationSpec.getJars())) {
-   primaryResource = new JavaMainAppResource(Option.apply(applicationSpec.getJars()));
+   primaryResource = JavaMainAppResource.of(applicationSpec.getJars());
```

### Why are the changes needed?

Apache Spark 4.2.0-preview4 provides Java-friendly factory methods on `JavaMainAppResource` (`of(String)` and `create()`). Using them removes Scala `Option` wrapping boilerplate from Java code and improves readability.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6