### PR TITLE
[SPARK-56445] Exclude unused `LoosePackageCoupling` PMD rule

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -51,6 +51,7 @@
     <exclude name="CyclomaticComplexity" />
     <exclude name="ExcessiveImports" />
     <exclude name="LawOfDemeter" />
+    <exclude name="LoosePackageCoupling" />
     <exclude name="NPathComplexity" />
     <exclude name="TooManyMethods" />
   </rule>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the unused `LoosePackageCoupling` rule from the PMD `category/java/design.xml` ruleset in `config/pmd/ruleset.xml` in order to suppress misleading warnings.

### Why are the changes needed?

The `LoosePackageCoupling` rule requires explicit `packages` properties to be configured to be meaningful, and without that configuration it does not provide value for this project. Excluding it keeps the PMD ruleset consistent with the other `design` category exclusions.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

**BEFORE**
```
$ gradle :spark-operator-api:pmdTest
...
> Task :spark-operator-api:pmdTest
Removed misconfigured rule: LoosePackageCoupling cause: No packages or classes specified

[Incubating] Problems report is available at: file:///Users/dongjoon/APACHE/spark-kubernetes-operator/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 9s
5 actionable tasks: 5 executed
Configuration cache entry stored.
```

**AFTER**
```
$ gradle :spark-operator-api:pmdTest
Starting a Gradle Daemon, 5 stopped Daemons could not be reused, use --status for details
Calculating task graph as no cached configuration is available for tasks: :spark-operator-api:pmdTest

> Configure project :build-tools-docs-utils
Doc generated at build/config_properties.md
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit
WARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release

> Task :spark-operator-api:compileTestJava
warning: unknown enum constant Type.STRING
  reason: class file for io.fabric8.crd.generator.annotation.AdditionalPrinterColumn$Type not found
warning: unknown enum constant Type.DATE
2 warnings

> Task :spark-operator-api:generateCrds
Property 'stateTransitionHistory' with '[simple type, class java.lang.Long]' key type is mapped to 'string' because of CRD schemas limitations
Property 'stateTransitionHistory' with '[simple type, class java.lang.Long]' key type is mapped to 'string' because of CRD schemas limitations
Property 'stateTransitionHistory' with '[simple type, class java.lang.Long]' key type is mapped to 'string' because of CRD schemas limitations
Property 'stateTransitionHistory' with '[simple type, class java.lang.Long]' key type is mapped to 'string' because of CRD schemas limitations
Property 'stateTransitionHistory' with '[simple type, class java.lang.Long]' key type is mapped to 'string' because of CRD schemas limitations
Property 'stateTransitionHistory' with '[simple type, class java.lang.Long]' key type is mapped to 'string' because of CRD schemas limitations
Generated CRD sparkclusters.spark.apache.org:
  v1 -> /Users/dongjoon/APACHE/spark-kubernetes-operator/.claude/worktrees/recursing-khayyam/spark-operator-api/build/resources/main/sparkclusters.spark.apache.org-v1.yml
Generated CRD sparkapplications.spark.apache.org:
  v1 -> /Users/dongjoon/APACHE/spark-kubernetes-operator/.claude/worktrees/recursing-khayyam/spark-operator-api/build/resources/main/sparkapplications.spark.apache.org-v1.yml

[Incubating] Problems report is available at: file:///Users/dongjoon/APACHE/spark-kubernetes-operator/.claude/worktrees/recursing-khayyam/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 9s
5 actionable tasks: 5 executed
Configuration cache entry stored.
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code