### PR TITLE
[SPARK-56446] Use Java `Optional` in `SparkAppDriverConf.create` method signature

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppDriverConf.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppDriverConf.java
@@ -21,7 +21,7 @@ package org.apache.spark.k8s.operator;
 
 import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_VERSION_NAME;
 
-import scala.Option;
+import java.util.Optional;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.deploy.k8s.Config;
@@ -41,8 +41,15 @@ public final class SparkAppDriverConf extends KubernetesDriverConf {
       MainAppResource mainAppResource,
       String mainClass,
       String[] appArgs,
-      Option<String> proxyUser) {
-    super(sparkConf, appId, mainAppResource, mainClass, appArgs, proxyUser, null);
+      Optional<String> proxyUser) {
+    super(
+        sparkConf,
+        appId,
+        mainAppResource,
+        mainClass,
+        appArgs,
+        scala.Option.apply(proxyUser.orElse(null)),
+        null);
     this.sparkVersion = sparkVersion;
   }
 
@@ -54,7 +61,7 @@ public final class SparkAppDriverConf extends KubernetesDriverConf {
    * @param mainAppResource The main application resource.
    * @param mainClass The main class of the application.
    * @param appArgs The application arguments.
-   * @param proxyUser The proxy user option.
+   * @param proxyUser The proxy user.
    * @return A new SparkAppDriverConf instance.
    */
   public static SparkAppDriverConf create(
@@ -64,7 +71,7 @@ public final class SparkAppDriverConf extends KubernetesDriverConf {
       MainAppResource mainAppResource,
       String mainClass,
       String[] appArgs,
-      Option<String> proxyUser) {
+      Optional<String> proxyUser) {
     // pre-create check only
     KubernetesVolumeUtils.parseVolumesWithPrefix(
         sparkConf, Config.KUBERNETES_EXECUTOR_VOLUMES_PREFIX());

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -26,8 +26,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
-
-import scala.Option;
+import java.util.Optional;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -181,7 +180,7 @@ public class SparkAppSubmissionWorker {
         primaryResource,
         applicationSpec.getMainClass(),
         applicationSpec.getDriverArgs().toArray(String[]::new),
-        Option.apply(applicationSpec.getProxyUser()));
+        Optional.ofNullable(applicationSpec.getProxyUser()));
   }
 
   /**

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppDriverConfTest.java
@@ -23,9 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import java.util.Optional;
 import java.util.UUID;
-
-import scala.Option;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +49,7 @@ class SparkAppDriverConfTest {
             mock(JavaMainAppResource.class),
             "foo",
             null,
-            Option.empty());
+            Optional.empty());
     String resourcePrefix = sparkAppDriverConf.resourceNamePrefix();
     assertEquals(
         resourcePrefix,
@@ -79,7 +78,7 @@ class SparkAppDriverConfTest {
             mock(JavaMainAppResource.class),
             "foo",
             null,
-            Option.empty());
+            Optional.empty());
     String configMapNameDriver = sparkAppDriverConf.configMapNameDriver();
     assertTrue(
         configMapNameDriver.length() <= 253,
@@ -100,7 +99,7 @@ class SparkAppDriverConfTest {
             mock(JavaMainAppResource.class),
             "foo",
             null,
-            Option.empty());
+            Optional.empty());
     assertEquals(VERSION, sparkAppDriverConf.labels().get("spark-version").get());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the `proxyUser` parameter of `SparkAppDriverConf.create` (and its private constructor) from Scala `Option<String>` to `java.util.Optional<String>`, and updates all call sites accordingly. The Scala `Option` is now used only at a single `super(...)` invocation inside the constructor via `scala.Option.apply(proxyUser.orElse(null))`.

### Why are the changes needed?

`SparkAppDriverConf` is a Java class in this repository, but its public factory previously leaked `scala.Option` into every Java caller (production code and tests), forcing them to use `Option.apply(...)` / `Option.empty()`. Using `java.util.Optional` gives Java callers a natural API and aligns with the recent direction of adopting Java-friendly Spark APIs (e.g., `JavaMainAppResource`, `KubernetesDriverSpec`).

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs with the existing `SparkAppDriverConfTest` tests, which were updated to pass `Optional.empty()`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6