### PR TITLE
[SPARK-56487] Update `spotbugs-gradle-plugin` to 6.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ mockito = "5.23.0"
 checkstyle = "13.2.0"
 pmd = "7.23.0"
 spotbugs-tool = "4.9.8"
-spotbugs-plugin = "6.4.8"
+spotbugs-plugin = "6.5.0"
 spotless-plugin = "8.4.0"
 
 # Packaging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `spotbugs-gradle-plugin` to 6.5.0.

### Why are the changes needed?

To keep the test dependency up to date.
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.6)