### PR TITLE
[SPARK-56552] Update `cyclonedx` to 3.2.4

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -61,7 +61,7 @@ subprojects {
           artifact sourceJar
           artifact javadocJar
           artifact testJar
-          artifact("$buildDir/reports/bom.xml") {
+          artifact("$buildDir/reports/cyclonedx/bom.xml") {
             classifier = 'cyclonedx'
             extension = 'xml'
             builtBy tasks.named('cyclonedxBom')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ spotbugs-plugin = "6.5.1"
 spotless-plugin = "8.4.0"
 
 # Packaging
-cyclonedx = "2.4.1"
+cyclonedx = "3.2.4"
 shadow-jar-plugin = "8.3.10"
 versions-plugin = "0.54.0"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `org.cyclonedx.bom.gradle.plugin` from `2.4.1` to `3.2.4`.

In `3.x`, the BOM output path was changed from `build/reports/bom.xml` to `build/reports/cyclonedx/bom.xml`, so `deploy.gradle` is updated accordingly to keep the `cyclonedx` classifier artifact published correctly.

### Why are the changes needed?

To bring in the latest stable `cyclonedx-gradle-plugin` improvements and bug fixes.
- https://github.com/CycloneDX/cyclonedx-gradle-plugin/releases/tag/cyclonedx-gradle-plugin-3.2.4 (2026-04-06)
- https://github.com/CycloneDX/cyclonedx-gradle-plugin/releases/tag/cyclonedx-gradle-plugin-3.2.0 (2026-02-13)
- https://github.com/CycloneDX/cyclonedx-gradle-plugin/releases/tag/cyclonedx-gradle-plugin-3.1.0 (2025-11-26)
- https://github.com/CycloneDX/cyclonedx-gradle-plugin/releases/tag/cyclonedx-gradle-plugin-3.0.0 (2025-10-03)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7