### PR TITLE
[SPARK-56571] Upgrade `Apache DataFusion Comet` to 0.15.0

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -46,7 +46,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.14.0/comet-spark-spark3.5_2.12-0.14.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.15.0/comet-spark-spark3.5_2.12-0.15.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -68,7 +68,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.14.0/comet-spark-spark3.5_2.12-0.14.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.15.0/comet-spark-spark3.5_2.12-0.15.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache DataFusion Comet to 0.15.0 in `examples/pi-with-comet.yaml`.

### Why are the changes needed?

To use the latest version of Apache DataFusion Comet 0.15.0.
- https://datafusion.apache.org/comet/user-guide/0.15/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

```
$ kubectl apply -f examples/pi-with-comet.yaml 
sparkapplication.spark.apache.org/pi-with-comet created

$ kubectl get sparkapp          
NAME            AGE   CURRENT STATE
pi-with-comet   45s   RunningHealthy

$ kubectl get sparkapp
NAME            AGE   CURRENT STATE
pi-with-comet   60s   ResourceReleased
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)