### PR TITLE
[SPARK-56115] Support `crds.install` in Helm Chart

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkapplications.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkapplications.spark.apache.org-v1.yaml
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -26511,3 +26512,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkapplications.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkapplications.spark.apache.org-v1.yaml
@@ -18,6 +18,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sparkapplications.spark.apache.org
+  {{- with .Values.crds.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   group: spark.apache.org
   names:

--- a/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkclusters.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkclusters.spark.apache.org-v1.yaml
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -22119,3 +22120,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkclusters.spark.apache.org-v1.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/crds/sparkclusters.spark.apache.org-v1.yaml
@@ -18,6 +18,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sparkclusters.spark.apache.org
+  {{- with .Values.crds.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   group: spark.apache.org
   names:

--- a/build-tools/helm/spark-kubernetes-operator/values.schema.json
+++ b/build-tools/helm/spark-kubernetes-operator/values.schema.json
@@ -11,6 +11,17 @@
       "type": "string",
       "description": "Override fully qualified app name"
     },
+    "crds": {
+      "type": "object",
+      "description": "CRD installation configuration",
+      "required": ["install"],
+      "properties": {
+        "install": {
+          "type": "boolean",
+          "description": "Install CRDs with the chart. Set to false if CRDs are managed separately."
+        }
+      }
+    },
     "image": {
       "type": "object",
       "description": "Operator image configuration",

--- a/build-tools/helm/spark-kubernetes-operator/values.schema.json
+++ b/build-tools/helm/spark-kubernetes-operator/values.schema.json
@@ -19,6 +19,13 @@
         "install": {
           "type": "boolean",
           "description": "Install CRDs with the chart. Set to false if CRDs are managed separately."
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to CRD resources. Default includes helm.sh/resource-policy: keep to prevent CRD deletion on helm uninstall.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     },

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -24,6 +24,8 @@ imagePullSecrets: [ ]
 
 crds:
   install: true
+  annotations:
+    "helm.sh/resource-policy": keep
 
 operatorDeployment:
   # Replicas must be 1 unless leader election is enabled

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -22,6 +22,9 @@ image:
 
 imagePullSecrets: [ ]
 
+crds:
+  install: true
+
 operatorDeployment:
   # Replicas must be 1 unless leader election is enabled
   replicas: 1

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -165,7 +165,7 @@ helm install us-west-1 spark/spark-kubernetes-operator --create-namespace --name
 ```
 
 ```bash
-helm install us-west-2 spark/spark-kubernetes-operator --create-namespace --namespace us-west-2 --set operatorRbac.clusterRole.name=spark-operator-clusterrole-us-west-2 --set operatorRbac.clusterRoleBinding.name=spark-operator-clusterrolebinding-us-west-2 --set workloadResources.clusterRole.name=spark-workload-clusterrole-us-west-2
+helm install us-west-2 spark/spark-kubernetes-operator --create-namespace --namespace us-west-2 --set crds.install=false --set operatorRbac.clusterRole.name=spark-operator-clusterrole-us-west-2 --set operatorRbac.clusterRoleBinding.name=spark-operator-clusterrolebinding-us-west-2 --set workloadResources.clusterRole.name=spark-workload-clusterrole-us-west-2
 ```
 
 Check installation.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -61,6 +61,8 @@ following table:
 
 | Parameters                                                       | Description                                                                                                                                                                    | Default value                                                                                           |
 |------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| crds.install                                                     | Whether to install CRDs with the chart. Set to `false` when CRDs are managed externally or when deploying additional operator instances.                                       | true                                                                                                    |
+| crds.annotations                                                 | Annotations to add to CRD resources. The default prevents CRDs from being deleted on `helm uninstall`.                                                                         | `"helm.sh/resource-policy": keep`                                                                       |
 | image.repository                                                 | The image repository of spark-kubernetes-operator.                                                                                                                             | apache/spark-kubernetes-operator                                                                        |
 | image.pullPolicy                                                 | The image pull policy of spark-kubernetes-operator.                                                                                                                            | IfNotPresent                                                                                            |
 | image.tag                                                        | The image tag of spark-kubernetes-operator.                                                                                                                                    | 0.9.0-SNAPSHOT                                                                                          |
@@ -154,6 +156,21 @@ metadata:
   name: spark-sentinel-resources
   labels:
     "spark.operator/sentinel": "true"
+```
+
+## Upgrading from chart versions that used the `crds/` directory
+
+Older chart versions installed CRDs via Helm's special `crds/` directory, which does not
+track ownership metadata. The current chart manages CRDs as regular templates. Before
+running `helm upgrade`, you must label and annotate the existing CRDs so Helm can adopt
+them. Replace `<release-name>` and `<release-namespace>` with your Helm release values:
+
+```bash
+kubectl label crd sparkapplications.spark.apache.org app.kubernetes.io/managed-by=Helm
+kubectl annotate crd sparkapplications.spark.apache.org meta.helm.sh/release-name=<release-name> meta.helm.sh/release-namespace=<release-namespace>
+
+kubectl label crd sparkclusters.spark.apache.org app.kubernetes.io/managed-by=Helm
+kubectl annotate crd sparkclusters.spark.apache.org meta.helm.sh/release-name=<release-name> meta.helm.sh/release-namespace=<release-namespace>
 ```
 
 ## Example

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -68,7 +68,7 @@ tasks.register("assertGeneratedCRDMatchesHelmChart") {
   def currentPath = projectDir.absolutePath
   doLast {
     def generatedCRDFileBase = "$currentPath/build/resources/main/"
-    def stagedCRDFileBase = "$currentPath/../build-tools/helm/spark-kubernetes-operator/crds/"
+    def stagedCRDFileBase = "$currentPath/../build-tools/helm/spark-kubernetes-operator/templates/crds/"
     def generatedAppCRD = [
         "yq",
         "e",
@@ -82,16 +82,12 @@ tasks.register("assertGeneratedCRDMatchesHelmChart") {
         "${generatedCRDFileBase}sparkclusters.spark.apache.org-v1.yml"
     ].execute().text.trim()
     def stagedAppCRD = [
-        "yq",
-        "e",
-        ".spec.versions[-1]",
-        "${stagedCRDFileBase}sparkapplications.spark.apache.org-v1.yaml"
+        "bash", "-c",
+        "sed '/^{{/d' ${stagedCRDFileBase}sparkapplications.spark.apache.org-v1.yaml | yq e '.spec.versions[-1]' -"
     ].execute().text.trim()
     def stagedClusterCRD = [
-        "yq",
-        "e",
-        ".spec.versions[-1]",
-        "${stagedCRDFileBase}sparkclusters.spark.apache.org-v1.yaml"
+        "bash", "-c",
+        "sed '/^{{/d' ${stagedCRDFileBase}sparkclusters.spark.apache.org-v1.yaml | yq e '.spec.versions[-1]' -"
     ].execute().text.trim()
     if (generatedAppCRD != stagedAppCRD || generatedClusterCRD != stagedClusterCRD) {
       def errorMessage = new StringBuilder("Generated CRD yaml does not match the staged " +

--- a/spark-operator-api/build.gradle
+++ b/spark-operator-api/build.gradle
@@ -83,11 +83,11 @@ tasks.register("assertGeneratedCRDMatchesHelmChart") {
     ].execute().text.trim()
     def stagedAppCRD = [
         "bash", "-c",
-        "sed '/^{{/d' ${stagedCRDFileBase}sparkapplications.spark.apache.org-v1.yaml | yq e '.spec.versions[-1]' -"
+        "sed '/{{/d' ${stagedCRDFileBase}sparkapplications.spark.apache.org-v1.yaml | yq e '.spec.versions[-1]' -"
     ].execute().text.trim()
     def stagedClusterCRD = [
         "bash", "-c",
-        "sed '/^{{/d' ${stagedCRDFileBase}sparkclusters.spark.apache.org-v1.yaml | yq e '.spec.versions[-1]' -"
+        "sed '/{{/d' ${stagedCRDFileBase}sparkclusters.spark.apache.org-v1.yaml | yq e '.spec.versions[-1]' -"
     ].execute().text.trim()
     if (generatedAppCRD != stagedAppCRD || generatedClusterCRD != stagedClusterCRD) {
       def errorMessage = new StringBuilder("Generated CRD yaml does not match the staged " +

--- a/tests/e2e/helm/dynamic-config-values-2.yaml
+++ b/tests/e2e/helm/dynamic-config-values-2.yaml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+crds:
+  install: false
+
 workloadResources:
   namespaces:
     overrideWatchedNamespaces: false


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, use `Draft` feature of GitHub Action.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR introduces a crds.install configuration option to the Helm chart. CRD files are moved from the crds/ directory
(unconditionally installed by Helm) to templates/crds/ with a {{- if .Values.crds.install }} guard, allowing users to
disable CRD installation by setting crds.install: false. Similar to:
https://github.com/argoproj/argo-helm/blob/f7aee451eb788abd682d187fb055668bbfe28091/charts/argo-cd/values.yaml#L31-L40


### Why are the changes needed?
In environments where CRDs are managed separately, users need the ability to skip CRD installation at the chart level. Previously the only option was the helm install --skip-crds flag, which is not declarative and cannot be expressed in a values file.


### Does this PR introduce _any_ user-facing change?
Yes. 

* crds.install (default: true) — Controls whether CRDs are installed with the chart. Set to false when CRDs are managed  externally or when deploying a second operator instance.
* crds.annotations (default: {"helm.sh/resource-policy": "keep"}) — Annotations applied to CRD resources. The default prevents CRDs from being deleted on helm uninstall.                                                                       
* Migration note: Users running multiple operator releases in different namespaces must set crds.install: false on 
releases.

### How was this patch tested?
```
helm template --set crds.install=true renders both CRDs
helm template --set crds.install=false renders no CRDs                                                                    
```
### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7
