### PR TITLE
[SPARK-56621] Update CI to test K8s 1.36

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         kubernetes-version:
           - "1.34.0"
-          - "1.35.0"
+          - "1.36.0"
         mode:
           - dynamic
           - static
@@ -209,7 +209,7 @@ jobs:
       max-parallel: 20
       matrix:
         kubernetes-version:
-          - "1.35.0"
+          - "1.36.0"
         test-group:
           - configmap-metadata
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update CI to test K8s 1.36.

### Why are the changes needed?

To ensure Apache Spark K8s Operator works with the latest Kubernetes 1.36 release.
- https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the installed version manually in the log.

```
System Info:
  ...
  Kubelet Version:            v1.36.0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7