### PR TITLE
[SPARK-56665] Use `gradle:9.4.1-jdk26-noble` Docker image for builder stage

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM gradle:9.4.1-jdk25-noble AS builder
+FROM gradle:9.4.1-jdk26-noble AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the builder stage base image of `build-tools/docker/Dockerfile` to `gradle:9.4.1-jdk26-noble`.

```diff
-FROM gradle:9.4.1-jdk25-noble AS builder
+FROM gradle:9.4.1-jdk26-noble AS builder
```

### Why are the changes needed?

Since SPARK-56088, the project's Gradle Java toolchain is set to `JavaLanguageVersion.of(26)` (`build.gradle`), and all build jobs in `.github/workflows/build_and_test.yml` already run on JDK 26.

- https://github.com/apache/spark-kubernetes-operator/pull/555

However, the Docker builder stage still ran Gradle on JDK 25 due to the missing Gradle Docker image so far, which forced Gradle to auto-provision JDK 26 inside the container during every image build.

Now, Gradle community provides Java 26-based image like the following.

https://hub.docker.com/layers/library/gradle/9.4.1-jdk26-noble/images/sha256-09d8e59d1bd43f3f06b41fb6aae38cd4ff62637a16ec68096cd842cc4b15cdc4

<img width="829" height="338" alt="Screenshot 2026-04-29 at 10 21 36" src="https://github.com/user-attachments/assets/a2241882-c965-484b-a472-bcdb031429fe" />

Aligning the builder image with JDK 26:
- Removes the in-container JDK 26 auto-provisioning step.
  - This will improve the stability of `ubuntu-slim` CI pipeline whose running time limit is short.
- Matches the CI build environment for consistent and reproducible image builds.
- Reduces external network dependency at build time.

The runtime stages (`azul/zulu-openjdk-alpine:26` for `jlink` and `alpine:3.23` for the final image) and the Java 21 bytecode target (`options.release = 21`, `jdeps --multi-release 21`) are unchanged.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7