### PR TITLE
[SPARK-56679] Fix Helm chart to render valid YAML for operator ConfigMap

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
@@ -191,25 +191,19 @@ metadata:
   {{- end }}
   {{- end }}
 data:
-  log4j2.properties: |+
+  log4j2.properties: |
 {{- if .Values.operatorConfiguration.append }}
-  {{- $.Files.Get "conf/log4j2.properties"  | nindent 4 -}}
+{{-   with $.Files.Get "conf/log4j2.properties" }}{{ . | nindent 4 }}{{ end }}
 {{- end }}
-{{- if index (.Values.operatorConfiguration) "log4j2.properties" }}
-  {{- index (.Values.operatorConfiguration) "log4j2.properties" | nindent 4 -}}
-{{- end }}
-  spark-operator.properties: |+
-  {{- include "spark-operator.defaultPropertyOverrides" . | nindent 4 }}
+{{- with index .Values.operatorConfiguration "log4j2.properties" }}{{ . | nindent 4 }}{{ end }}
+  spark-operator.properties: |
+{{- include "spark-operator.defaultPropertyOverrides" . | nindent 4 }}
 {{- if .Values.operatorConfiguration.append }}
-  {{- $.Files.Get "conf/spark-operator.properties"  | nindent 4 -}}
+{{-   with $.Files.Get "conf/spark-operator.properties" }}{{ . | nindent 4 }}{{ end }}
 {{- end }}
-{{- if index (.Values.operatorConfiguration) "spark-operator.properties" }}
-  {{- index (.Values.operatorConfiguration) "spark-operator.properties" | nindent 4 -}}
-{{- end }}
-  metrics.properties: |+
-{{- if index (.Values.operatorConfiguration) "metrics.properties" }}
-  {{- index (.Values.operatorConfiguration) "metrics.properties" | nindent 4 -}}
-{{- end }}
+{{- with index .Values.operatorConfiguration "spark-operator.properties" }}{{ . | nindent 4 }}{{ end }}
+  metrics.properties: |
+{{- with index .Values.operatorConfiguration "metrics.properties" }}{{ . | nindent 4 }}{{ end }}
 ---
 {{- if .Values.operatorConfiguration.dynamicConfig.create }}
 apiVersion: v1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the Helm chart so that `spark-kubernetes-operator-configuration` ConfigMap renders valid YAML under the default `values.yaml`.

In `templates/spark-operator.yaml`, the three data keys (`log4j2.properties`, `spark-operator.properties`, `metrics.properties`) used the `|+` block scalar header followed by `{{- ... | nindent 4 -}}` for each content source. Because `nindent` always emits a leading newline plus indent (even for an empty input), an empty source — for example `$.Files.Get "conf/log4j2.properties"` which currently always returns an empty string since the chart contains no `conf/` directory — produced a leading line containing only 4 trailing spaces.

The fix:

- Replace `|+` with `|` (clip chomping is sufficient for these properties files).
- Replace `{{- if <source-non-empty-check>... | nindent 4 -}}` with `{{- with <source> }}{{ . | nindent 4 }}{{ end }}`. `with` skips the block when the source is an empty string, so no phantom indent line is emitted.
- The user-facing `append` toggle is still expressed with `if`; the `with` guards only the content insertion underneath it.

### Why are the changes needed?

The previously rendered output looked like the following:

```yaml
data:
  log4j2.properties: |+

    # Logging Overrides
    rootLogger.level=INFO
```

The first line of the literal block contains only 4 spaces. Strict YAML parsers (e.g., YamlDotNet used by Octopus Deploy) reject this with:

```
YAML syntax error: While scanning a literal block scalar, found extra spaces in first line.
```

This made the chart unusable for users on those platforms even though `helm install` itself accepted it.

### Does this PR introduce _any_ user-facing change?

Yes. The rendered ConfigMap no longer contains the leading blank line with stray spaces inside each block scalar. Functionally the ConfigMap content is equivalent for non-empty values, and it now parses under strict YAML parsers.

**BEFORE**
```
$ kubectl describe cm spark-kubernetes-operator-configuration
Name:         spark-kubernetes-operator-configuration
Namespace:    default
Labels:       app.kubernetes.io/component=operator-config
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=spark-kubernetes-operator
              app.kubernetes.io/version=0.8.0
              helm.sh/chart=spark-kubernetes-operator-1.6.0
              spark-role=operator
Annotations:  meta.helm.sh/release-name: spark
              meta.helm.sh/release-namespace: default

Data
====
log4j2.properties:
----

# Logging Overrides
rootLogger.level=INFO
rootLogger.appenderRef.stdout.ref = console
appender.console.type = Console
appender.console.name = console
appender.console.target = SYSTEM_ERR
appender.console.layout.type = PatternLayout
appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X{resource.name} %X{resource.namespace} %C{1.} %m%n%ex
...
```

**AFTER**
```
$ kubectl describe cm spark-kubernetes-operator-configuration
Name:         spark-kubernetes-operator-configuration
Namespace:    default
Labels:       app.kubernetes.io/component=operator-config
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=spark-kubernetes-operator
              app.kubernetes.io/version=0.9.0-SNAPSHOT
              helm.sh/chart=spark-kubernetes-operator-1.7.0-dev
              spark-role=operator
Annotations:  meta.helm.sh/release-name: spark
              meta.helm.sh/release-namespace: default

Data
====
log4j2.properties:
----
# Logging Overrides
rootLogger.level=INFO
rootLogger.appenderRef.stdout.ref = console
appender.console.type = Console
appender.console.name = console
appender.console.target = SYSTEM_ERR
appender.console.layout.type = PatternLayout
appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %X{resource.name} %X{resource.namespace} %C{1.} %m%n%ex
...
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)

Closes #647 