### PR TITLE
[SPARK-56701] Use Apache Spark 4.0.2 in `pi-with-comet` example

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -30,7 +30,7 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.executor.extraClassPath: "local:///comet/comet.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:3.5.8-java17"
+    spark.kubernetes.container.image: "apache/spark:4.0.2-scala"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
     spark.plugins: "org.apache.spark.CometPlugin"
@@ -46,7 +46,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.15.0/comet-spark-spark3.5_2.12-0.15.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/0.15.0/comet-spark-spark4.0_2.13-0.15.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -68,7 +68,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark3.5_2.12/0.15.0/comet-spark-spark3.5_2.12-0.15.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/0.15.0/comet-spark-spark4.0_2.13-0.15.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -82,4 +82,4 @@ spec:
           emptyDir:
             sizeLimit: 200Mi
   runtimeVersions:
-    sparkVersion: "3.5.8"
+    sparkVersion: "4.0.2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades the `pi-with-comet` example to Apache Spark 4.0.2.

### Why are the changes needed?

**GOAL**
- To align with the other examples which already use Apache Spark 4.0.2.
- To support and help the adoption of `Apache DataFusion Comet` with Spark 4.x more easily.

Note that `Apache DataFusion Comet` v0.15 has an experimental Spark 4.0 support. The upcoming `v0.16` will support `Apache Spark 4.0.2` officially.
- https://datafusion.apache.org/comet/user-guide/0.15/installation.html
- https://datafusion.apache.org/comet/user-guide/latest/compatibility/spark-versions.html

<img width="938" height="335" alt="Screenshot 2026-05-01 at 13 12 21" src="https://github.com/user-attachments/assets/5990d7dc-0ad2-4843-b732-b4b8cadaf1b8" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)