### PR TITLE
[SPARK-56723] Use the latest `docker/*` GitHub Actions

### DIFF
--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -24,11 +24,11 @@ jobs:
         branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
     - name: Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
     - name: Build and push
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
       with:
         # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
         cache-from: type=gha


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the `docker/*` GitHub Actions in `.github/workflows/publish_snapshot_dockerhub.yml` to the latest versions approved by [Apache infrastructure-actions](https://github.com/apache/infrastructure-actions/blob/main/actions.yml).

| Action | Before | After |
| --- | --- | --- |
| `docker/setup-qemu-action` | `29109295f81e9208d7d86ff1c6c12d2833863392` (v3.6.0) | `ce360397dd3f832beb865e1373c09c0e9f86d70a` (v4.0.0) |
| `docker/setup-buildx-action` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` (v3.12.0) | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` (v4.0.0) |
| `docker/login-action` | `c94ce9fb468520275223c153574b00df6fe4bcc9` (v3.7.0) | `4907a6ddec9925e35a0a9e82d7399ccc52663121` (v4.1.0) |
| `docker/build-push-action` | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` (v6.19.2) | `bcafcacb16a39f128d818304e6c9c0c18556b85f` (v7.1.0) |

### Why are the changes needed?

To pick up upstream improvements and bug fixes, and to stay aligned with Apache's approved action SHAs. The previously pinned SHAs are scheduled to be removed from the Apache approved list on `2026-06-14`, after which the snapshot Docker publish workflow could be rejected.

### Does this PR introduce _any_ user-facing change?

No. CI-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)