### PR TITLE
[SPARK-56727] Add `Apache DataFusion Comet` K8s integration test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
   k8s-integration-tests:
     name: "K8s Integration Tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       max-parallel: 20
@@ -131,6 +131,10 @@ jobs:
             test-group: watched-namespaces
           - mode: selector
             test-group: driver-start-timeout
+        include:
+          - kubernetes-version: "1.36.0"
+            mode: static
+            test-group: pi-with-comet
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -34,7 +34,7 @@ spec:
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
     spark.plugins: "org.apache.spark.CometPlugin"
-    spark.shuffle.manager": "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
+    spark.shuffle.manager: "org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   driverSpec:

--- a/tests/e2e/pi-with-comet/chainsaw-test.yaml
+++ b/tests/e2e/pi-with-comet/chainsaw-test.yaml
@@ -22,8 +22,8 @@ metadata:
 spec:
   steps:
   - try:
-    - script:
-        content: kubectl apply -f ./examples/pi-with-comet.yaml
+    - apply:
+        file: ../../../examples/pi-with-comet.yaml
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE

--- a/tests/e2e/pi-with-comet/chainsaw-test.yaml
+++ b/tests/e2e/pi-with-comet/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
   steps:
   - try:
     - script:
-        content: kubectl apply -f ../../examples/pi-with-comet.yaml
+        content: kubectl apply -f ./examples/pi-with-comet.yaml
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE

--- a/tests/e2e/pi-with-comet/chainsaw-test.yaml
+++ b/tests/e2e/pi-with-comet/chainsaw-test.yaml
@@ -20,6 +20,7 @@ kind: Test
 metadata:
   name: spark-operator-pi-with-comet-validation
 spec:
+  namespace: default
   steps:
   - try:
     - apply:

--- a/tests/e2e/pi-with-comet/chainsaw-test.yaml
+++ b/tests/e2e/pi-with-comet/chainsaw-test.yaml
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: spark-operator-pi-with-comet-validation
+spec:
+  steps:
+  - try:
+    - script:
+        content: kubectl apply -f ../../examples/pi-with-comet.yaml
+    - assert:
+        bindings:
+          - name: SPARK_APP_NAMESPACE
+            value: default
+        timeout: 10m
+        file: spark-state-transition.yaml
+    catch:
+    - describe:
+        apiVersion: spark.apache.org/v1
+        kind: SparkApplication
+        namespace: default
+    - podLogs:
+        selector: spark-app-name=pi-with-comet
+        namespace: default
+    - podLogs:
+        selector: app.kubernetes.io/name=spark-kubernetes-operator
+        namespace: default
+    finally:
+    - script:
+        timeout: 120s
+        content: |
+          kubectl delete sparkapplication pi-with-comet --ignore-not-found=true

--- a/tests/e2e/pi-with-comet/spark-state-transition.yaml
+++ b/tests/e2e/pi-with-comet/spark-state-transition.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-with-comet
+  namespace: ($SPARK_APP_NAMESPACE)
+status:
+  stateTransitionHistory:
+    (*.currentStateSummary):
+      - "Submitted"
+      - "DriverRequested"
+      - "DriverStarted"
+      - "DriverReady"
+      - "RunningHealthy"
+      - "Succeeded"
+      - "ResourceReleased"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Apache DataFusion Comet` K8s integration test coverage.

### Why are the changes needed?

To provide a test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7