### PR TITLE
[SPARK-56728] Simplify `chainsaw` test manifests via `apply` syntax

### DIFF
--- a/tests/e2e/driver-start-timeout/chainsaw-test.yaml
+++ b/tests/e2e/driver-start-timeout/chainsaw-test.yaml
@@ -30,11 +30,8 @@ spec:
         value: spark-example-driver-start-timeout
   steps:
   - try:
-    - script:
-        env:
-          - name: FILE_NAME
-            value: ($APPLICATION_FILE_NAME)
-        content: kubectl apply -f $FILE_NAME
+    - apply:
+        file: ($APPLICATION_FILE_NAME)
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE

--- a/tests/e2e/resource-retain-duration/chainsaw-test.yaml
+++ b/tests/e2e/resource-retain-duration/chainsaw-test.yaml
@@ -30,11 +30,8 @@ spec:
         value: spark-example-retain-duration
   steps:
   - try:
-    - script:
-        env:
-          - name: FILE_NAME
-            value: ($APPLICATION_FILE_NAME)
-        content: kubectl apply -f $FILE_NAME
+    - apply:
+        file: ($APPLICATION_FILE_NAME)
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE

--- a/tests/e2e/resource-retain-on-failure/chainsaw-test.yaml
+++ b/tests/e2e/resource-retain-on-failure/chainsaw-test.yaml
@@ -30,11 +30,8 @@ spec:
         value: spark-example-retain-on-failure
   steps:
   - try:
-    - script:
-        env:
-          - name: FILE_NAME
-            value: ($APPLICATION_FILE_NAME)
-        content: kubectl apply -f $FILE_NAME
+    - apply:
+        file: ($APPLICATION_FILE_NAME)
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE

--- a/tests/e2e/state-transition/chainsaw-test.yaml
+++ b/tests/e2e/state-transition/chainsaw-test.yaml
@@ -34,11 +34,8 @@ spec:
         value: spark-cluster-succeeded-test
   steps:
   - try:
-    - script:
-        env:
-          - name: FILE_NAME
-            value: ($APPLICATION_FILE_NAME)
-        content: kubectl apply -f $FILE_NAME
+    - apply:
+        file: ($APPLICATION_FILE_NAME)
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE
@@ -59,11 +56,8 @@ spec:
         content: |
           kubectl delete sparkapplication $SPARK_APPLICATION_NAME
   - try:
-    - script:
-        env:
-          - name: FILE_NAME
-            value: ($CLUSTER_FILE_NAME)
-        content: kubectl apply -f $FILE_NAME
+    - apply:
+        file: ($CLUSTER_FILE_NAME)
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the `script: kubectl apply -f $FILE_NAME` pattern with the native chainsaw `apply` operation in four e2e chainsaw tests:

- `tests/e2e/driver-start-timeout/chainsaw-test.yaml`
- `tests/e2e/resource-retain-on-failure/chainsaw-test.yaml`
- `tests/e2e/resource-retain-duration/chainsaw-test.yaml`
- `tests/e2e/state-transition/chainsaw-test.yaml` (two occurrences)

Before:
```yaml
- script:
    env:
      - name: FILE_NAME
        value: ($APPLICATION_FILE_NAME)
    content: kubectl apply -f $FILE_NAME
```

After:
```yaml
- apply:
    file: ($APPLICATION_FILE_NAME)
```

### Why are the changes needed?

Other e2e tests in the same directory (`python`, `spark-versions`, `resource-selector`, `watched-namespaces`) already use the native chainsaw `apply` operator. Aligning the remaining tests with this pattern restores consistency, removes the `script.env` indirection, and lets chainsaw track applied resources for better lifecycle handling and diagnostics.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)