### PR TITLE
[SPARK-55554] Add `Apache Gluten` example

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -135,6 +135,9 @@ jobs:
           - kubernetes-version: "1.36.0"
             mode: static
             test-group: pi-with-comet
+          - kubernetes-version: "1.36.0"
+            mode: static
+            test-group: pi-with-gluten
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/examples/pi-with-gluten.yaml
+++ b/examples/pi-with-gluten.yaml
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-with-gluten
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.driver.extraClassPath: "local:///gluten/gluten.jar"
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.executor.extraClassPath: "local:///gluten/gluten.jar"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.0.2-scala"
+    spark.kubernetes.node.selector.kubernetes.io/arch: "amd64"
+    spark.memory.offHeap.enabled: "true"
+    spark.memory.offHeap.size: "1g"
+    spark.plugins: "org.apache.gluten.GlutenPlugin"
+    spark.shuffle.manager: "org.apache.spark.shuffle.sort.ColumnarShuffleManager"
+    spark.sql.ansi.enabled: "false"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  driverSpec:
+    podTemplateSpec:
+      spec:
+        initContainers:
+        - name: download-gluten
+          image: busybox
+          command: ["sh", "-c"]
+          args:
+          - |
+            wget -O /tmp/gluten.tar.gz "https://www.apache.org/dyn/closer.lua/gluten/1.6.0/apache-gluten-1.6.0-bin-spark-4.0.tar.gz?action=download" && \
+            tar -xzf /tmp/gluten.tar.gz -C /tmp && \
+            cp /tmp/gluten-velox-bundle-spark4.0_2.13-linux_amd64-1.6.0.jar /gluten/gluten.jar
+          volumeMounts:
+          - name: gluten
+            mountPath: /gluten
+        containers:
+        - name: spark-kubernetes-driver
+          volumeMounts:
+          - name: gluten
+            mountPath: /gluten
+        volumes:
+        - name: gluten
+          emptyDir:
+            sizeLimit: 500Mi
+  executorSpec:
+    podTemplateSpec:
+      spec:
+        initContainers:
+        - name: download-gluten
+          image: busybox
+          command: ["sh", "-c"]
+          args:
+          - |
+            wget -O /tmp/gluten.tar.gz "https://www.apache.org/dyn/closer.lua/gluten/1.6.0/apache-gluten-1.6.0-bin-spark-4.0.tar.gz?action=download" && \
+            tar -xzf /tmp/gluten.tar.gz -C /tmp && \
+            cp /tmp/gluten-velox-bundle-spark4.0_2.13-linux_amd64-1.6.0.jar /gluten/gluten.jar
+          volumeMounts:
+          - name: gluten
+            mountPath: /gluten
+        containers:
+        - name: spark-kubernetes-executor
+          volumeMounts:
+          - name: gluten
+            mountPath: /gluten
+        volumes:
+        - name: gluten
+          emptyDir:
+            sizeLimit: 500Mi
+  runtimeVersions:
+    sparkVersion: "4.0.2"

--- a/tests/e2e/pi-with-gluten/chainsaw-test.yaml
+++ b/tests/e2e/pi-with-gluten/chainsaw-test.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: spark-operator-pi-with-gluten-validation
+spec:
+  namespace: default
+  steps:
+  - try:
+    - apply:
+        file: ../../../examples/pi-with-gluten.yaml
+    - assert:
+        bindings:
+          - name: SPARK_APP_NAMESPACE
+            value: default
+        timeout: 10m
+        file: spark-state-transition.yaml
+    catch:
+    - describe:
+        apiVersion: spark.apache.org/v1
+        kind: SparkApplication
+        namespace: default
+    - podLogs:
+        selector: spark-app-name=pi-with-gluten
+        namespace: default
+    - podLogs:
+        selector: app.kubernetes.io/name=spark-kubernetes-operator
+        namespace: default
+    finally:
+    - script:
+        timeout: 120s
+        content: |
+          kubectl delete sparkapplication pi-with-gluten --ignore-not-found=true

--- a/tests/e2e/pi-with-gluten/spark-state-transition.yaml
+++ b/tests/e2e/pi-with-gluten/spark-state-transition.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-with-gluten
+  namespace: ($SPARK_APP_NAMESPACE)
+status:
+  stateTransitionHistory:
+    (*.currentStateSummary):
+      - "Submitted"
+      - "DriverRequested"
+      - "DriverStarted"
+      - "DriverReady"
+      - "RunningHealthy"
+      - "Succeeded"
+      - "ResourceReleased"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add an `Apache Gluten` example with K8s integration test coverage.

- New example: `examples/pi-with-gluten.yaml` (SparkPi with Gluten Velox backend on Spark 4.0.2)
- New chainsaw test: `tests/e2e/pi-with-gluten/`
- New CI matrix entry: `pi-with-gluten` test-group

### Why are the changes needed?

Apache Gluten became the Top-level project with Spark 4 and Java 21 support.
- https://github.com/apache/gluten/releases/tag/v1.6.0

To provide an example and test coverage for `Apache Gluten`, mirroring the existing `Apache DataFusion Comet` example added in SPARK-56727.

The example uses the official Apache Gluten 1.6.0 binary distribution from the Apache mirror via `closer.lua`, which provides the `linux_amd64` Velox bundle JAR. An `initContainer` extracts the JAR from the tarball and shares it with the driver/executor via an `emptyDir` volume.

Notable differences vs. `pi-with-comet`:
- Tarball extraction (Gluten is not published to Maven Central as a single JAR)
- `spark.plugins=org.apache.gluten.GlutenPlugin`
- `spark.shuffle.manager=org.apache.spark.shuffle.sort.ColumnarShuffleManager`
- `spark.sql.ansi.enabled=false` (required by Gluten 1.6.0 on Spark 4.0)
- `spark.kubernetes.node.selector.kubernetes.io/arch=amd64` (Gluten 1.6.0 ships `linux_amd64` binaries only)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7