### PR TITLE
[SPARK-56733] Improve `SparkAppResourceSpec` to use Java-friendly `KubernetesDriverSpec` APIs

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
@@ -19,8 +19,6 @@
 
 package org.apache.spark.k8s.operator;
 
-import static scala.jdk.javaapi.CollectionConverters.asJava;
-
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -80,7 +78,7 @@ public class SparkAppResourceSpec {
         KubernetesClientUtils.buildSparkConfDirFilesMapJava(
                 kubernetesDriverConf.configMapNameDriver(),
                 kubernetesDriverConf.sparkConf(),
-                asJava(kubernetesDriverSpec.systemProperties()));
+                kubernetesDriverSpec.getSystemPropertiesAsJavaMap());
     Map<String, String> confFilesMap = new HashMap<>(originalConfFilesMap);
     confFilesMap.put(Config.KUBERNETES_NAMESPACE().key(), namespace);
     SparkPod sparkPod = addConfigMap(kubernetesDriverSpec.pod(), confFilesMap);
@@ -91,9 +89,9 @@ public class SparkAppResourceSpec {
             .endSpec()
             .build();
     this.driverPreResources =
-        new ArrayList<>(asJava(kubernetesDriverSpec.driverPreKubernetesResources()));
+        new ArrayList<>(kubernetesDriverSpec.getDriverPreKubernetesResourcesAsJavaList());
     this.driverResources =
-        new ArrayList<>(asJava(kubernetesDriverSpec.driverKubernetesResources()));
+        new ArrayList<>(kubernetesDriverSpec.getDriverKubernetesResourcesAsJavaList());
     this.driverResources.add(
         KubernetesClientUtils.buildConfigMapJava(
             kubernetesDriverConf.configMapNameDriver(), confFilesMap, Map.of()));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses Java-friendly accessors on `KubernetesDriverSpec` in `SparkAppResourceSpec`, removing the `asJava` import statement.

- `systemProperties()` → `getSystemPropertiesAsJavaMap()`
- `driverPreKubernetesResources()` → `getDriverPreKubernetesResourcesAsJavaList()`
- `driverKubernetesResources()` → `getDriverKubernetesResourcesAsJavaList()`

### Why are the changes needed?

To align with the existing `KubernetesClientUtils.*Java` calls in the same file and drop the Scala converter dependency.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7