### PR TITLE
[SPARK-56735] Improve `SparkClusterResourceSpec` to use Java-friendly `SparkConf` API

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -24,8 +24,6 @@ import static org.apache.spark.k8s.operator.Constants.*;
 import java.util.Map;
 import java.util.Optional;
 
-import scala.Tuple2;
-
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
@@ -75,8 +73,8 @@ public class SparkClusterResourceSpec {
     ClusterSpec spec = cluster.getSpec();
     String version = spec.getRuntimeVersions().getSparkVersion();
     StringBuilder options = new StringBuilder();
-    for (Tuple2<String, String> t : conf.getAll()) {
-      options.append(String.format("-D%s=\"%s\" ", t._1, t._2));
+    for (Map.Entry<String, String> e : conf.getAllAsJavaMap().entrySet()) {
+      options.append(String.format("-D%s=\"%s\" ", e.getKey(), e.getValue()));
     }
     MasterSpec masterSpec = spec.getMasterSpec();
     WorkerSpec workerSpec = spec.getWorkerSpec();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `SparkConf.getAllAsJavaMap()` instead of `SparkConf.getAll()` in `SparkClusterResourceSpec`.

### Why are the changes needed?

To remove the `scala.Tuple2` dependency in favor of Java's `Map.Entry`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7