### PR TITLE
[SPARK-56752] Enable `spark.kubernetes.driver.annotateExitException` by default

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorker.java
@@ -167,6 +167,7 @@ public class SparkAppSubmissionWorker {
     effectiveSparkConf.setIfMissing("spark.app.id", appId);
     effectiveSparkConf.setIfMissing("spark.authenticate", "true");
     effectiveSparkConf.setIfMissing("spark.io.encryption.enabled", "true");
+    effectiveSparkConf.setIfMissing("spark.kubernetes.driver.annotateExitException", "true");
     // In case of static allocation, use K8s Garbage Collection instead of explicit API invocations
     if (!"true".equalsIgnoreCase(effectiveSparkConf.get("spark.dynamicAllocation.enabled", "false"))
         && applicationSpec.getApplicationTolerations().getResourceRetainPolicy() !=

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppSubmissionWorkerTest.java
@@ -320,4 +320,25 @@ class SparkAppSubmissionWorkerTest {
     SparkAppDriverConf conf3 = submissionWorker.buildDriverConf(mockApp, Map.of());
     assertEquals("false", conf3.get("spark.kubernetes.executor.deleteOnTermination", "true"));
   }
+
+  @Test
+  void annotateExitExceptionShouldDefaultToTrueWhenUnset() {
+    SparkApplication mockApp = mock(SparkApplication.class);
+    ApplicationSpec mockSpec = mock(ApplicationSpec.class);
+    ObjectMeta appMeta = new ObjectMetaBuilder().withName("app1").withNamespace("ns1").build();
+    when(mockSpec.getApplicationTolerations()).thenReturn(new ApplicationTolerations());
+    when(mockApp.getSpec()).thenReturn(mockSpec);
+    when(mockApp.getMetadata()).thenReturn(appMeta);
+
+    SparkAppSubmissionWorker submissionWorker = new SparkAppSubmissionWorker();
+
+    when(mockSpec.getSparkConf()).thenReturn(Map.of());
+    SparkAppDriverConf conf1 = submissionWorker.buildDriverConf(mockApp, Map.of());
+    assertEquals("true", conf1.get("spark.kubernetes.driver.annotateExitException", "false"));
+
+    when(mockSpec.getSparkConf())
+        .thenReturn(Map.of("spark.kubernetes.driver.annotateExitException", "false"));
+    SparkAppDriverConf conf2 = submissionWorker.buildDriverConf(mockApp, Map.of());
+    assertEquals("false", conf2.get("spark.kubernetes.driver.annotateExitException", "true"));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to default `spark.kubernetes.driver.annotateExitException` to `true` in `SparkAppSubmissionWorker.buildDriverConf()` when the user has not specified a value.

### Why are the changes needed?

To improve out-of-the-box observability by annotating driver pods with exit exceptions, which is valuable for post-mortem debugging.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with a new unit test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7