### PR TITLE
[SPARK-56753] Upgrade `Netty` to 4.2.13.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.6.1"
 lombok = "1.18.46"
-netty = "4.2.12.Final"
+netty = "4.2.13.Final"
 operator-sdk = "5.3.3"
 dropwizard-metrics = "4.2.38"
 spark = "4.2.0-preview5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `Netty` to 4.2.13.Final.

### Why are the changes needed?

To bring in the latest bug-fix and security release.
- https://netty.io/news/2026/05/04/4-2-13-Final.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the existing tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)