### PR TITLE
[SPARK-56777] Upgrade `log4j` to 2.26.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ operator-sdk = "5.3.3"
 dropwizard-metrics = "4.2.38"
 spark = "4.2.0-preview5"
 hadoop = "3.5.0"
-log4j = "2.25.4"
+log4j = "2.26.0"
 slf4j = "2.0.17"
 
 # Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Log4j` from `2.25.4` to `2.26.0`.

### Why are the changes needed?

To bring the latest stable Log4j 2.x patch.

- https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.26.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code