### PR TITLE
[SPARK-56779] Upgrade `spotbugs-gradle-plugin` to 6.5.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ mockito = "5.23.0"
 checkstyle = "13.2.0"
 pmd = "7.23.0"
 spotbugs-tool = "4.9.8"
-spotbugs-plugin = "6.5.1"
+spotbugs-plugin = "6.5.4"
 spotless-plugin = "8.4.0"
 
 # Packaging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotbugs-gradle-plugin` from `6.5.1` to `6.5.4`.

### Why are the changes needed?

To bring the latest bug fixes and improvements from upstream.

- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.4
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.3
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.2

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with `gradle clean build` and `gradle check`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)