### PR TITLE
[SPARK-56780] Upgrade PMD to 7.24.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ mockito = "5.23.0"
 
 # Build Analysis
 checkstyle = "13.4.2"
-pmd = "7.23.0"
+pmd = "7.24.0"
 spotbugs-tool = "4.9.8"
 spotbugs-plugin = "6.5.4"
 spotless-plugin = "8.4.0"

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/config/SparkOperatorConfigMapReconcilerTest.java
@@ -65,7 +65,6 @@ class SparkOperatorConfigMapReconcilerTest {
   }
 
   @Test
-  @SuppressWarnings("PMD.UnitTestShouldIncludeAssert")
   void sanityTest() {
     client.resource(testConfigMap()).create();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade PMD from 7.23.0 to 7.24.0.

### Why are the changes needed?

To stay current with the latest stable PMD release.
- https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.24.0

PMD 7.24.0 introduces a new `UnnecessaryWarningSuppression` rule that flagged one redundant `@SuppressWarnings("PMD.UnitTestShouldIncludeAssert")` in `SparkOperatorConfigMapReconcilerTest.sanityTest`. The annotation is removed because the lambda inside `await().untilAsserted(...)` already contains an `assertThat(...)` call, so the suppression is no longer needed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code