### PR TITLE
[SPARK-56785] Use the latest `actions/*` GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -158,7 +158,9 @@ jobs:
           cpus: 3
           memory: 10240m
       - name: Set Up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
       - name: Set Up Chainsaw
         run: |
           go install github.com/kyverno/chainsaw@latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump `actions/*` GitHub Actions to the latest major versions.

| Action | Before | After |
|---|---|---|
| `actions/setup-go` | `v5` | `v6` |
| `actions/configure-pages` | `v5` | `v6` |
| `actions/upload-pages-artifact` | `v3` | `v5` |
| `actions/deploy-pages` | `v4` | `v5` |

`actions/checkout@v6` and `actions/setup-java@v5` are already on the latest majors.

### Why are the changes needed?

To keep CI on the latest official actions for security fixes and Node.js runtime updates.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7