### PR TITLE
[SPARK-56786] Add `pi-preview.yaml` with Apache Spark 4.2.0-preview5

### DIFF
--- a/examples/pi-preview.yaml
+++ b/examples/pi-preview.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-preview
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.2.0-preview5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `examples/pi-preview.yaml` pinned to Apache Spark `4.2.0-preview5`.

### Why are the changes needed?

To provide a ready-to-apply SparkPi example for the upcoming `4.2.0-preview5` release.
- https://spark.apache.org/docs/4.2.0-preview5/

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually with `kubectl apply -f examples/pi-preview.yaml`.

```
$ kubectl apply -f examples/pi-preview.yaml    
sparkapplication.spark.apache.org/pi-preview created

$ kubectl get sparkapp                     
NAME         AGE   CURRENT STATE
pi-preview   4s    DriverRequested

$ kubectl get pod                                                                               
NAME                                         READY   STATUS      RESTARTS      AGE
pi-preview-0-driver                          0/1     Completed   0             28s
spark-kubernetes-operator-584498648c-pxfpc   1/1     Running     4 (46h ago)   3d4h

$ kubectl logs -f pi-preview-0-driver | grep version
26/05/07 20:28:41 INFO SparkContext: Running Spark version 4.2.0-preview5
26/05/07 20:28:41 INFO SparkContext: Java version 21.0.10+7-LTS
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)