### PR TITLE
[SPARK-56787] Add `Deployment`-based SparkApp example

### DIFF
--- a/examples/pi-preview-deployment.yaml
+++ b/examples/pi-preview-deployment.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-preview-deployment
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  driverArgs: ["20000"]
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.executor.instances: "3"
+    spark.kubernetes.allocation.pods.allocator: "deployment"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.2.0-preview5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `examples/pi-preview-deployment.yaml`, a SparkPi example that uses `spark.kubernetes.allocation.pods.allocator=deployment`.

### Why are the changes needed?

To provide a ready-to-apply example demonstrating the `deployment`-based pod allocator alongside the upcoming `4.2.0-preview5` release.

- apache/spark#52867

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested.

```
$ kubectl apply -f examples/pi-preview-deployment.yaml 
sparkapplication.spark.apache.org/pi-preview-deployment created

$ kubectl get sparkapp                                
NAME                    AGE   CURRENT STATE
pi-preview-deployment   3s    DriverRequested

$ kubectl get sparkapp
NAME                    AGE   CURRENT STATE
pi-preview-deployment   11s   RunningHealthy

$ kubectl get deploy                                        
NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
spark-d-pi-preview-deployment-0-0   3/3     3            3           16s
spark-kubernetes-operator           1/1     1            1           3d4h

$ kubectl get pod   
NAME                                                 READY   STATUS    RESTARTS      AGE
pi-preview-deployment-0-driver                       1/1     Running   0             23s
spark-d-pi-preview-deployment-0-0-7cc95db6bb-8dzln   1/1     Running   0             20s
spark-d-pi-preview-deployment-0-0-7cc95db6bb-hhfqn   1/1     Running   0             20s
spark-d-pi-preview-deployment-0-0-7cc95db6bb-pglpb   1/1     Running   0             20s
spark-kubernetes-operator-584498648c-pxfpc           1/1     Running   4 (46h ago)   3d4h
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)