### PR TITLE
[SPARK-56789] Add `ExecutorResizePlugin` example

### DIFF
--- a/examples/pi-preview-with-executor-resize-plugin.yaml
+++ b/examples/pi-preview-with-executor-resize-plugin.yaml
@@ -18,13 +18,16 @@ metadata:
   name: pi-preview-with-executor-resize-plugin
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
+  driverArgs: ["200000"]
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.dynamicAllocation.enabled: "true"
-    spark.dynamicAllocation.maxExecutors: "3"
+    spark.dynamicAllocation.maxExecutors: "1"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
+    spark.kubernetes.executor.resizeInterval: "1min"
+    spark.kubernetes.executor.resizeThreshold: "0.25"
     spark.plugins: "org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin"
   applicationTolerations:
     resourceRetainPolicy: OnFailure

--- a/examples/pi-preview-with-executor-resize-plugin.yaml
+++ b/examples/pi-preview-with-executor-resize-plugin.yaml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-preview-with-executor-resize-plugin
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
+    spark.plugins: "org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.2.0-preview5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new example that show Apache Spark 4.2.0-preview5's `ExecutorResizePlugin`.

- apache/spark#54215

### Why are the changes needed?

To provide an out-of-the-box `SparkApplication` example that demonstrates the `ExecutorResizePlugin` along with its related configurations (`spark.kubernetes.executor.resizeInterval`, `spark.kubernetes.executor.resizeThreshold`).

### Does this PR introduce _any_ user-facing change?

No, this is an example-only addition.

### How was this patch tested?

Manual review.

```
$ kubectl apply -f examples/pi-preview-with-executor-resize-plugin.yaml

$ kubectl logs -f pi-preview-with-executor-resize-plugin-0-driver | grep Plugin
26/05/07 21:31:59 INFO DriverPluginContainer: Initialized driver component for plugin org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin.
26/05/07 21:32:59 INFO ExecutorResizeDriverPlugin: Increase executor 1 container memory from 1476395008 to 1624034508 as usage 505622528 exceeded threshold.
26/05/07 21:33:59 INFO ExecutorResizeDriverPlugin: Increase executor 1 container memory from 1624034508 to 1786437958 as usage 506228736 exceeded threshold.
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)