### PR TITLE
[SPARK-56848] Upgrade `Apache DataFusion Comet` to 0.16.0

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -46,7 +46,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/0.15.0/comet-spark-spark4.0_2.13-0.15.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/0.16.0/comet-spark-spark4.0_2.13-0.16.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -68,7 +68,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/0.15.0/comet-spark-spark4.0_2.13-0.15.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.0_2.13/0.16.0/comet-spark-spark4.0_2.13-0.16.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache DataFusion Comet to 0.16.0 in `examples/pi-with-comet.yaml`.

### Why are the changes needed?

To use the latest version of Apache DataFusion Comet 0.16.0.
- https://github.com/apache/datafusion-comet/releases/tag/0.16.0 (2026-05-06)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs because we have an integration test.
- #652

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)