### PR TITLE
[SPARK-56850] Add Spark `4.2.0-preview5` K8s integration tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,6 +138,9 @@ jobs:
           - kubernetes-version: "1.36.0"
             mode: static
             test-group: pi-with-gluten
+          - kubernetes-version: "1.36.0"
+            mode: static
+            test-group: pi-preview
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/tests/e2e/pi-preview/chainsaw-test.yaml
+++ b/tests/e2e/pi-preview/chainsaw-test.yaml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: spark-operator-pi-preview-validation
+spec:
+  namespace: default
+  steps:
+  - try:
+    - apply:
+        file: ../../../examples/pi-preview.yaml
+    - assert:
+        bindings:
+          - name: SPARK_APP_NAMESPACE
+            value: default
+        timeout: 10m
+        file: spark-state-transition.yaml
+    catch:
+    - describe:
+        apiVersion: spark.apache.org/v1
+        kind: SparkApplication
+        namespace: default
+    - podLogs:
+        selector: spark-app-name=pi-preview
+        namespace: default
+    - podLogs:
+        selector: app.kubernetes.io/name=spark-kubernetes-operator
+        namespace: default
+    finally:
+    - script:
+        timeout: 120s
+        content: |
+          kubectl delete sparkapplication pi-preview --ignore-not-found=true

--- a/tests/e2e/pi-preview/spark-state-transition.yaml
+++ b/tests/e2e/pi-preview/spark-state-transition.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-preview
+  namespace: ($SPARK_APP_NAMESPACE)
+status:
+  stateTransitionHistory:
+    (*.currentStateSummary):
+      - "Submitted"
+      - "DriverRequested"
+      - "DriverStarted"
+      - "DriverReady"
+      - "RunningHealthy"
+      - "Succeeded"
+      - "ResourceReleased"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a Chainsaw-based e2e integration test group `pi-preview` that validates [`examples/pi-preview.yaml`](examples/pi-preview.yaml) end-to-end, following the same pattern as `pi-with-comet` and `pi-with-gluten`.

### Why are the changes needed?

To improve the test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)