### PR TITLE
[SPARK-56930] Upgrade `spotless-plugin-gradle` to 8.5.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ checkstyle = "13.4.2"
 pmd = "7.24.0"
 spotbugs-tool = "4.9.8"
 spotbugs-plugin = "6.5.4"
-spotless-plugin = "8.4.0"
+spotless-plugin = "8.5.1"
 
 # Packaging
 cyclonedx = "3.2.4"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotless-plugin-gradle` to 8.5.1.

### Why are the changes needed?

To bring the latest bug fixes and improvements.
- https://github.com/diffplug/spotless/releases/tag/gradle%2F8.5.1 (2025-05-15)
- https://github.com/diffplug/spotless/releases/tag/gradle%2F8.5.0 (2026-05-14)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)