### PR TITLE
[SPARK-56986] Upgrade `java-operator-sdk` to 5.3.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 fabric8 = "7.7.0"
 lombok = "1.18.46"
 netty = "4.2.13.Final"
-operator-sdk = "5.3.3"
+operator-sdk = "5.3.4"
 dropwizard-metrics = "4.2.38"
 spark = "4.2.0-preview5"
 hadoop = "3.5.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `java-operator-sdk` to 5.3.4.

### Why are the changes needed?

To bring the latest bug fixes and improvements from `java-operator-sdk` 5.3.4:
- https://github.com/operator-framework/java-operator-sdk/releases/tag/v5.3.4
  - Revert breaking constructor change in `InformerConfiguration` to restore compatibility.
  - Read-cache-after-write aware `list` and `byIndex`.
  - Use `onList()` for ghost resource cleanup.
  - Handle empty YAML configuration files containing only comments.
  - Invoke `ConfigurationServiceOverrider` only once.
  - Restore JUnit5 compatibility for `LocallyRunOperatorExtension`.
  - Fix flaky integration tests (`WorkflowAllFeatureIT`, `MultipleReconcilerSameTypeIT`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7