### PR TITLE
[SPARK-57006] Use Spark 4.1.2 in docs, examples, tests, and default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ ./examples/submit-pi-to-prod.sh
 {
   "action" : "CreateSubmissionResponse",
   "message" : "Driver successfully submitted as driver-20260110030233-0000",
-  "serverSparkVersion" : "4.1.1",
+  "serverSparkVersion" : "4.1.2",
   "submissionId" : "driver-20260110030233-0000",
   "success" : true
 }
@@ -87,7 +87,7 @@ $ curl http://localhost:6066/v1/submissions/status/driver-20260110030233-0000/
 {
   "action" : "SubmissionStatusResponse",
   "driverState" : "FINISHED",
-  "serverSparkVersion" : "4.1.1",
+  "serverSparkVersion" : "4.1.2",
   "submissionId" : "driver-20260110030233-0000",
   "success" : true,
   "workerHostPort" : "10.1.1.172:44233",
@@ -124,7 +124,7 @@ Events:
   Normal  Scheduling         1s    yunikorn  default/pi-on-yunikorn-0-driver is queued and waiting for allocation
   Normal  Scheduled          1s    yunikorn  Successfully assigned default/pi-on-yunikorn-0-driver to node docker-desktop
   Normal  PodBindSuccessful  1s    yunikorn  Pod default/pi-on-yunikorn-0-driver is successfully bound to node docker-desktop
-  Normal  Pulled             0s    kubelet   Container image "apache/spark:4.1.1-scala" already present on machine
+  Normal  Pulled             0s    kubelet   Container image "apache/spark:4.1.2-scala" already present on machine
   Normal  Created            0s    kubelet   Created container: spark-kubernetes-driver
   Normal  Started            0s    kubelet   Started container spark-kubernetes-driver
 

--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -48,12 +48,12 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.1-scala"
+    spark.kubernetes.container.image: "apache/spark:4.1.2-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
 ```
 
 After application is submitted, Operator will add status information to your application based on

--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-on-yunikorn
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/cluster-with-hpa-template.yaml
+++ b/examples/cluster-with-hpa-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-hpa-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/cluster-with-hpa.yaml
+++ b/examples/cluster-with-hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-hpa
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/dfs-read-write.yaml
+++ b/examples/dfs-read-write.yaml
@@ -41,4 +41,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-java17.yaml
+++ b/examples/pi-java17.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-on-volcano.yaml
+++ b/examples/pi-on-volcano.yaml
@@ -33,4 +33,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -34,4 +34,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-python.yaml
+++ b/examples/pi-python.yaml
@@ -27,4 +27,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-statefulset.yaml
+++ b/examples/pi-statefulset.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-v1beta1.yaml
+++ b/examples/pi-v1beta1.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -30,7 +30,7 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.executor.extraClassPath: "local:///comet/comet.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.1-scala"
+    spark.kubernetes.container.image: "apache/spark:4.1.2-scala"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
     spark.plugins: "org.apache.spark.CometPlugin"
@@ -82,4 +82,4 @@ spec:
           emptyDir:
             sizeLimit: 200Mi
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-driver-timeout.yaml
+++ b/examples/pi-with-driver-timeout.yaml
@@ -32,4 +32,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-eventlog.yaml
+++ b/examples/pi-with-eventlog.yaml
@@ -40,4 +40,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-instanceconfig.yaml
+++ b/examples/pi-with-instanceconfig.yaml
@@ -31,4 +31,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-on-demand-pvc.yaml
+++ b/examples/pi-with-on-demand-pvc.yaml
@@ -35,4 +35,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -26,4 +26,4 @@ spec:
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-spark-connect-plugin.yaml
+++ b/examples/pi-with-spark-connect-plugin.yaml
@@ -30,4 +30,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi-with-template.yaml
+++ b/examples/pi-with-template.yaml
@@ -38,4 +38,4 @@ spec:
         priorityClassName: system-cluster-critical
         terminationGracePeriodSeconds: 0
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -29,4 +29,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -18,7 +18,7 @@ metadata:
   name: prod
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -18,7 +18,7 @@ metadata:
   name: qa
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/spark-connect-server-with-spark-cluster.yaml
+++ b/examples/spark-connect-server-with-spark-cluster.yaml
@@ -27,4 +27,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.ui.reverseProxy: "true"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -30,4 +30,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/spark-history-server-with-jws-filter.yaml
+++ b/examples/spark-history-server-with-jws-filter.yaml
@@ -39,7 +39,7 @@ spec:
     spark.ui.filters: "org.apache.spark.ui.JWSFilter"
     spark.org.apache.spark.ui.JWSFilter.param.secretKey: "VmlzaXQgaHR0cHM6Ly9zcGFyay5hcGFjaGUub3JnIHRvIGRvd25sb2FkIEFwYWNoZSBTcGFyay4="
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/spark-history-server.yaml
+++ b/examples/spark-history-server.yaml
@@ -36,7 +36,7 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/spark-thrift-server.yaml
+++ b/examples/spark-thrift-server.yaml
@@ -28,7 +28,7 @@ spec:
     spark.kubernetes.executor.podNamePrefix: "spark-thrift-server"
     spark.scheduler.mode: "FAIR"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -27,4 +27,4 @@ spec:
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/stream-word-count.yaml
+++ b/examples/stream-word-count.yaml
@@ -37,4 +37,4 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/examples/word-count.yaml
+++ b/examples/word-count.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -69,7 +69,7 @@ public class SparkClusterResourceSpec {
     String clusterName = cluster.getMetadata().getName();
     String scheduler = conf.get(Config.KUBERNETES_SCHEDULER_NAME().key(), "default-scheduler");
     String namespace = conf.get(Config.KUBERNETES_NAMESPACE().key(), clusterNamespace);
-    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.1.1");
+    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.1.2");
     ClusterSpec spec = cluster.getSpec();
     String version = spec.getRuntimeVersions().getSparkVersion();
     StringBuilder options = new StringBuilder();

--- a/tests/benchmark/sparkapps.sh
+++ b/tests/benchmark/sparkapps.sh
@@ -46,7 +46,7 @@ spec:
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.driver.request.cores: "100m"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
 ---
 EOF
 done

--- a/tests/e2e/driver-start-timeout/spark-example-driver-start-timeout.yaml
+++ b/tests/e2e/driver-start-timeout/spark-example-driver-start-timeout.yaml
@@ -31,4 +31,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:non-existent-image"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -23,11 +23,11 @@ spec:
   scenarios:
     - bindings:
         - name: "SPARK_VERSION"
-          value: "4.1.1"
+          value: "4.1.2"
         - name: "SCALA_VERSION"
           value: "2.13"
         - name: "IMAGE"
-          value: "apache/spark:4.1.1-python3"
+          value: "apache/spark:4.1.2-python3"
     - bindings:
         - name: "SPARK_VERSION"
           value: "3.5.8"

--- a/tests/e2e/resource-retain-duration/spark-example-retain-duration.yaml
+++ b/tests/e2e/resource-retain-duration/spark-example-retain-duration.yaml
@@ -32,4 +32,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/tests/e2e/resource-retain-on-failure/spark-example-retain-on-failure.yaml
+++ b/tests/e2e/resource-retain-on-failure/spark-example-retain-on-failure.yaml
@@ -30,4 +30,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/tests/e2e/resource-selector/chainsaw-test.yaml
+++ b/tests/e2e/resource-selector/chainsaw-test.yaml
@@ -27,9 +27,9 @@ spec:
         - name: SPARK_APPLICATION_NAME
           value: "spark-example-resource-selector"
         - name: SPARK_VERSION
-          value: "4.1.1"
+          value: "4.1.2"
         - name: IMAGE
-          value: "apache/spark:4.1.1-scala"
+          value: "apache/spark:4.1.2-scala"
   steps:
     - name: install-spark-application-and-apply-label
       try:

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -23,13 +23,13 @@ spec:
   scenarios:
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.1.1"
+        value: "4.1.2"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: "apache/spark:4.1.1-scala-java17"
+        value: "apache/spark:4.1.2-scala-java17"
   - bindings:
       - name: "SPARK_VERSION"
         value: "3.5.8"
@@ -41,13 +41,13 @@ spec:
         value: 'apache/spark:3.5.8-scala2.12-java17-ubuntu'
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.1.1"
+        value: "4.1.2"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "21"
       - name: "IMAGE"
-        value: 'apache/spark:4.1.1-scala'
+        value: 'apache/spark:4.1.2-scala'
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -28,4 +28,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -28,4 +28,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.1"
+    sparkVersion: "4.1.2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Spark from `4.1.1` to `4.1.2`.

### Why are the changes needed?

To use the latest Apache Spark.

- https://spark.apache.org/news/spark-4-1-2-released.html
- https://github.com/apache/spark/releases/tag/v4.1.2
- [Docker Hub: apache/spark:4.1.2](https://hub.docker.com/r/apache/spark/tags?name=4.1.2)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7