### PR TITLE
[SPARK-57012] Drop Spark 3.5 Support

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/README.md
+++ b/build-tools/helm/spark-kubernetes-operator/README.md
@@ -38,7 +38,7 @@ cluster using the [Helm](https://helm.sh) package manager. With this, you can la
 
 ## Features
 
-- Support Apache Spark 3.5+
+- Support Apache Spark 4.0+
 - Support `SparkApp` and `SparkCluster` CRDs
   - `sparkapplications.spark.apache.org` (v1)
   - `sparkclusters.spark.apache.org` (v1)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,7 +25,7 @@ under the License.
 - Kubernetes version compatibility:
   - k8s version >= 1.34 is recommended. Operator attempts to be as API compatible as possible, but
       patch support will not be performed on k8s versions that reached EOL.
-- Spark versions 3.5 or above.
+- Spark versions 4.0 or above.
 
 ## Spark Application Namespaces
 

--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -28,13 +28,6 @@ spec:
           value: "2.13"
         - name: "IMAGE"
           value: "apache/spark:4.1.2-python3"
-    - bindings:
-        - name: "SPARK_VERSION"
-          value: "3.5.8"
-        - name: "SCALA_VERSION"
-          value: "2.12"
-        - name: "IMAGE"
-          value: "apache/spark:3.5.8-scala2.12-java17-python3-ubuntu"
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -32,15 +32,6 @@ spec:
         value: "apache/spark:4.1.2-scala-java17"
   - bindings:
       - name: "SPARK_VERSION"
-        value: "3.5.8"
-      - name: "SCALA_VERSION"
-        value: "2.12"
-      - name: "JAVA_VERSION"
-        value: "17"
-      - name: "IMAGE"
-        value: 'apache/spark:3.5.8-scala2.12-java17-ubuntu'
-  - bindings:
-      - name: "SPARK_VERSION"
         value: "4.1.2"
       - name: "SCALA_VERSION"
         value: "2.13"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes Apache Spark 3.5 related contents and code.

### Why are the changes needed?

According to the Apache Spark EOL policy, we drop Spark 3.5 support. Spark 3.5.x reached **the planned EOL on 2026-04-12**. The only exception is the extension to the main repository which is irrelevant to `Apache Spark K8s Operator` as mentioned in the website.

- https://spark.apache.org/versioning-policy.html

<img width="981" height="348" alt="Screenshot 2026-05-22 at 13 03 12" src="https://github.com/user-attachments/assets/602f66d1-20ab-4b99-a046-86aa57d9f95f" />

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7