### PR TITLE
[SPARK-57016] Upgrade `spotbugs-gradle-plugin` to 6.5.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ mockito = "5.23.0"
 checkstyle = "13.4.2"
 pmd = "7.24.0"
 spotbugs-tool = "4.9.8"
-spotbugs-plugin = "6.5.4"
+spotbugs-plugin = "6.5.5"
 spotless-plugin = "8.5.1"
 
 # Packaging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotbugs-gradle-plugin` from 6.5.4 to 6.5.5.

### Why are the changes needed?

To bring the latest bug fixes:
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.5 (2026-05-21)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7