### PR TITLE
[SPARK-57079] Add `*.pyc` and `*.pyo` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.swp
 *~
+*.pyc
+*.pyo
 .java-version
 .DS_Store
 .idea/


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `*.pyc` and `*.pyo` to `.gitignore` to exclude Python bytecode files from being tracked by Git.

### Why are the changes needed?

Like Apache Spark main repository, to prevent accidental commits of Python compiled bytecode files (`*.pyc`, `*.pyo`) that may be generated when running Python scripts in this repository (e.g., `dev/spark_jira_utils.py`).

https://github.com/apache/spark/blob/30bdf0b39fa6b28ea149ddd43ecd962b2b3c0cd2/.gitignore#L6-L7

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review of `.gitignore`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7