### PR TITLE
[SPARK-57107] Pin `apache/skywalking-eyes` to `v0.8.0` commit SHA

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Check license header
-        uses: apache/skywalking-eyes@main
+        uses: apache/skywalking-eyes@e9f91c35e4d4ae4420f722aa6598c4a13cc69093
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `apache/skywalking-eyes` to the `v0.8.0` commit SHA in `.github/workflows/build_and_test.yml`.

```yaml
- uses: apache/skywalking-eyes@e9f91c35e4d4ae4420f722aa6598c4a13cc69093
```

### Why are the changes needed?

To improve supply-chain security by pinning the third-party GitHub Action to an immutable commit SHA instead of the mutable `@main` branch reference.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7