### PR TITLE
[SPARK-57272] Upgrade `Netty` to 4.2.15.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@
 [versions]
 fabric8 = "7.7.0"
 lombok = "1.18.46"
-netty = "4.2.14.Final"
+netty = "4.2.15.Final"
 operator-sdk = "5.3.4"
 dropwizard-metrics = "4.2.39"
 spark = "4.2.0-preview5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Netty` to 4.2.15.Final.

### Why are the changes needed?

To bring the latest bug fixes:

- https://netty.io/news/2026/06/01/4-2-15-Final.html
  - [CVE-2026-48059](https://github.com/netty/netty/security/advisories/GHSA-h2qv-fj59-j46j): memory exhaustion in io.netty:netty-codec-haproxy (high).
  - [CVE-2026-47691](https://github.com/netty/netty/security/advisories/GHSA-5pvg-856g-cp85): DNS cache poisoning in io.netty:netty-resolver-dns (high).
  - [CVE-2026-50560](https://github.com/netty/netty/security/advisories/GHSA-563q-j3cm-6jxm): DDoS in io.netty:netty-codec-http2.
  - [CVE-2026-50011](https://github.com/netty/netty/security/advisories/GHSA-5w86-c3rq-vjj7): memory exhaustion in io.netty:netty-codec-redis (high).
  - [CVE-2026-44250](https://github.com/netty/netty/security/advisories/GHSA-3244-j874-rhc2): memory exhaustion in io.netty:netty-codec-redis (high).
  - [CVE-2026-44890](https://github.com/netty/netty/security/advisories/GHSA-6ghj-frrj-jjj3): memory exhaustion in io.netty:netty-codec-redis (high).
  - [CVE-2026-50009](https://github.com/netty/netty/security/advisories/GHSA-cq4q-cv5g-r8q5): information disclosure and denial of service in io.netty:netty-codec-classes-quic.
  - [CVE-2026-44249](https://github.com/netty/netty/security/advisories/GHSA-3qp7-7mw8-wx86): IPv6 subnet filter bypass in io.netty:netty-handler (high).
  - [CVE-2026-50020](https://github.com/netty/netty/security/advisories/GHSA-hvcg-qmg6-jm4c): request smuggling in io.netty:netty-codec-http.
  - [CVE-2026-44892](https://github.com/netty/netty/security/advisories/GHSA-c2rx-5r8w-8xr2): memory exhaustion in io.netty:netty-codec-http3 (high).
  - [CVE-2026-44893](https://github.com/netty/netty/security/advisories/GHSA-cc37-9q2j-3hfv): memory leak in io.netty:netty-codec-haproxy (high).
  - [CVE-2026-44894](https://github.com/netty/netty/security/advisories/GHSA-cmm3-54f8-px4j): traffic amplification in io.netty:netty-codec-classes-quic (high).
  - [CVE-2026-50010](https://github.com/netty/netty/security/advisories/GHSA-c653-97m9-rcg9): TLS hostname verification accidentally disabled in io.netty:netty-handler (high).
  - [CVE-2026-45673](https://github.com/netty/netty/security/advisories/GHSA-xmv7-r254-6q78): DNS cache poisoning in io.netty:netty-resolver-dns.
  - [CVE-2026-45416](https://github.com/netty/netty/security/advisories/GHSA-x4gw-5cx5-pgmh): excessive memory usage from SNIHandler in io.netty:netty-handler (high).
  - [CVE-2026-45536](https://github.com/netty/netty/security/advisories/GHSA-w573-9ffj-6ff9): file descriptor leak in io.netty:netty-transport-native-epoll and io.netty:netty-transport-native-kqueue.
  - [CVE-2026-45674](https://github.com/netty/netty/security/advisories/GHSA-676x-f7gg-47vc): DNS cache poisoning in io.netty:netty-resolver-dns (high).
  - [CVE-2026-46340](https://github.com/netty/netty/security/advisories/GHSA-5xrh-qmmq-w6ch): memory exhaustion in io.netty:netty-transport-sctp (high).
  - [CVE-2026-47244](https://github.com/netty/netty/security/advisories/GHSA-5x3r-wrvg-rp6q): denial of service in io.netty:netty-codec-http2.
  - [CVE-2026-48006](https://github.com/netty/netty/security/advisories/GHSA-6jv9-x5w9-2ccm): memory exhaustion in io.netty:netty-codec-redis (high).
  - [CVE-2026-48748](https://github.com/netty/netty/security/advisories/GHSA-4grm-h2qv-h6w6): memory exhaustion in io.netty:netty-codec-http3 (high).
  - [CVE-2026-48043](https://github.com/netty/netty/security/advisories/GHSA-c2gf-v879-257j): memory exhaustion in io.netty:netty-codec-http2.
  - https://github.com/netty/netty/pull/16836
  - https://github.com/netty/netty/pull/16810
  - https://github.com/netty/netty/pull/16853
  - https://github.com/netty/netty/pull/16837
  - https://github.com/netty/netty/pull/16844
  - https://github.com/netty/netty/pull/16850
  - https://github.com/netty/netty/pull/16890

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8