### PR TITLE
[SPARK-57280] Add `SECURITY.md` for scan-agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,9 @@ JaCoCo. Run it before pushing; CI runs the same matrix on Java 21 / 25 / 26 (x86
 - Write PR descriptions in English following
   [.github/PULL_REQUEST_TEMPLATE](.github/PULL_REQUEST_TEMPLATE), and follow the
   [Spark contributing guide](https://spark.apache.org/contributing.html).
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` for the project's threat model, in-scope / out-of-scope declarations, and known non-findings before reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Reporting a vulnerability
+
+To report a security vulnerability in apache/spark-kubernetes-operator, follow the ASF security process at <https://www.apache.org/security/>.  Reports can be sent privately to security@apache.org or to private@spark.apache.org.
+
+## Threat model
+
+This repository extend K8s resource manager to manage Apache Spark applications via Operator Pattern. Apache Spark's security guidance for operators — covering authentication, encryption, access control, Kerberos integration, trust boundaries, environmental assumptions, security properties provided and not provided, and downstream operator responsibilities — is documented at:
+
+<https://spark.apache.org/docs/latest/security.html>
+
+Automated security scanning agents should consult that document for the project's in-scope / out-of-scope declarations before reporting issues.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `SECURITY.md` for scan-agent discoverability.

### Why are the changes needed?

Like Apache Spark main repository, we had better provide this.
- https://github.com/apache/spark/blob/master/SECURITY.md

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.