### PR TITLE
[SPARK-57391] Use Apache Spark 4.0.3 in examples

### DIFF
--- a/examples/pi-with-gluten.yaml
+++ b/examples/pi-with-gluten.yaml
@@ -26,7 +26,7 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.executor.extraClassPath: "local:///gluten/gluten.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.2-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.3-scala"
     spark.kubernetes.node.selector.kubernetes.io/arch: "amd64"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
@@ -84,4 +84,4 @@ spec:
           emptyDir:
             sizeLimit: 500Mi
   runtimeVersions:
-    sparkVersion: "4.0.2"
+    sparkVersion: "4.0.3"

--- a/examples/spark-connect-server-iceberg.yaml
+++ b/examples/spark-connect-server-iceberg.yaml
@@ -30,7 +30,7 @@ spec:
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.1,org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.11.0"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.2"
+    spark.kubernetes.container.image: "apache/spark:4.0.3"
     spark.kubernetes.executor.podNamePrefix: "spark-connect-server-iceberg"
     spark.scheduler.mode: "FAIR"
     spark.sql.catalog.s3.type: "hadoop"
@@ -41,4 +41,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.0.2"
+    sparkVersion: "4.0.3"

--- a/examples/word-count-celeborn.yaml
+++ b/examples/word-count-celeborn.yaml
@@ -25,7 +25,7 @@ spec:
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.jars.packages: "org.apache.celeborn:celeborn-client-spark-4-shaded_2.13:0.6.2"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.2-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.3-scala"
     spark.kubernetes.driver.limit.cores: "5"
     spark.kubernetes.driver.master: "local[10]"
     spark.kubernetes.driver.request.cores: "5"
@@ -37,4 +37,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.0.2"
+    sparkVersion: "4.0.3"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Spark to `4.0.3` in examples.

### Why are the changes needed?

To use the latest Apache Spark 4.0.x.

- https://spark.apache.org/news/spark-4-0-3-released.html
- https://github.com/apache/spark/releases/tag/v4.0.3
- [Docker Hub: apache/spark:4.0.3](https://hub.docker.com/r/apache/spark/tags?name=4.0.3)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Fable 5)