### PR TITLE
[SPARK-57432] Upgrade `spotbugs-gradle-plugin` to 6.5.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ mockito = "5.23.0"
 checkstyle = "13.4.2"
 pmd = "7.24.0"
 spotbugs-tool = "4.9.8"
-spotbugs-plugin = "6.5.5"
+spotbugs-plugin = "6.5.6"
 spotless-plugin = "8.6.0"
 
 # Packaging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotbugs-gradle-plugin` to 6.5.6.

### Why are the changes needed?

To keep the build tooling up to date by using the latest version of the plugin.
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.6

### Does this PR introduce _any_ user-facing change?

No. This is a build/test-only dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)