### PR TITLE
[SPARK-57450] Add JWSFilter-enabled Spark Cluster example

### DIFF
--- a/examples/cluster-with-jws-filter.yaml
+++ b/examples/cluster-with-jws-filter.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkCluster
+metadata:
+  name: cluster-with-jws-filter
+spec:
+  runtimeVersions:
+    sparkVersion: "4.1.2"
+  clusterTolerations:
+    instanceConfig:
+      initWorkers: 3
+      minWorkers: 3
+      maxWorkers: 3
+  sparkConf:
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
+    spark.master.ui.title: "Prod Spark Cluster"
+    spark.master.rest.host: "0.0.0.0"
+    spark.ui.reverseProxy: "true"
+    # JWS Filter Configuration
+    spark.ui.filters: "org.apache.spark.ui.JWSFilter"
+    spark.master.rest.filters: "org.apache.spark.ui.JWSFilter"
+    spark.org.apache.spark.ui.JWSFilter.param.secretKey: "VmlzaXQgaHR0cHM6Ly9zcGFyay5hcGFjaGUub3JnIHRvIGRvd25sb2FkIEFwYWNoZSBTcGFyay4="


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `examples/cluster-with-jws-filter.yaml`, a copy of `examples/cluster.yaml`
that enables `org.apache.spark.ui.JWSFilter` via the following `sparkConf` entries:

```yaml
spark.ui.filters: "org.apache.spark.ui.JWSFilter"
spark.master.rest.filters: "org.apache.spark.ui.JWSFilter"
spark.org.apache.spark.ui.JWSFilter.param.secretKey: "VmlzaXQgaHR0cHM6Ly9zcGFyay5hcGFjaGUub3JnIHRvIGRvd25sb2FkIEFwYWNoZSBTcGFyay4="
```

### Why are the changes needed?

To provide an example for securing the Spark UI and Master REST endpoint with `JWSFilter`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test after launching the example Spark cluster and do the port-forward.

**Without Authorization Header**
```
$ curl http://localhost:6066/v1/submissions/readyz
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 403 Authorization header is missing.</title>
</head>
<body><h2>HTTP ERROR 403 Authorization header is missing.</h2>
<table>
<tr><th>URI:</th><td>/v1/submissions/readyz</td></tr>
<tr><th>STATUS:</th><td>403</td></tr>
<tr><th>MESSAGE:</th><td>Authorization header is missing.</td></tr>
<tr><th>SERVLET:</th><td>org.apache.spark.deploy.rest.StandaloneReadyzRequestServlet-2e828cb1</td></tr>
</table>

</body>
</html>
```

**With Authorization Header**
```
$ curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.4EKWlOkobpaAPR0J4BE0cPQ-ZD1tRQKLZp1vtE7upPw" http://localhost:6066/v1/submissions/readyz   
{
  "action" : "ReadyzResponse",
  "message" : "",
  "serverSparkVersion" : "4.1.2",
  "success" : true
}%
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)