### PR TITLE
[SPARK-57495] Default `driver/master/worker` container `allowPrivilegeEscalation` to false if unset

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/decorators/SecurityContextDecorator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/decorators/SecurityContextDecorator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.decorators;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+
+/**
+ * Defaults each container's {@code securityContext.allowPrivilegeEscalation} to {@code false} when
+ * it is not set. Containers that already specify a value are left untouched. Handles both a {@link
+ * Pod} directly and the pod template of a {@link StatefulSet}; other resource kinds are a no-op.
+ */
+public class SecurityContextDecorator implements ResourceDecorator {
+
+  @Override
+  public <T extends HasMetadata> T decorate(T resource) {
+    PodSpec podSpec = extractPodSpec(resource);
+    if (podSpec != null) {
+      disallowPrivilegeEscalationIfUnset(podSpec.getInitContainers());
+      disallowPrivilegeEscalationIfUnset(podSpec.getContainers());
+    }
+    return resource;
+  }
+
+  private static PodSpec extractPodSpec(HasMetadata resource) {
+    if (resource instanceof Pod pod) {
+      return pod.getSpec();
+    } else if (resource instanceof StatefulSet statefulSet) {
+      PodTemplateSpec template = statefulSet.getSpec().getTemplate();
+      return template == null ? null : template.getSpec();
+    }
+    return null;
+  }
+
+  private static void disallowPrivilegeEscalationIfUnset(List<Container> containers) {
+    if (containers == null) {
+      return;
+    }
+    for (Container container : containers) {
+      SecurityContext securityContext = container.getSecurityContext();
+      if (securityContext == null) {
+        securityContext = new SecurityContext();
+        container.setSecurityContext(securityContext);
+      }
+      if (securityContext.getAllowPrivilegeEscalation() == null) {
+        securityContext.setAllowPrivilegeEscalation(false);
+      }
+    }
+  }
+}

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkAppResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkAppResourceSpecFactory.java
@@ -42,6 +42,7 @@ import org.apache.spark.k8s.operator.SparkAppResourceSpec;
 import org.apache.spark.k8s.operator.SparkAppSubmissionWorker;
 import org.apache.spark.k8s.operator.SparkApplication;
 import org.apache.spark.k8s.operator.decorators.OwnerResourceDecorator;
+import org.apache.spark.k8s.operator.decorators.SecurityContextDecorator;
 import org.apache.spark.k8s.operator.spec.BaseApplicationTemplateSpec;
 import org.apache.spark.k8s.operator.utils.ModelUtils;
 
@@ -68,6 +69,7 @@ public final class SparkAppResourceSpecFactory {
     cleanUpTempResourcesForApp(app, confOverrides);
     OwnerResourceDecorator decorator = new OwnerResourceDecorator(app, sparkAppResourceLabels(app));
     decorator.decorate(resourceSpec.getConfiguredPod());
+    new SecurityContextDecorator().decorate(resourceSpec.getConfiguredPod());
     return resourceSpec;
   }
 

--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkClusterResourceSpecFactory.java
@@ -30,6 +30,7 @@ import org.apache.spark.k8s.operator.SparkCluster;
 import org.apache.spark.k8s.operator.SparkClusterResourceSpec;
 import org.apache.spark.k8s.operator.SparkClusterSubmissionWorker;
 import org.apache.spark.k8s.operator.decorators.OwnerResourceDecorator;
+import org.apache.spark.k8s.operator.decorators.SecurityContextDecorator;
 
 /** Factory for creating SparkClusterResourceSpec objects. */
 @Slf4j
@@ -55,6 +56,9 @@ public final class SparkClusterResourceSpecFactory {
     decorator.decorate(spec.getMasterStatefulSet());
     decorator.decorate(spec.getWorkerStatefulSet());
     decorator.decorate(spec.getWorkerNetworkPolicy());
+    SecurityContextDecorator securityContextDecorator = new SecurityContextDecorator();
+    securityContextDecorator.decorate(spec.getMasterStatefulSet());
+    securityContextDecorator.decorate(spec.getWorkerStatefulSet());
     if (spec.getHorizontalPodAutoscaler().isPresent()) {
       decorator.decorate(spec.getHorizontalPodAutoscaler().get());
     }

--- a/spark-operator/src/test/java/org/apache/spark/k8s/operator/decorators/SecurityContextDecoratorTest.java
+++ b/spark-operator/src/test/java/org/apache/spark/k8s/operator/decorators/SecurityContextDecoratorTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.k8s.operator.decorators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.SecurityContext;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import org.junit.jupiter.api.Test;
+
+class SecurityContextDecoratorTest {
+
+  @Test
+  void defaultsAllowPrivilegeEscalationWhenSecurityContextMissing() {
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName("driver")
+            .endMetadata()
+            .withNewSpec()
+            .addNewContainer()
+            .withName("spark-kubernetes-driver")
+            .endContainer()
+            .endSpec()
+            .build();
+
+    new SecurityContextDecorator().decorate(pod);
+
+    Container container = pod.getSpec().getContainers().get(0);
+    assertNotNull(container.getSecurityContext());
+    assertFalse(container.getSecurityContext().getAllowPrivilegeEscalation());
+  }
+
+  @Test
+  void defaultsAllowPrivilegeEscalationButKeepsOtherFields() {
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName("driver")
+            .endMetadata()
+            .withNewSpec()
+            .addNewContainer()
+            .withName("driver")
+            .withNewSecurityContext()
+            .withReadOnlyRootFilesystem(true)
+            .endSecurityContext()
+            .endContainer()
+            .endSpec()
+            .build();
+
+    new SecurityContextDecorator().decorate(pod);
+
+    SecurityContext securityContext = pod.getSpec().getContainers().get(0).getSecurityContext();
+    assertFalse(securityContext.getAllowPrivilegeEscalation());
+    assertTrue(securityContext.getReadOnlyRootFilesystem());
+  }
+
+  @Test
+  void preservesExplicitAllowPrivilegeEscalation() {
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName("driver")
+            .endMetadata()
+            .withNewSpec()
+            .addNewContainer()
+            .withName("driver")
+            .withNewSecurityContext()
+            .withAllowPrivilegeEscalation(true)
+            .endSecurityContext()
+            .endContainer()
+            .endSpec()
+            .build();
+
+    new SecurityContextDecorator().decorate(pod);
+
+    assertTrue(
+        pod.getSpec().getContainers().get(0).getSecurityContext().getAllowPrivilegeEscalation());
+  }
+
+  @Test
+  void defaultsInitContainers() {
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName("driver")
+            .endMetadata()
+            .withNewSpec()
+            .addNewInitContainer()
+            .withName("init")
+            .endInitContainer()
+            .addNewContainer()
+            .withName("driver")
+            .endContainer()
+            .endSpec()
+            .build();
+
+    new SecurityContextDecorator().decorate(pod);
+
+    Container initContainer = pod.getSpec().getInitContainers().get(0);
+    Container container = pod.getSpec().getContainers().get(0);
+    assertFalse(initContainer.getSecurityContext().getAllowPrivilegeEscalation());
+    assertFalse(container.getSecurityContext().getAllowPrivilegeEscalation());
+  }
+
+  @Test
+  void defaultsStatefulSetTemplateContainers() {
+    StatefulSet statefulSet =
+        new StatefulSetBuilder()
+            .withNewMetadata()
+            .withName("worker")
+            .endMetadata()
+            .withNewSpec()
+            .withNewTemplate()
+            .withNewSpec()
+            .addNewContainer()
+            .withName("worker")
+            .endContainer()
+            .endSpec()
+            .endTemplate()
+            .endSpec()
+            .build();
+
+    new SecurityContextDecorator().decorate(statefulSet);
+
+    Container container = statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0);
+    assertFalse(container.getSecurityContext().getAllowPrivilegeEscalation());
+  }
+
+  @Test
+  void ignoresOtherResourceKinds() {
+    Service service =
+        new ServiceBuilder()
+            .withNewMetadata()
+            .withName("svc")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+
+    Service result = new SecurityContextDecorator().decorate(service);
+
+    assertSame(service, result);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `SecurityContextDecorator` that sets each container's `securityContext.allowPrivilegeEscalation` to `false` when it is unset, and apply it to the operator-created Pods:

- driver Pod (`SparkApplication`) in `SparkAppResourceSpecFactory`
- master/worker `StatefulSet`s (`SparkCluster`) in `SparkClusterResourceSpecFactory`

It only fills in the value when null, so a value the user set explicitly is preserved. Executor Pods (created by the Spark driver, not the operator) are out of scope.

### Why are the changes needed?

An unset `allowPrivilegeEscalation` is treated as `true` by Kubernetes, which violates the Pod Security Standards "restricted" profile. Defaulting it to `false` hardens operator-created Pods by default.

In addition, this is consistent with Apache Spark 4.3.0 behavior.
- https://github.com/apache/spark/pull/56549

### Does this PR introduce _any_ user-facing change?

Yes. Driver/master/worker containers now get `securityContext.allowPrivilegeEscalation: false` when the user did not set it. An explicitly set value (e.g. `true`) is kept.

### How was this patch tested?

Added `SecurityContextDecoratorTest` (unset, partially-set, explicit-value-preserved, init containers, `StatefulSet`, non-Pod no-op). `gradle build` passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)