### PR TITLE
[SPARK-57629] Upgrade `spotless-plugin-gradle` to 8.7.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ checkstyle = "13.4.2"
 pmd = "7.24.0"
 spotbugs-tool = "4.10.2"
 spotbugs-plugin = "6.5.6"
-spotless-plugin = "8.6.0"
+spotless-plugin = "8.7.0"
 
 # Packaging
 cyclonedx = "3.2.4"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades `spotless-plugin-gradle` to `8.7.0`.

### Why are the changes needed?

To use the latest release (`8.7.0`, released on 2026-06-16).
- https://github.com/diffplug/spotless/releases/tag/gradle/8.7.0
  - https://github.com/diffplug/spotless/pull/2962
  - https://github.com/diffplug/spotless/issues/2940
  - https://github.com/diffplug/spotless/pull/2973

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8