### PR TITLE
[SPARK-57630] Fix `publish_snapshot_chart` GitHub Actions job

### DIFF
--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -53,7 +53,7 @@ jobs:
         helm repo index tmp/$DIR --url https://nightlies.apache.org/spark/$DIR
         helm show chart tmp/$DIR/spark-kubernetes-operator-*.tgz
     - name: Upload
-      uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6
+      uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1
       with:
         switches: -avzr
         path: build-tools/helm/tmp/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `publish_snapshot_chart` GitHub Actions job by updating `burnett01/rsync-deployments` to an ASF-approved commit hash.

### Why are the changes needed?

`publish_snapshot_chart` is broken since last month because the old hash is outdated on the ASF `approved_patterns.yml` allowlist.
- https://github.com/apache/spark-kubernetes-operator/actions/workflows/publish_snapshot_chart.yml
  - https://github.com/apache/spark-kubernetes-operator/actions/runs/27994804602

    > The action burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 is not allowed in apache/spark-kubernetes-operator because ...

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI-only change. Verified the new hash is in ASF `approved_patterns.yml`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)