### PR TITLE
[SPARK-57706] Add one-zone `Spark Connect Server` example

### DIFF
--- a/examples/spark-connect-server-usw2-az2.yaml
+++ b/examples/spark-connect-server-usw2-az2.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: spark-connect-server-usw2-az2
+spec:
+  mainClass: "org.apache.spark.sql.connect.service.SparkConnectServer"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.minExecutors: "3"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
+    spark.kubernetes.executor.podNamePrefix: "spark-connect-server"
+    spark.scheduler.mode: "FAIR"
+  driverSpec:
+    podTemplateSpec:
+      spec:
+        nodeSelector:
+          topology.k8s.aws/zone-id: usw2-az2
+  executorSpec:
+    podTemplateSpec:
+      spec:
+        nodeSelector:
+          topology.k8s.aws/zone-id: usw2-az2
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.1.2"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add one-zone `Spark Connect Server` example.

### Why are the changes needed?

One-zone deployment is recommended to reduce the network cost among pods.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

```
$ kubectl get pod -l spark.operator/spark-app-name=spark-connect-server-usw2-az2
NAME                                     READY   STATUS    RESTARTS   AGE
spark-connect-server-exec-1              1/1     Running   0          87s
spark-connect-server-exec-2              1/1     Running   0          87s
spark-connect-server-exec-3              1/1     Running   0          87s
spark-connect-server-usw2-az2-0-driver   1/1     Running   0          93s
```

```
$ kubectl get pod -l spark.operator/spark-app-name=spark-connect-server-usw2-az2 -oyaml | grep zone-id
      topology.k8s.aws/zone-id: usw2-az2
      topology.k8s.aws/zone-id: usw2-az2
      topology.k8s.aws/zone-id: usw2-az2
      topology.k8s.aws/zone-id: usw2-az2
```

### Was this patch authored or co-authored using generative AI tooling?

No.