### PR TITLE
[SPARK-57788] Prevent Build CI cancellation between different commits in `main` branch

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -23,9 +23,10 @@ on:
   push:
     branches: [ "**" ]
 
-# Cancel previous build on the same branch
+# Cancel previous build on the same branch, except on `main` where different
+# commits (e.g. a re-run of an older commit) must not cancel each other
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR scopes the `Build` workflow `concurrency.group` by commit SHA on `main`, while keeping the existing branch-level grouping for all other branches:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
```

### Why are the changes needed?

With the branch-only key, all `Build` runs on a branch shared one concurrency group, and `cancel-in-progress: true` made unrelated runs cancel each other. Re-running an older commit's failed jobs on `main` cancelled the newest commit's in-progress CI.

Appending the commit SHA only on `main` ensures different commits no longer cancel each other there, while feature/PR branches keep the original behavior where a new push cancels the previous in-progress run on the same branch.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8