### PR TITLE
[SPARK-57794] Exclude 3rd party Maven metadata from shadow jar

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -94,6 +94,8 @@ shadowJar {
   exclude("org/apache/spark/ui/static/**")
   // Hadoop webapps (HDFS/YARN UI)
   exclude("webapps/**")
+  // Exclude 3rd party metadata to avoid conflicts
+  exclude("META-INF/maven/**")
   // Netty QUIC native libraries - not needed for K8s API server communication (HTTP/1.1 & HTTP/2)
   exclude("META-INF/native/libnetty_quiche*")
   exclude("META-INF/native/netty_quiche*")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes 3rd party Maven metadata (`META-INF/maven/**`) from the `spark-operator` shadow jar.

### Why are the changes needed?

`minimize()` strips unreachable classes but leaves the matching `pom.properties`/`pom.xml` behind, so orphaned Maven metadata remains for fully-removed dependencies. These files are build-time only and serve no runtime purpose.

For the record, we provide SBOM for trace-ability.
- #332

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.

**BEFORE**
```
$ gradle build -x test
$ jar tvf spark-operator/build/libs/spark-kubernetes-operator-1.0.0-SNAPSHOT-all.jar | grep maven | wc -l
     696
```

**AFTER**
```
$ gradle build -x test
$ jar tvf spark-operator/build/libs/spark-kubernetes-operator-1.0.0-SNAPSHOT-all.jar | grep maven | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8