### PR TITLE
[SPARK-57796] Exclude `org.checkerframework` dependency

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     exclude group: "commons-collections", module: "commons-collections"
     exclude group: "org.apache.commons", module: "commons-compress"
     exclude group: "org.apache.logging.log4j"
+    exclude group: "org.checkerframework"
     exclude group: "org.fusesource.leveldbjni"
     exclude group: "org.lz4"
     exclude group: "org.rocksdb"

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     exclude group: "org.apache.avro"
     exclude group: "org.apache.commons", module: "commons-compress"
     exclude group: "org.apache.logging.log4j"
+    exclude group: "org.checkerframework"
     exclude group: "org.fusesource.leveldbjni"
     exclude group: "org.lz4"
     exclude group: "org.rocksdb"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the `org.checkerframework` dependency (transitively pulled in by Spark via Guava) from the Spark dependency configurations in both `spark-submission-worker` (`spark-kubernetes`) and `spark-operator` (`spark-core`).

### Why are the changes needed?

`org.checkerframework:checker-qual` is a compile-time annotation-only artifact that is not needed at runtime. Excluding it removes an unnecessary dependency from the operator's runtime classpath and shaded jar.

Before this change, `checker-qual` appeared in the runtime classpath:

```
$ ./gradlew -q :spark-operator:dependencies --configuration runtimeClasspath | grep checker
     |    |                   +--- org.checkerframework:checker-qual:3.33.0
```

After this change, it is no longer present.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and verify that `org.checkerframework:checker-qual` is removed from the runtime classpath:

```
$ ./gradlew -q :spark-operator:dependencies --configuration runtimeClasspath | grep -ic checker
0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8