### PR TITLE
[SPARK-57798] Exclude `net.sf.py4j` dependency

### DIFF
--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     exclude group: "commons-codec"
     exclude group: "commons-collections", module: "commons-collections"
     exclude group: "io.fabric8"
+    exclude group: "net.sf.py4j"
     exclude group: "org.apache.avro"
     exclude group: "org.apache.commons", module: "commons-compress"
     exclude group: "org.apache.logging.log4j"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the transitive `net.sf.py4j:py4j` dependency from the operator shadow jar.

### Why are the changes needed?

`py4j` is PySpark's Python-to-JVM gateway, pulled in transitively by `spark-core`. It only runs inside the Spark driver pod, never in the operator JVM, yet all 71 `py4j/` classes were bundled into the operator fat jar as dead weight.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8