### PR TITLE
[SPARK-57799] Exclude `net.razorvine` dependency

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     exclude group: "com.ibm.icu"
     exclude group: "commons-codec"
     exclude group: "commons-collections", module: "commons-collections"
+    exclude group: "net.razorvine"
     exclude group: "org.apache.commons", module: "commons-compress"
     exclude group: "org.apache.logging.log4j"
     exclude group: "org.checkerframework"

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     exclude group: "commons-codec"
     exclude group: "commons-collections", module: "commons-collections"
     exclude group: "io.fabric8"
+    exclude group: "net.razorvine"
     exclude group: "org.apache.avro"
     exclude group: "org.apache.commons", module: "commons-compress"
     exclude group: "org.apache.logging.log4j"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the `net.razorvine` dependency (transitively pulled in by Spark) from `spark-submission-worker` (`spark-kubernetes`) and `spark-operator` (`spark-core`).

### Why are the changes needed?

`net.razorvine:pickle` is a PySpark serialization library that the operator never uses. Excluding it removes an unnecessary dependency from the runtime classpath and shaded jar.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8