### PR TITLE
[SPARK-57845] Exclude `org.roaringbitmap` dependency

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     exclude group: "org.checkerframework"
     exclude group: "org.fusesource.leveldbjni"
     exclude group: "org.lz4"
+    exclude group: "org.roaringbitmap"
     exclude group: "org.rocksdb"
     exclude group: "org.slf4j"
     exclude group: "org.xerial.snappy"

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     exclude group: "org.checkerframework"
     exclude group: "org.fusesource.leveldbjni"
     exclude group: "org.lz4"
+    exclude group: "org.roaringbitmap"
     exclude group: "org.rocksdb"
     exclude group: "org.slf4j"
     exclude group: "org.xerial.snappy"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the transitive `org.roaringbitmap:RoaringBitmap` dependency from the shaded operator jar by adding `exclude group: "org.roaringbitmap"` to the Spark dependency declarations in the `spark-operator` and `spark-submission-worker` modules.

### Why are the changes needed?

`RoaringBitmap` is pulled in transitively via `org.apache.spark:spark-network-common`, where Spark uses it for shuffle map status tracking (`HighlyCompressedMapStatus`). The operator only builds driver/submission specs and does not run the shuffle/executor runtime, so this library is unused. It belongs to the same category of shuffle/storage runtime libraries that are already excluded (`org.lz4`, `org.rocksdb`, `org.fusesource.leveldbjni`, `org.xerial.snappy`, `com.github.luben`). Removing it keeps the shaded jar lean and reduces the dependency surface.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8