### PR TITLE
[SPARK-57856] Authenticate `minikube` GitHub API requests to avoid CI rate limit failures

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -148,6 +148,8 @@ jobs:
           cache-provider: basic
       - name: Set up Minikube
         uses: medyagh/setup-minikube@v0.0.21
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache: true
           kubernetes-version: ${{ matrix.kubernetes-version }}
@@ -245,6 +247,8 @@ jobs:
           cache-provider: basic
       - name: Set up Minikube
         uses: medyagh/setup-minikube@v0.0.21
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           cache: true
           kubernetes-version: ${{ matrix.kubernetes-version }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `GITHUB_TOKEN` to the `medyagh/setup-minikube` steps in
`.github/workflows/build_and_test.yml` (the `k8s-integration-tests` and
`helm-tests` jobs) so that minikube authenticates its GitHub API requests.

### Why are the changes needed?

When starting minikube with a pinned `kubernetes-version` (e.g. `1.36.0`),
minikube resolves the exact version by querying the GitHub API
(`api.github.com/repos/kubernetes/kubernetes/releases/tags/v1.36.0`).
Without a token this request is unauthenticated and limited to 60 requests
per hour per runner IP. Because these jobs fan out across a large matrix
(`max-parallel: 20`), the shared limit is exhausted and the jobs fail with:

- https://github.com/apache/spark-kubernetes-operator/actions/runs/28527974981/job/84569529838

```
Exiting due to K8S_FAIL_CONNECT: error fetching Kubernetes version list from GitHub:
GET https://api.github.com/repos/kubernetes/kubernetes/releases/tags/v1.36.0:
403 API rate limit exceeded for 13.71.231.42.

(But here's the good news: Authenticated requests get a higher rate limit.
Check out the documentation for more details.) [rate reset in 41m27s]
```

Providing `GITHUB_TOKEN` switches minikube to authenticated requests, raising
the limit to 1,000 requests/hour per repository and removing the flaky failure.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Existing CI. The `k8s-integration-tests` and `helm-tests` jobs run minikube
setup and pass without hitting the GitHub API rate limit.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8