### PR TITLE
[SPARK-57857] Exclude `com.ning` dependency

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   compileOnly(libs.spark.core) {
     exclude group: "com.github.luben"
     exclude group: "com.ibm.icu"
+    exclude group: "com.ning"
     exclude group: "commons-codec"
     exclude group: "commons-collections", module: "commons-collections"
     exclude group: "net.razorvine"

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation(libs.spark.kubernetes) {
     exclude group: "com.github.luben"
     exclude group: "com.ibm.icu"
+    exclude group: "com.ning"
     exclude group: "commons-codec"
     exclude group: "commons-collections", module: "commons-collections"
     exclude group: "io.fabric8"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the transitive `com.ning:compress-lzf` dependency from the shaded operator jar.

### Why are the changes needed?

`compress-lzf` is pulled in via `spark-core` as a shuffle/broadcast compression codec. The operator only builds driver/submission specs and never runs it, like the other already-excluded runtime codecs (`org.lz4`, `org.xerial.snappy`, `com.github.luben`, `org.roaringbitmap`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8