### PR TITLE
[SPARK-57859] Exclude `com.esotericsoftware` dependency

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   implementation(libs.metrics.core)
   implementation(libs.metrics.jvm)
   compileOnly(libs.spark.core) {
+    exclude group: "com.esotericsoftware"
     exclude group: "com.github.luben"
     exclude group: "com.ibm.icu"
     exclude group: "com.ning"

--- a/spark-submission-worker/build.gradle
+++ b/spark-submission-worker/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation(libs.slf4j.api)
 
   implementation(libs.spark.kubernetes) {
+    exclude group: "com.esotericsoftware"
     exclude group: "com.github.luben"
     exclude group: "com.ibm.icu"
     exclude group: "com.ning"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the transitive `com.esotericsoftware` dependency from the shaded operator jar.

### Why are the changes needed?

`com.esotericsoftware:kryo-shaded` is pulled in via `spark-core` (directly and through `com.twitter:chill`) as a serializer. The operator only builds driver/submission specs and never runs it, like the other already-excluded runtime codecs and serializers (`org.lz4`, `org.xerial.snappy`, `com.github.luben`, `org.roaringbitmap`, `com.ning`).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8