### PR TITLE
[SPARK-57874] Exclude Hadoop MapReduce resources from shadow jar

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -104,6 +104,8 @@ shadowJar {
   // Hadoop MapReduce classes - not used for K8s deployment
   exclude("org/apache/hadoop/mapred/**")
   exclude("org/apache/hadoop/mapreduce/**")
+  exclude("mapred-default.xml")
+  exclude("META-INF/services/org.apache.hadoop.mapreduce.protocol.ClientProtocolProvider")
   // Exclude 3rd party metadata to avoid conflicts
   exclude("META-INF/maven/**")
   // Netty QUIC native libraries - not needed for K8s API server communication (HTTP/1.1 & HTTP/2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the remaining Hadoop MapReduce resource files from the operator shadow jar.

- `mapred-default.xml`
- `META-INF/services/org.apache.hadoop.mapreduce.protocol.ClientProtocolProvider`

### Why are the changes needed?

SPARK-57871 excluded the Hadoop MapReduce classes, but these two resource files remain.
They are dead resources because the classes that use them (`JobConf`, `YarnClientProtocolProvider`,
`LocalClientProtocolProvider`) are already excluded. This shrinks the shadow jar by ~21KB.

- https://github.com/apache/spark-kubernetes-operator/pull/732

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5