### PR TITLE
[SPARK-57875] Exclude Hadoop `filecache` classes from shadow jar

### DIFF
--- a/spark-operator/build.gradle
+++ b/spark-operator/build.gradle
@@ -102,6 +102,7 @@ shadowJar {
   // Hadoop YARN classes - not used for K8s deployment
   exclude("org/apache/hadoop/yarn/**")
   // Hadoop MapReduce classes - not used for K8s deployment
+  exclude("org/apache/hadoop/filecache/**")
   exclude("org/apache/hadoop/mapred/**")
   exclude("org/apache/hadoop/mapreduce/**")
   exclude("mapred-default.xml")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR excludes the Hadoop `filecache` package (`org/apache/hadoop/filecache/**`) from the
operator shadow jar by adding a class-path filter to the `shadowJar` block in
`spark-operator/build.gradle`.

### Why are the changes needed?

The operator never uses Hadoop `DistributedCache`. While the `minimize` step already drops the
unreferenced `DistributedCache` class, the package directory entry and `package-info.class`
(from `hadoop-client-api`) still remain in the shadow jar. This change removes those leftover
entries explicitly, consistent with the existing MapReduce exclusions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5