### PR TITLE
[SPARK-57886] Upgrade `spotless-plugin-gradle` to 8.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ checkstyle = "13.4.2"
 pmd = "7.24.0"
 spotbugs-tool = "4.10.2"
 spotbugs-plugin = "6.5.6"
-spotless-plugin = "8.7.0"
+spotless-plugin = "8.8.0"
 
 # Packaging
 cyclonedx = "3.2.4"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotless-plugin-gradle` to 8.8.0.

### Why are the changes needed?

To bring the latest bug fixes and improvements.

- https://github.com/diffplug/spotless/releases/tag/gradle%2F8.8.0

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the CI