### PR TITLE
[SPARK-57887] Upgrade `spotbugs-gradle-plugin` to 6.5.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ awaitility = "4.3.0"
 checkstyle = "13.4.2"
 pmd = "7.24.0"
 spotbugs-tool = "4.10.2"
-spotbugs-plugin = "6.5.6"
+spotbugs-plugin = "6.5.8"
 spotless-plugin = "8.7.0"
 
 # Packaging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotbugs-gradle-plugin` to 6.5.8.

### Why are the changes needed?

To bring the latest bug fixes.

- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.8
- https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.5.7

### Does this PR introduce _any_ user-facing change?

No, this is a build-time dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5