### PR TITLE
[SPARK-57917] Fix workload RoleBinding name in operator namespace

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -144,7 +144,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $workloadResources.serviceAccount.name }}
+  name: {{ $workloadResources.roleBinding.name }}
   namespace: {{ $systemNs }}
 {{- template "spark-operator.workloadLabelsAnnotations" $ }}
 {{- template "spark-operator.workloadRoleRef" $ }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the workload `RoleBinding` name in `workload-rbac.yaml` to use
`$workloadResources.roleBinding.name` instead of `$workloadResources.serviceAccount.name`
when `workloadResources.namespaces.data` is empty, consistent with the per-namespace branch.

### Why are the changes needed?

The `RoleBinding` was named `spark` (the service account name) instead of the intended
`spark-workload-rolebinding`.

### Does this PR introduce _any_ user-facing change?

Yes. The `RoleBinding` in the operator namespace is now named `spark-workload-rolebinding`
instead of `spark`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5