### PR TITLE
[SPARK-57918] Use `Files.createTempFile` instead of `File.createTempFile` to ensure owner-only temp file

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkAppResourceSpecFactory.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/reconciler/SparkAppResourceSpecFactory.java
@@ -30,6 +30,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -203,7 +204,7 @@ public final class SparkAppResourceSpecFactory {
   private static String createLocalFileForPodTemplateSpec(
       final PodTemplateSpec podTemplateSpec, final String tempFilePrefix) {
     try {
-      File tmpFile = File.createTempFile(tempFilePrefix, ".json");
+      File tmpFile = Files.createTempFile(tempFilePrefix, ".json").toFile();
       try (OutputStreamWriter writer =
           new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
         writer.write(ModelUtils.asJsonString(ModelUtils.getPodFromTemplateSpec(podTemplateSpec)));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to replace `File.createTempFile` with `Files.createTempFile` in
`SparkAppResourceSpecFactory` to guarantee that the pod template temp file is
created with owner-only permissions.

### Why are the changes needed?

`SparkAppResourceSpecFactory.createLocalFileForPodTemplateSpec` writes the driver/executor
`PodTemplateSpec` (which may contain sensitive information such as environment variables)
to a local temporary file. `File.createTempFile` creates the file with permissions subject
to the process `umask` (e.g., `0644`), which may allow other users on the same host to read it.
`java.nio.file.Files.createTempFile` guarantees owner-only permissions (`0600`) on
POSIX file systems.

Before:

```
-rw-r--r--  ... <uid>-driver-XXXX.json
```

After:

```
-rw-------  ... <uid>-driver-XXXX.json
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5