### PR TITLE
[SPARK-57940] Enable `readOnlyRootFilesystem` for operator container in Helm chart

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/spark-operator.yaml
@@ -148,6 +148,8 @@ spec:
               mountPath: /opt/spark-operator/conf
             - name: logs-volume
               mountPath: /opt/spark-operator/logs
+            - name: tmp-volume
+              mountPath: /tmp
             {{- if and .Values.operatorConfiguration.dynamicConfig.enable (eq .Values.operatorConfiguration.dynamicConfig.source "file") }}
             - name: spark-operator-dynamic-config-volume
               mountPath: /opt/spark-operator/dynamic-conf
@@ -174,6 +176,8 @@ spec:
           configMap:
             name: spark-kubernetes-operator-configuration
         - name: logs-volume
+          emptyDir: { }
+        - name: tmp-volume
           emptyDir: { }
         {{- if and .Values.operatorConfiguration.dynamicConfig.enable (eq .Values.operatorConfiguration.dynamicConfig.source "file") }}
         - name: spark-operator-dynamic-config-volume

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -78,6 +78,7 @@ operatorDeployment:
         capabilities:
           drop:
             - ALL
+        readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 185
         seccompProfile:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `readOnlyRootFilesystem` for the operator container in the Helm chart.

Since the operator writes temporary files under `java.io.tmpdir` (SPARK-57918), an `emptyDir`
volume is mounted at `/tmp`, following the existing `logs-volume` pattern.

### Why are the changes needed?

A read-only root filesystem prevents tampering with the container image at runtime and
completes the CIS Benchmark hardening on top of the existing restricted Pod Security
Standard compliance.

### Does this PR introduce _any_ user-facing change?

Yes. The operator container root filesystem becomes read-only by default; writable paths are
provided via `emptyDir` volumes (`/tmp`, `/opt/spark-operator/logs`). Users can override
`operatorDeployment.operatorPod.operatorContainer.securityContext` if needed.

### How was this patch tested?

Pass the CIs. Also manually verified with `helm lint --strict` and `helm template`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5