### PR TITLE
[SPARK-57942] Replace wildcard RBAC verbs with explicit verb list in Helm chart

### DIFF
--- a/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/operator-rbac.yaml
@@ -27,45 +27,87 @@ rules:
       - persistentvolumeclaims
       - events
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - "apps"
     resources:
       - statefulsets
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - "autoscaling"
     resources:
       - horizontalpodautoscalers
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - "spark.apache.org"
     resources:
       - '*'
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - "networking.k8s.io"
     resources:
       - ingresses
       - networkpolicies
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - "policy"
     resources:
       - poddisruptionbudgets
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 {{- if gt (int .Values.operatorDeployment.replicas) 1 }}
   - apiGroups:
       - "coordination.k8s.io"
     resources:
       - leases
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 {{- end }}
 {{- end }}
 
@@ -131,7 +173,13 @@ rules:
     resources:
       - configmaps
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/templates/workload-rbac.yaml
@@ -26,13 +26,25 @@ rules:
       - configmaps
       - persistentvolumeclaims
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - "apps"
     resources:
       - statefulsets
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to replace the wildcard `verbs: ['*']` in the Helm chart RBAC rules
(`operator-rbac.yaml` and `workload-rbac.yaml`) with the explicit verb list
`get, list, watch, create, update, patch, delete`.

### Why are the changes needed?

This addresses CIS Kubernetes Benchmark 5.1.3 (minimize wildcard use in Roles and
ClusterRoles). The operator uses informers (`get`/`list`/`watch`), server-side apply
(`create`/`patch`), status updates and sentinel replacement (`update`), and resource
cleanup (`delete`). Unused verbs such as `deletecollection` are no longer granted.

### Does this PR introduce _any_ user-facing change?

Yes. The generated (Cluster)Roles enumerate verbs explicitly instead of `*`; permissions
such as `deletecollection` are no longer granted. No operator behavior change is expected.

### How was this patch tested?

Pass the CIs. Also manually verified with `helm lint --strict` and `helm template`
(default values and all conditional branches).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5