### PR TITLE
[SPARK-57943] MetricsSystem should not expose sink property values

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/MetricsSystem.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/MetricsSystem.java
@@ -110,7 +110,7 @@ public class MetricsSystem {
    * via reflection.
    */
   protected void registerSinks() {
-    log.info("sinkPropertiesMap: {}", sinkPropertiesMap);
+    log.info("Configured metrics sinks: {}", sinkPropertiesMap.keySet());
     sinkPropertiesMap
         .values()
         .forEach(
@@ -130,12 +130,7 @@ public class MetricsSystem {
                   | NoSuchMethodException
                   | SecurityException
                   | ClassNotFoundException e) {
-                if (log.isErrorEnabled()) {
-                  log.error(
-                      "Fail to create metrics sink for sink name {}, sink properties {}",
-                      sinkProp.getClassName(),
-                      sinkProp.getProperties());
-                }
+                log.error("Fail to create metrics sink for sink class {}", sinkProp.getClassName());
                 throw new IllegalStateException("Fail to create metrics sink", e);
               }
             });


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to prevent metrics sink properties from being logged in `MetricsSystem`.

- `registerSinks()` logs only the sink names instead of the entire `sinkPropertiesMap`.
- The error log on sink creation failure reports only the sink class name, not the properties.

### Why are the changes needed?

Sink properties can contain sensitive values such as credentials, which should not be leaked into operator logs.

### Does this PR introduce _any_ user-facing change?

No, except the log messages.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5