### PR TITLE
[SPARK-57968] Use virtual threads for `SentinelManager` scheduled executor

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManager.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/metrics/healthcheck/SentinelManager.java
@@ -54,7 +54,8 @@ public class SentinelManager<CR extends BaseResource<?, ?, ?, ?, ?>> {
 
   private final ScheduledExecutorService executorService =
       Executors.newScheduledThreadPool(
-          SparkOperatorConf.SENTINEL_EXECUTOR_SERVICE_POOL_SIZE.getValue());
+          SparkOperatorConf.SENTINEL_EXECUTOR_SERVICE_POOL_SIZE.getValue(),
+          Thread.ofVirtual().name("sentinel-", 0).factory());
 
   /**
    * Checks if a given resource is a sentinel resource.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use virtual threads for the `SentinelManager` scheduled executor by providing a virtual thread factory.

### Why are the changes needed?

- The sentinel health-check workers spend most of their time on Kubernetes API calls (network I/O), which is an ideal workload for virtual threads.

- In addition, the worker threads now have meaningful names (`sentinel-0`, `sentinel-1`, ...) instead of the anonymous default (`pool-N-thread-M`), which helps thread-dump analysis.

- Note on behavior change: the workers change from non-daemon platform threads to daemon virtual threads (virtual threads are always daemon). This does not affect JVM liveness in practice because the operator process is kept alive by the `com.sun.net.httpserver` dispatcher thread (non-daemon) and the Java Operator SDK threads.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5