### PR TITLE
[SPARK-57969] Use virtual thread for periodic GC scheduler

### DIFF
--- a/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
+++ b/spark-operator/src/main/java/org/apache/spark/k8s/operator/SparkOperator.java
@@ -124,11 +124,7 @@ public class SparkOperator {
     if (periodicGcIntervalSeconds > 0L) {
       this.periodicGcScheduler =
           Executors.newSingleThreadScheduledExecutor(
-              r -> {
-                Thread t = new Thread(r, "spark-operator-periodic-gc");
-                t.setDaemon(true);
-                return t;
-              });
+              Thread.ofVirtual().name("periodic-gc").factory());
       this.periodicGcScheduler.scheduleAtFixedRate(
           SparkOperator::runSystemGc,
           periodicGcIntervalSeconds,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use a virtual thread factory for the periodic GC scheduler thread in `SparkOperator`.

### Why are the changes needed?

The scheduled task (`SparkOperator::runSystemGc`) is short and periodic, which is an ideal fit for a virtual thread. Virtual threads are always daemon threads, so the existing daemon semantics are preserved.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5