### PR TITLE
[SPARK-58090] Add `doc.crds.dev` link to Spark custom resources documentation

### DIFF
--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -29,6 +29,10 @@ kubectl by the user, orchestrate secondary resources (pods, configmaps .etc).
 
 Please check out the [quickstart](../README.md) as well for installing operator.
 
+The full CRD schemas (all `spec` and `status` fields with types and descriptions) can be
+browsed on the web at
+[doc.crds.dev](https://doc.crds.dev/github.com/apache/spark-kubernetes-operator).
+
 ## SparkApplication
 
 SparkApplication can be defined in YAML format. User may configure the application entrypoint


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a `doc.crds.dev` link to `docs/spark_custom_resources.md` so that users can browse the full `SparkApplication` and `SparkCluster` CRD schemas on the web.

- https://doc.crds.dev/github.com/apache/spark-kubernetes-operator

### Why are the changes needed?

`doc.crds.dev` is a community service that indexes CRDs from public git repositories and renders all `spec` and `status` fields with types and descriptions in a browsable form. It already indexes this repository, so linking it from the custom resources documentation lets users explore the full CRD schemas without cloning the repository or reading the raw CRD YAML files.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?

Manual review. Verified that the link resolves and shows the `SparkApplication` and `SparkCluster` CRDs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5