### PR TITLE
[SPARK-58145] Upgrade `Apache Celeborn` to 0.6.3

### DIFF
--- a/examples/word-count-celeborn.yaml
+++ b/examples/word-count-celeborn.yaml
@@ -23,7 +23,7 @@ spec:
   sparkConf:
     spark.celeborn.master.endpoints: "celeborn-master-0.celeborn-master-svc:9097"
     spark.jars.ivy: "/tmp/.ivy2.5.2"
-    spark.jars.packages: "org.apache.celeborn:celeborn-client-spark-4-shaded_2.13:0.6.2"
+    spark.jars.packages: "org.apache.celeborn:celeborn-client-spark-4-shaded_2.13:0.6.3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.0.3-scala"
     spark.kubernetes.driver.limit.cores: "5"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Celeborn to 0.6.3 in the `word-count-celeborn` example.

### Why are the changes needed?

Apache Celeborn 0.6.3 is the latest version with bug fixes and improvements.

- https://celeborn.apache.org/community/release_notes/release_note_0.6.3

### Does this PR introduce _any_ user-facing change?

No, this is an example-only change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5