### PR TITLE
[SPARK-58194] Upgrade docker images to Apache Spark 4.2.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -133,7 +133,7 @@ jobs:
             test-group: pi-with-gluten
           - kubernetes-version: "1.36.0"
             mode: static
-            test-group: pi-preview
+            test-group: pi-java25
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ ./examples/submit-pi-to-prod.sh
 {
   "action" : "CreateSubmissionResponse",
   "message" : "Driver successfully submitted as driver-20260110030233-0000",
-  "serverSparkVersion" : "4.1.2",
+  "serverSparkVersion" : "4.2.0",
   "submissionId" : "driver-20260110030233-0000",
   "success" : true
 }
@@ -105,7 +105,7 @@ $ curl http://localhost:6066/v1/submissions/status/driver-20260110030233-0000/
 {
   "action" : "SubmissionStatusResponse",
   "driverState" : "FINISHED",
-  "serverSparkVersion" : "4.1.2",
+  "serverSparkVersion" : "4.2.0",
   "submissionId" : "driver-20260110030233-0000",
   "success" : true,
   "workerHostPort" : "10.1.1.172:44233",
@@ -142,7 +142,7 @@ Events:
   Normal  Scheduling         1s    yunikorn  default/pi-on-yunikorn-0-driver is queued and waiting for allocation
   Normal  Scheduled          1s    yunikorn  Successfully assigned default/pi-on-yunikorn-0-driver to node docker-desktop
   Normal  PodBindSuccessful  1s    yunikorn  Pod default/pi-on-yunikorn-0-driver is successfully bound to node docker-desktop
-  Normal  Pulled             0s    kubelet   Container image "apache/spark:4.1.2-scala" already present on machine
+  Normal  Pulled             0s    kubelet   Container image "apache/spark:4.2.0-scala" already present on machine
   Normal  Created            0s    kubelet   Created container: spark-kubernetes-driver
   Normal  Started            0s    kubelet   Started container spark-kubernetes-driver
 

--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -52,12 +52,12 @@ spec:
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.2-scala"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-scala"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
 ```
 
 After application is submitted, Operator will add status information to your application based on

--- a/examples/cluster-on-yunikorn.yaml
+++ b/examples/cluster-on-yunikorn.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-on-yunikorn
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/cluster-with-hpa-template.yaml
+++ b/examples/cluster-with-hpa-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-hpa-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/cluster-with-hpa.yaml
+++ b/examples/cluster-with-hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-hpa
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/cluster-with-jws-filter.yaml
+++ b/examples/cluster-with-jws-filter.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-jws-filter
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/cluster-with-template.yaml
+++ b/examples/cluster-with-template.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster-with-template
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: cluster
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/dfs-read-write.yaml
+++ b/examples/dfs-read-write.yaml
@@ -41,4 +41,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-java17.yaml
+++ b/examples/pi-java17.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-java25-deployment.yaml
+++ b/examples/pi-java25-deployment.yaml
@@ -15,18 +15,18 @@
 apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
-  name: pi-preview
+  name: pi-java25-deployment
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
+  driverArgs: ["20000"]
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
-    spark.dynamicAllocation.enabled: "true"
-    spark.dynamicAllocation.shuffleTracking.enabled: "true"
-    spark.dynamicAllocation.maxExecutors: "3"
+    spark.executor.instances: "3"
+    spark.kubernetes.allocation.pods.allocator: "deployment"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-scala-java25"
   applicationTolerations:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.2.0-preview5"
+    sparkVersion: "4.2.0"

--- a/examples/pi-java25-with-executor-resize-plugin.yaml
+++ b/examples/pi-java25-with-executor-resize-plugin.yaml
@@ -15,7 +15,7 @@
 apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
-  name: pi-preview-with-executor-resize-plugin
+  name: pi-java25-with-executor-resize-plugin
 spec:
   mainClass: "org.apache.spark.examples.SparkPi"
   driverArgs: ["200000"]
@@ -25,7 +25,7 @@ spec:
     spark.dynamicAllocation.maxExecutors: "1"
     spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-scala-java25"
     spark.kubernetes.executor.resizeInterval: "1min"
     spark.kubernetes.executor.resizeThreshold: "0.25"
     spark.plugins: "org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin"
@@ -33,4 +33,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.2.0-preview5"
+    sparkVersion: "4.2.0"

--- a/examples/pi-java25.yaml
+++ b/examples/pi-java25.yaml
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -6,27 +5,28 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
 apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
-  name: pi-preview
-  namespace: ($SPARK_APP_NAMESPACE)
-status:
-  stateTransitionHistory:
-    (*.currentStateSummary):
-      - "Submitted"
-      - "DriverRequested"
-      - "DriverStarted"
-      - "DriverReady"
-      - "RunningHealthy"
-      - "Succeeded"
-      - "ResourceReleased"
+  name: pi-java25
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.dynamicAllocation.enabled: "true"
+    spark.dynamicAllocation.shuffleTracking.enabled: "true"
+    spark.dynamicAllocation.maxExecutors: "3"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-scala-java25"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.2.0"

--- a/examples/pi-on-volcano.yaml
+++ b/examples/pi-on-volcano.yaml
@@ -33,4 +33,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-on-yunikorn.yaml
+++ b/examples/pi-on-yunikorn.yaml
@@ -34,4 +34,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-python.yaml
+++ b/examples/pi-python.yaml
@@ -27,4 +27,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-statefulset.yaml
+++ b/examples/pi-statefulset.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-v1beta1.yaml
+++ b/examples/pi-v1beta1.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-driver-timeout.yaml
+++ b/examples/pi-with-driver-timeout.yaml
@@ -32,4 +32,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-eventlog.yaml
+++ b/examples/pi-with-eventlog.yaml
@@ -40,4 +40,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-instanceconfig.yaml
+++ b/examples/pi-with-instanceconfig.yaml
@@ -31,4 +31,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-on-demand-pvc.yaml
+++ b/examples/pi-with-on-demand-pvc.yaml
@@ -35,4 +35,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-one-pod.yaml
+++ b/examples/pi-with-one-pod.yaml
@@ -26,4 +26,4 @@ spec:
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-spark-connect-plugin.yaml
+++ b/examples/pi-with-spark-connect-plugin.yaml
@@ -30,4 +30,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi-with-template.yaml
+++ b/examples/pi-with-template.yaml
@@ -38,4 +38,4 @@ spec:
         priorityClassName: system-cluster-critical
         terminationGracePeriodSeconds: 0
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -29,4 +29,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/prod-cluster-with-three-workers.yaml
+++ b/examples/prod-cluster-with-three-workers.yaml
@@ -18,7 +18,7 @@ metadata:
   name: prod
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 3

--- a/examples/qa-cluster-with-one-worker.yaml
+++ b/examples/qa-cluster-with-one-worker.yaml
@@ -18,7 +18,7 @@ metadata:
   name: qa
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/examples/spark-connect-server-usw2-az2.yaml
+++ b/examples/spark-connect-server-usw2-az2.yaml
@@ -41,4 +41,4 @@ spec:
     resourceRetainPolicy: OnFailure
     ttlAfterStopMillis: 10000
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/spark-connect-server-with-spark-cluster.yaml
+++ b/examples/spark-connect-server-with-spark-cluster.yaml
@@ -26,4 +26,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.ui.reverseProxy: "true"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/spark-connect-server.yaml
+++ b/examples/spark-connect-server.yaml
@@ -30,4 +30,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/spark-history-server-with-jws-filter.yaml
+++ b/examples/spark-history-server-with-jws-filter.yaml
@@ -39,7 +39,7 @@ spec:
     spark.ui.filters: "org.apache.spark.ui.JWSFilter"
     spark.org.apache.spark.ui.JWSFilter.param.secretKey: "VmlzaXQgaHR0cHM6Ly9zcGFyay5hcGFjaGUub3JnIHRvIGRvd25sb2FkIEFwYWNoZSBTcGFyay4="
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/spark-history-server.yaml
+++ b/examples/spark-history-server.yaml
@@ -36,7 +36,7 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/spark-thrift-server.yaml
+++ b/examples/spark-thrift-server.yaml
@@ -28,7 +28,7 @@ spec:
     spark.kubernetes.executor.podNamePrefix: "spark-thrift-server"
     spark.scheduler.mode: "FAIR"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   applicationTolerations:
     restartConfig:
       restartPolicy: Always

--- a/examples/sql.yaml
+++ b/examples/sql.yaml
@@ -27,4 +27,4 @@ spec:
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/stream-word-count.yaml
+++ b/examples/stream-word-count.yaml
@@ -37,4 +37,4 @@ spec:
     spark.hadoop.fs.s3a.access.key: "test"
     spark.hadoop.fs.s3a.secret.key: "test"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/examples/word-count.yaml
+++ b/examples/word-count.yaml
@@ -28,4 +28,4 @@ spec:
   applicationTolerations:
     resourceRetainPolicy: OnFailure
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkClusterResourceSpec.java
@@ -69,7 +69,7 @@ public class SparkClusterResourceSpec {
     String clusterName = cluster.getMetadata().getName();
     String scheduler = conf.get(Config.KUBERNETES_SCHEDULER_NAME().key(), "default-scheduler");
     String namespace = conf.get(Config.KUBERNETES_NAMESPACE().key(), clusterNamespace);
-    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.1.2");
+    String image = conf.get(Config.CONTAINER_IMAGE().key(), "apache/spark:4.2.0");
     ClusterSpec spec = cluster.getSpec();
     String version = spec.getRuntimeVersions().getSparkVersion();
     StringBuilder options = new StringBuilder();

--- a/tests/benchmark/sparkapps.sh
+++ b/tests/benchmark/sparkapps.sh
@@ -46,7 +46,7 @@ spec:
     spark.kubernetes.driver.pod.excludedFeatureSteps: "org.apache.spark.deploy.k8s.features.KerberosConfDriverFeatureStep"
     spark.kubernetes.driver.request.cores: "100m"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
 ---
 EOF
 done

--- a/tests/e2e/driver-start-timeout/spark-example-driver-start-timeout.yaml
+++ b/tests/e2e/driver-start-timeout/spark-example-driver-start-timeout.yaml
@@ -31,4 +31,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:non-existent-image"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/tests/e2e/pi-java25/chainsaw-test.yaml
+++ b/tests/e2e/pi-java25/chainsaw-test.yaml
@@ -18,13 +18,13 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: spark-operator-pi-preview-validation
+  name: spark-operator-pi-java25-validation
 spec:
   namespace: default
   steps:
   - try:
     - apply:
-        file: ../../../examples/pi-preview.yaml
+        file: ../../../examples/pi-java25.yaml
     - assert:
         bindings:
           - name: SPARK_APP_NAMESPACE
@@ -37,7 +37,7 @@ spec:
         kind: SparkApplication
         namespace: default
     - podLogs:
-        selector: spark-app-name=pi-preview
+        selector: spark-app-name=pi-java25
         namespace: default
     - podLogs:
         selector: app.kubernetes.io/name=spark-kubernetes-operator
@@ -46,4 +46,4 @@ spec:
     - script:
         timeout: 120s
         content: |
-          kubectl delete sparkapplication pi-preview --ignore-not-found=true
+          kubectl delete sparkapplication pi-java25 --ignore-not-found=true

--- a/tests/e2e/pi-java25/spark-state-transition.yaml
+++ b/tests/e2e/pi-java25/spark-state-transition.yaml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -5,28 +6,27 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+
 apiVersion: spark.apache.org/v1
 kind: SparkApplication
 metadata:
-  name: pi-preview-deployment
-spec:
-  mainClass: "org.apache.spark.examples.SparkPi"
-  driverArgs: ["20000"]
-  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
-  sparkConf:
-    spark.executor.instances: "3"
-    spark.kubernetes.allocation.pods.allocator: "deployment"
-    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.2.0-preview5-scala"
-  applicationTolerations:
-    resourceRetainPolicy: OnFailure
-    ttlAfterStopMillis: 10000
-  runtimeVersions:
-    sparkVersion: "4.2.0-preview5"
+  name: pi-java25
+  namespace: ($SPARK_APP_NAMESPACE)
+status:
+  stateTransitionHistory:
+    (*.currentStateSummary):
+      - "Submitted"
+      - "DriverRequested"
+      - "DriverStarted"
+      - "DriverReady"
+      - "RunningHealthy"
+      - "Succeeded"
+      - "ResourceReleased"

--- a/tests/e2e/python/chainsaw-test.yaml
+++ b/tests/e2e/python/chainsaw-test.yaml
@@ -23,11 +23,11 @@ spec:
   scenarios:
     - bindings:
         - name: "SPARK_VERSION"
-          value: "4.1.2"
+          value: "4.2.0"
         - name: "SCALA_VERSION"
           value: "2.13"
         - name: "IMAGE"
-          value: "apache/spark:4.1.2-python3"
+          value: "apache/spark:4.2.0-python3"
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/resource-retain-duration/spark-example-retain-duration.yaml
+++ b/tests/e2e/resource-retain-duration/spark-example-retain-duration.yaml
@@ -32,4 +32,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/tests/e2e/resource-retain-on-failure/spark-example-retain-on-failure.yaml
+++ b/tests/e2e/resource-retain-on-failure/spark-example-retain-on-failure.yaml
@@ -30,4 +30,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/tests/e2e/resource-selector/chainsaw-test.yaml
+++ b/tests/e2e/resource-selector/chainsaw-test.yaml
@@ -27,9 +27,9 @@ spec:
         - name: SPARK_APPLICATION_NAME
           value: "spark-example-resource-selector"
         - name: SPARK_VERSION
-          value: "4.1.2"
+          value: "4.2.0"
         - name: IMAGE
-          value: "apache/spark:4.1.2-scala"
+          value: "apache/spark:4.2.0-scala"
   steps:
     - name: install-spark-application-and-apply-label
       try:

--- a/tests/e2e/spark-versions/chainsaw-test.yaml
+++ b/tests/e2e/spark-versions/chainsaw-test.yaml
@@ -23,22 +23,22 @@ spec:
   scenarios:
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.1.2"
+        value: "4.2.0"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "17"
       - name: "IMAGE"
-        value: "apache/spark:4.1.2-scala-java17"
+        value: "apache/spark:4.2.0-scala-java17"
   - bindings:
       - name: "SPARK_VERSION"
-        value: "4.1.2"
+        value: "4.2.0"
       - name: "SCALA_VERSION"
         value: "2.13"
       - name: "JAVA_VERSION"
         value: "21"
       - name: "IMAGE"
-        value: 'apache/spark:4.1.2-scala'
+        value: 'apache/spark:4.2.0-scala'
   steps:
     - name: install-spark-application
       try:

--- a/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-cluster-example-succeeded.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 spec:
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"
   clusterTolerations:
     instanceConfig:
       initWorkers: 1

--- a/tests/e2e/state-transition/spark-example-succeeded.yaml
+++ b/tests/e2e/state-transition/spark-example-succeeded.yaml
@@ -28,4 +28,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/tests/e2e/watched-namespaces-file/spark-example.yaml
+++ b/tests/e2e/watched-namespaces-file/spark-example.yaml
@@ -28,4 +28,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"

--- a/tests/e2e/watched-namespaces/spark-example.yaml
+++ b/tests/e2e/watched-namespaces/spark-example.yaml
@@ -28,4 +28,4 @@ spec:
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.2.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Spark 4.2.0 docker images instead of `4.1.2` and `4.2.0-preview5`.

- Rename `pi-preview*` examples and the `pi-preview` E2E test to `pi-java25*` with `apache/spark:4.2.0-scala-java25` image.
- Update all examples, E2E tests, benchmark script, and docs from `4.1.2` to `4.2.0`.
- Update the default Spark cluster image of `SparkClusterResourceSpec` from `apache/spark:4.1.2` to `apache/spark:4.2.0`.

Note that `pi-with-comet.yaml` stays on `4.1.2` because `Apache DataFusion Comet` does not provide a Spark 4.2 artifact yet, like `pi-with-gluten.yaml` stays on `4.0.3`.

### Why are the changes needed?

Since Apache Spark 4.2.0 is released, the examples and tests should use the official release images instead of the preview and old versions. The build dependency is already on Spark 4.2.0 in `gradle/libs.versions.toml`.

### Does this PR introduce _any_ user-facing change?

Yes, the default Spark cluster image becomes `apache/spark:4.2.0`, and the examples are updated. However, this is a consistent behavior change with the already-upgraded Spark 4.2.0 dependency.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5