### PR TITLE
[SPARK-58288] Bump version to 1.1.0-SNAPSHOT in `main` branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ there, never inline in a module.
 ## Module Layout
 
 Gradle multi-project build (see [settings.gradle](settings.gradle)); root group is
-`org.apache.spark.k8s.operator`, version `1.0.0-SNAPSHOT`.
+`org.apache.spark.k8s.operator`, version `1.1.0-SNAPSHOT`.
 
 - `spark-operator-api/` — CRD model: `SparkApplication` / `SparkCluster` spec, status, and diff
   types. Minimal dependencies (fabric8 `kubernetes-client` only); CRDs are generated here.

--- a/build-tools/helm/spark-kubernetes-operator/Chart.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/Chart.yaml
@@ -14,8 +14,8 @@
 # limitations under the License.
 apiVersion: v2
 name: spark-kubernetes-operator
-version: 1.8.0-dev
-appVersion: 1.0.0-SNAPSHOT
+version: 1.9.0-dev
+appVersion: 1.1.0-SNAPSHOT
 description: The official Helm chart to deploy Apache Spark, an unified engine for large-scale data analytics
 type: application
 home: https://apache.github.io/spark-kubernetes-operator/

--- a/build-tools/helm/spark-kubernetes-operator/values.yaml
+++ b/build-tools/helm/spark-kubernetes-operator/values.yaml
@@ -16,7 +16,7 @@
 image:
   repository: apache/spark-kubernetes-operator
   pullPolicy: IfNotPresent
-  tag: 1.0.0-SNAPSHOT
+  tag: 1.1.0-SNAPSHOT
   # If image digest is set then it takes precedence and the image tag will be ignored
   # digest: ""
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21): "Java 21 
 
 allprojects {
   group = "org.apache.spark.k8s.operator"
-  version = "1.0.0-SNAPSHOT"
+  version = "1.1.0-SNAPSHOT"
 }
 
 tasks.register('buildDockerImage', Exec) {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -74,7 +74,7 @@ following table:
 |------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | image.repository                                                 | The image repository of spark-kubernetes-operator.                                                                                                                             | apache/spark-kubernetes-operator                                                                        |
 | image.pullPolicy                                                 | The image pull policy of spark-kubernetes-operator.                                                                                                                            | IfNotPresent                                                                                            |
-| image.tag                                                        | The image tag of spark-kubernetes-operator.                                                                                                                                    | 1.0.0-SNAPSHOT                                                                                          |
+| image.tag                                                        | The image tag of spark-kubernetes-operator.                                                                                                                                    | 1.1.0-SNAPSHOT                                                                                          |
 | image.digest                                                     | The image digest of spark-kubernetes-operator. If set then it takes precedence and the image tag will be ignored.                                                              |                                                                                                         |
 | imagePullSecrets                                                 | The image pull secrets of spark-kubernetes-operator.                                                                                                                           |                                                                                                         |
 | operatorDeployment.replica                                       | Operator replica count. Must be 1 unless leader election is configured.                                                                                                        | 1                                                                                                       |
@@ -215,8 +215,8 @@ Check installation.
 ```bash
 $ helm list -A
 NAME      NAMESPACE REVISION UPDATED                              STATUS   CHART                               APP VERSION
-us-west-1 us-west-1 1        2026-05-06 10:00:00.000000 -0700 PDT deployed spark-kubernetes-operator-1.8.0-dev 1.0.0-SNAPSHOT
-us-west-2 us-west-2 1        2026-05-06 10:00:03.000000 -0700 PDT deployed spark-kubernetes-operator-1.8.0-dev 1.0.0-SNAPSHOT
+us-west-1 us-west-1 1        2026-05-06 10:00:00.000000 -0700 PDT deployed spark-kubernetes-operator-1.9.0-dev 1.1.0-SNAPSHOT
+us-west-2 us-west-2 1        2026-05-06 10:00:03.000000 -0700 PDT deployed spark-kubernetes-operator-1.9.0-dev 1.1.0-SNAPSHOT
 ```
 
 Launch `pi.yaml` at `us-west-1` and `us-west-2` namespaces.

--- a/tests/e2e/watched-namespaces-file/spark-operator-dynamic-config-1.yaml
+++ b/tests/e2e/watched-namespaces-file/spark-operator-dynamic-config-1.yaml
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/component: operator-dynamic-config-overrides
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: spark-kubernetes-operator
-    app.kubernetes.io/version: 1.0.0-SNAPSHOT
-    helm.sh/chart: spark-kubernetes-operator-1.8.0-dev
+    app.kubernetes.io/version: 1.1.0-SNAPSHOT
+    helm.sh/chart: spark-kubernetes-operator-1.9.0-dev
   name: spark-kubernetes-operator-dynamic-configuration
   namespace: default

--- a/tests/e2e/watched-namespaces/spark-operator-dynamic-config-1.yaml
+++ b/tests/e2e/watched-namespaces/spark-operator-dynamic-config-1.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/component: operator-dynamic-config-overrides
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: spark-kubernetes-operator
-    app.kubernetes.io/version: 1.0.0-SNAPSHOT
-    helm.sh/chart: spark-kubernetes-operator-1.8.0-dev
+    app.kubernetes.io/version: 1.1.0-SNAPSHOT
+    helm.sh/chart: spark-kubernetes-operator-1.9.0-dev
   name: spark-kubernetes-operator-dynamic-configuration
   namespace: default

--- a/tests/e2e/watched-namespaces/spark-operator-dynamic-config-2.yaml
+++ b/tests/e2e/watched-namespaces/spark-operator-dynamic-config-2.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/component: operator-dynamic-config-overrides
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: spark-kubernetes-operator
-    app.kubernetes.io/version: 1.0.0-SNAPSHOT
-    helm.sh/chart: spark-kubernetes-operator-1.8.0-dev
+    app.kubernetes.io/version: 1.1.0-SNAPSHOT
+    helm.sh/chart: spark-kubernetes-operator-1.9.0-dev
   name: spark-kubernetes-operator-dynamic-configuration
   namespace: default


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump version to `1.1.0-SNAPSHOT` in `main` branch.

### Why are the changes needed?

`branch-1.0` is created. We need to distinguish `main` branch from `branch-1.0`.
- https://github.com/apache/spark-kubernetes-operator/tree/branch-1.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Claude Fable 5`