### PR TITLE
[SPARK-58301] Upgrade `Apache DataFusion Comet` to 0.17.1

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -46,7 +46,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/0.17.0/comet-spark-spark4.1_2.13-0.17.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/0.17.1/comet-spark-spark4.1_2.13-0.17.1.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -68,7 +68,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/0.17.0/comet-spark-spark4.1_2.13-0.17.0.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/0.17.1/comet-spark-spark4.1_2.13-0.17.1.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades Apache DataFusion Comet to `0.17.1` in the `pi-with-comet` example.

### Why are the changes needed?

To use the latest Comet release (`0.17.1`, released on 2026-07-17).
- https://github.com/apache/datafusion-comet/releases/tag/0.17.1
- https://datafusion.apache.org/comet/changelog/0.17.1.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5