### PR TITLE
[SPARK-58303] Declare least-privilege `permissions` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,9 @@ name: Build and test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     name: "License Check"

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   call-build-and-test:
     name: Run

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -12,6 +12,9 @@ on:
         # keep in sync with default value of strategy matrix 'branch'
         default: '["main"]'
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot-chart:
     if: ${{ startsWith(github.repository, 'apache/') }}

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -12,6 +12,9 @@ on:
         # keep in sync with default value of strategy matrix 'branch'
         default: '["main"]'
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot-image:
     if: ${{ startsWith(github.repository, 'apache/') }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to declare least-privilege `permissions: contents: read` in the four GitHub Actions workflows that did not declare any token permissions: `build_and_test.yml`, `build_main.yml`, `publish_snapshot_chart.yml`, and `publish_snapshot_dockerhub.yml`. The other workflows already declare job-level permissions.

### Why are the changes needed?

Without an explicit `permissions` block, workflows run with the default `GITHUB_TOKEN` permissions, which are broader than needed. These workflows only read via `GITHUB_TOKEN`; publishing uses dedicated secrets.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5