### PR TITLE
[SPARK-58306] Use `ubuntu-26.04(-arm)?` in GitHub Action jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   license-check:
     name: "License Check"
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        os: [ 'ubuntu-slim', 'ubuntu-24.04-arm' ]
+        os: [ 'ubuntu-26.04', 'ubuntu-26.04-arm' ]
         java-version: [ 21, 25, 26 ]
     steps:
       - name: Checkout repository
@@ -47,7 +47,7 @@ jobs:
           ./gradlew build
   build-image:
     name: "Build Operator Image CI"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -66,7 +66,7 @@ jobs:
           ./gradlew buildDockerImage
   k8s-integration-tests:
     name: "K8s Integration Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -223,7 +223,7 @@ jobs:
           chainsaw test --test-dir ./tests/e2e/${{ matrix.test-group }} --parallel 1
   helm-tests:
     name: "Helm Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -271,7 +271,7 @@ jobs:
           helm test spark
   lint:
     name: "Linter and documentation"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   notify:
     name: Notify test workflow
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       checks: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   docs:
     name: Build and deploy documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       id-token: write
       pages: write

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish-snapshot-chart:
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish-snapshot-image:
     if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/.github/workflows/update_build_status.yml
+++ b/.github/workflows/update_build_status.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   update:
     name: Update build status
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       checks: write


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `ubuntu-26.04` and `ubuntu-26.04-arm` runner images in all GitHub Action jobs.

- `ubuntu-slim` → `ubuntu-26.04` (This is better because `ubuntu-slim` is flaky in these days due to 15-min timeout)
- `ubuntu-latest` → `ubuntu-26.04`
- `ubuntu-24.04-arm` → `ubuntu-26.04-arm`

### Why are the changes needed?

For Apache Spark K8s Operator v1.1.0, this PR aims the following:

1. **Consistent environment across the build matrix** — Previously, the x86 job used `ubuntu-slim` (24.04-based) while the arm job used `ubuntu-24.04-arm`, so the two architectures ran on different image types. Now both architectures are tested on the same Ubuntu 26.04 environment, eliminating variables other than the architecture itself.

2. **Longer support window** — The 26.04 runner image will be supported longer than the 24.04-based images, buying time until the next LTS migration.

3. **Early validation on the latest kernel and system libraries** — The operator is built and tested on top of the newest glibc, kernel, and Docker versions, so issues on modern environments are caught in CI first.

### Does this PR introduce _any_ user-facing change?

No. This is an infra-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5