### PR TITLE
[SPARK-58331] Use Java-friendly `sparkVersion` API instead of `labels` override in `SparkAppDriverConf`

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppDriverConf.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppDriverConf.java
@@ -19,8 +19,6 @@
 
 package org.apache.spark.k8s.operator;
 
-import static org.apache.spark.k8s.operator.Constants.LABEL_SPARK_VERSION_NAME;
-
 import java.util.Optional;
 
 import org.apache.spark.SparkConf;
@@ -90,13 +88,13 @@ public final class SparkAppDriverConf extends KubernetesDriverConf {
   }
 
   /**
-   * Returns the driver label key and value map.
+   * Returns the Spark version of the application.
    *
-   * @return The label key-value pair map.
+   * @return The Spark version.
    */
   @Override
-  public scala.collection.immutable.Map<String, String> labels() {
-    return super.labels().updated(LABEL_SPARK_VERSION_NAME, sparkVersion);
+  public String sparkVersion() {
+    return sparkVersion;
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to replace the Scala-typed `labels()` override of `SparkAppDriverConf` with the Java-friendly `sparkVersion()` API which was introduced via SPARK-56736 in Apache Spark 4.2.0.

- https://github.com/apache/spark/pull/55697

### Why are the changes needed?

To use Java-friendly APIs instead of Scala APIs.

### Does this PR introduce _any_ user-facing change?

No. The generated driver labels are identical. The existing `testLabels` test passes without modification.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5