### PR TITLE
[SPARK-58380] Update Spark 4.1/4.0 examples to use 4.1.3 and 4.0.4 docker images

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -27,7 +27,7 @@ spec:
     spark.driver.extraClassPath: "local:///comet/comet.jar"
     spark.executor.extraClassPath: "local:///comet/comet.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.2-scala"
+    spark.kubernetes.container.image: "apache/spark:4.1.3-scala"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
     spark.plugins: "org.apache.spark.CometPlugin"
@@ -79,4 +79,4 @@ spec:
           emptyDir:
             sizeLimit: 200Mi
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.1.3"

--- a/examples/pi-with-gluten.yaml
+++ b/examples/pi-with-gluten.yaml
@@ -23,7 +23,7 @@ spec:
     spark.driver.extraClassPath: "local:///gluten/gluten.jar"
     spark.executor.extraClassPath: "local:///gluten/gluten.jar"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.3-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.4-scala"
     spark.kubernetes.node.selector.kubernetes.io/arch: "amd64"
     spark.memory.offHeap.enabled: "true"
     spark.memory.offHeap.size: "1g"
@@ -81,4 +81,4 @@ spec:
           emptyDir:
             sizeLimit: 500Mi
   runtimeVersions:
-    sparkVersion: "4.0.3"
+    sparkVersion: "4.0.4"

--- a/examples/spark-connect-server-iceberg.yaml
+++ b/examples/spark-connect-server-iceberg.yaml
@@ -26,7 +26,7 @@ spec:
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.jars.packages: "org.apache.hadoop:hadoop-aws:3.4.2,org.apache.iceberg:iceberg-spark-runtime-4.1_2.13:1.11.0"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.1.2"
+    spark.kubernetes.container.image: "apache/spark:4.1.3"
     spark.kubernetes.executor.podNamePrefix: "spark-connect-server-iceberg"
     spark.scheduler.mode: "FAIR"
     spark.sql.catalog.s3.type: "hadoop"
@@ -35,4 +35,4 @@ spec:
     spark.sql.defaultCatalog: "s3"
     spark.sql.extensions: "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
   runtimeVersions:
-    sparkVersion: "4.1.2"
+    sparkVersion: "4.1.3"

--- a/examples/word-count-celeborn.yaml
+++ b/examples/word-count-celeborn.yaml
@@ -25,7 +25,7 @@ spec:
     spark.jars.ivy: "/tmp/.ivy2.5.2"
     spark.jars.packages: "org.apache.celeborn:celeborn-client-spark-4-shaded_2.13:0.6.3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
-    spark.kubernetes.container.image: "apache/spark:4.0.3-scala"
+    spark.kubernetes.container.image: "apache/spark:4.0.4-scala"
     spark.kubernetes.driver.limit.cores: "5"
     spark.kubernetes.driver.master: "local[10]"
     spark.kubernetes.driver.request.cores: "5"
@@ -34,4 +34,4 @@ spec:
     spark.sql.adaptive.localShuffleReader.enabled: "false"
     spark.serializer: "org.apache.spark.serializer.KryoSerializer"
   runtimeVersions:
-    sparkVersion: "4.0.3"
+    sparkVersion: "4.0.4"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update Spark 4.1/4.0 examples to use 4.1.3 and 4.0.4 docker images

- [v4.1.3](https://github.com/apache/spark/releases/tag/v4.1.3) (2026-07-11)
- [v4.0.4](https://github.com/apache/spark/releases/tag/v4.0.4) (2026-07-12)

### Why are the changes needed?

To recommend the latest Apache Spark maintenance releases which bring the latest bug fixes.

### Does this PR introduce _any_ user-facing change?

No, this is an example-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5