### PR TITLE
[SPARK-58596] Remove `spark.dynamicAllocation.shuffleTracking.enabled` from examples and docs

### DIFF
--- a/docs/spark_custom_resources.md
+++ b/docs/spark_custom_resources.md
@@ -49,7 +49,6 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.dynamicAllocation.enabled: "true"
-    spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.2.0-scala"

--- a/examples/pi-java25-with-executor-resize-plugin.yaml
+++ b/examples/pi-java25-with-executor-resize-plugin.yaml
@@ -23,7 +23,6 @@ spec:
   sparkConf:
     spark.dynamicAllocation.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "1"
-    spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:4.2.0-scala-java25"
     spark.kubernetes.executor.resizeInterval: "1min"

--- a/examples/pi.yaml
+++ b/examples/pi.yaml
@@ -21,7 +21,6 @@ spec:
   jars: "local:///opt/spark/examples/jars/spark-examples.jar"
   sparkConf:
     spark.dynamicAllocation.enabled: "true"
-    spark.dynamicAllocation.shuffleTracking.enabled: "true"
     spark.dynamicAllocation.maxExecutors: "3"
     spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
     spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the `spark.dynamicAllocation.shuffleTracking.enabled` setting from the example YAML files and the documentation.

- `examples/pi.yaml`
- `examples/pi-java25-with-executor-resize-plugin.yaml`
- `docs/spark_custom_resources.md` (the `SparkApplication` example quoting `examples/pi.yaml`)

### Why are the changes needed?

`spark.dynamicAllocation.shuffleTracking.enabled` is `true` by default since Apache Spark 3.4.0 via [SPARK-39846](https://issues.apache.org/jira/browse/SPARK-39846). Since all examples use Spark 4.2.0, this setting is redundant and can be omitted to keep the examples minimal.
- https://github.com/apache/spark/pull/37257

### Does this PR introduce _any_ user-facing change?

No. This is an example and documentation-only change with no behavior difference.

### How was this patch tested?

Manually verified that no occurrence remains in the repository.

```
$ grep -rn "shuffleTracking" examples/ docs/ | wc -l
       0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5