### PR TITLE
[SPARK-58597] Add `ExecutorPVCResizePlugin` example

### DIFF
--- a/examples/pi-java25-with-executor-pvc-resize-plugin.yaml
+++ b/examples/pi-java25-with-executor-pvc-resize-plugin.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: pi-java25-with-executor-pvc-resize-plugin
+spec:
+  mainClass: "org.apache.spark.examples.SparkPi"
+  driverArgs: ["200000"]
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:4.2.0-scala-java25"
+    spark.kubernetes.executor.pvc.resizeInterval: "5min"
+    spark.kubernetes.executor.pvc.resizeThreshold: "0.5"
+    spark.kubernetes.executor.pvc.resizeFactor: "1.0"
+    # The StorageClass must have `allowVolumeExpansion: true`.
+    spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.mount.path: "/data"
+    spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.claimName: "OnDemand"
+    spark.kubernetes.executor.volumes.persistentVolumeClaim.spark-local-dir-1.options.sizeLimit: "1Gi"
+    spark.plugins: "org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+    ttlAfterStopMillis: 10000
+  runtimeVersions:
+    sparkVersion: "4.2.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new example, `pi-java25-with-executor-pvc-resize-plugin.yaml`, which demonstrates how to use `org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin` of Apache Spark 4.2.0 with the Spark K8s Operator, like the existing `pi-java25-with-executor-resize-plugin.yaml` example.

The example runs `SparkPi` with an `OnDemand` PVC mounted as `spark-local-dir-1` on the executors and enables the plugin which grows the PVC storage request when the executor disk usage ratio exceeds the threshold.

```yaml
spark.kubernetes.executor.pvc.resizeInterval: "5min"
spark.kubernetes.executor.pvc.resizeThreshold: "0.5"
spark.kubernetes.executor.pvc.resizeFactor: "1.0"
spark.plugins: "org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin"
```

### Why are the changes needed?

To help users discover and try the executor PVC resize feature easily on K8s environments. Note that the PVCs should be provisioned by a `StorageClass` with `allowVolumeExpansion: true`.

### Does this PR introduce _any_ user-facing change?

No, this is an example addition.

### How was this patch tested?

Manual review because this is a new YAML example file.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5