### PR TITLE
[SPARK-58599] Add `Recovery-mode Executor` example

### DIFF
--- a/examples/group-by-with-recovery-mode.yaml
+++ b/examples/group-by-with-recovery-mode.yaml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: spark.apache.org/v1
+kind: SparkApplication
+metadata:
+  name: group-by-with-recovery-mode
+spec:
+  mainClass: "org.apache.spark.examples.GroupByTest"
+  # numMappers, numKVPairs, valueSize, numReducers
+  # Each mapper task materializes ~450MiB. Three concurrent tasks exceed the 1g
+  # executor heap and cause OOM. A recovery-mode executor accepts only a single
+  # task per executor JVM, so the whole heap serves one task and the job succeeds.
+  # If the conf below is removed, the recovery mode is activated automatically
+  # when the driver detects the OOM. Set it to `false` to see the job fail with OOM.
+  driverArgs: ["6", "450000", "1000", "6"]
+  jars: "local:///opt/spark/examples/jars/spark-examples.jar"
+  sparkConf:
+    spark.kubernetes.allocation.recoveryMode.enabled: "true"
+    spark.executor.instances: "2"
+    spark.executor.cores: "3"
+    spark.executor.memory: "1g"
+    spark.kubernetes.authenticate.driver.serviceAccountName: "spark"
+    spark.kubernetes.container.image: "apache/spark:{{SPARK_VERSION}}-scala"
+  applicationTolerations:
+    resourceRetainPolicy: OnFailure
+  runtimeVersions:
+    sparkVersion: "4.2.0"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new example, `group-by-with-recovery-mode.yaml`, which demonstrates
`spark.kubernetes.allocation.recoveryMode.enabled` (SPARK-55639, Apache Spark 4.2.0).
- https://github.com/apache/spark/pull/54558

The example runs `GroupByTest` where each mapper task materializes about 450MiB. With
`spark.executor.cores=3` and `spark.executor.memory=1g`, three concurrent tasks exceed the
executor heap and cause OOM. With the recovery mode enabled, every executor accepts only a
single task per executor JVM (`SPARK_EXECUTOR_CORES=1` while the pod still requests 3 CPUs),
so the whole heap serves one task and the job succeeds.

### Why are the changes needed?

To help users try out the recovery-mode executor feature of Apache Spark 4.2.0 with a
self-contained example that actually exercises the OOM boundary:

- As-is (`"true"`): the job succeeds with single-task executors.
- Set to `"false"`: the job fails with executor OOM (exit code 52).
- Removed: the recovery mode is activated automatically when the driver detects the OOM.

### Does this PR introduce _any_ user-facing change?

No. This is an example addition.

### How was this patch tested?

Manually tested on a local Kubernetes cluster with the operator built from this repository.

```
$ sed 's/{{SPARK_VERSION}}/4.2.0/' examples/group-by-with-recovery-mode.yaml | kubectl apply -f -
```

- `enabled: "true"` (as-is): executor pods request 3 CPUs but run with `SPARK_EXECUTOR_CORES=1`;
  the application reached `Succeeded` and then `ResourceReleased`.
- `enabled: "false"`: all executors terminated with exit code 52 (`JVM OOM`) and the job failed
  after task retries, as described in the example comment.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5