### PR TITLE
[SPARK-58654] Upgrade `Apache DataFusion Comet` to 1.0.0

### DIFF
--- a/examples/pi-with-comet.yaml
+++ b/examples/pi-with-comet.yaml
@@ -43,7 +43,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/0.17.1/comet-spark-spark4.1_2.13-0.17.1.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/1.0.0/comet-spark-spark4.1_2.13-1.0.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet
@@ -65,7 +65,7 @@ spec:
           command: ["sh", "-c"]
           args:
           - |
-            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/0.17.1/comet-spark-spark4.1_2.13-0.17.1.jar"
+            wget -O /comet/comet.jar "https://repo1.maven.org/maven2/org/apache/datafusion/comet-spark-spark4.1_2.13/1.0.0/comet-spark-spark4.1_2.13-1.0.0.jar"
           volumeMounts:
           - name: comet
             mountPath: /comet


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR upgrades Apache DataFusion Comet to `1.0.0` in the `pi-with-comet` example.

### Why are the changes needed?

To use the latest Comet release (`1.0.0`, released on 2026-08-07).
- https://github.com/apache/datafusion-comet/releases/tag/1.0.0 (2026-08-07)
  - https://github.com/apache/datafusion-comet/pull/5183
- https://datafusion.apache.org/comet/changelog/1.0.0.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5

Closes #788