### PR TITLE
[SPARK-58926] Driver pod SPARK_USER should reflect --proxy-user

### DIFF
--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
@@ -87,6 +87,7 @@ public class SparkAppResourceSpec {
     Map<String, String> confFilesMap = new HashMap<>(originalConfFilesMap);
     confFilesMap.put(Config.KUBERNETES_NAMESPACE().key(), namespace);
     SparkPod sparkPod = addConfigMap(kubernetesDriverSpec.pod(), confFilesMap);
+    sparkPod = overrideSparkUserForProxyUser(sparkPod);
     this.configuredPod =
         new PodBuilder(sparkPod.pod())
             .editSpec()
@@ -153,6 +154,30 @@ public class SparkAppResourceSpec {
             .endSpec()
             .build();
     return new SparkPod(podWithConfigMapVolume, containerWithConfigMapVolume);
+  }
+
+  /**
+   * Overrides the {@code SPARK_USER} environment variable on the driver container with the
+   * proxy user when one is configured. In {@code spark-submit}, {@code SparkSubmit} wraps
+   * {@code runMain} in {@code proxyUser.doAs(...)}, so {@code Utils.getCurrentUserName()} inside
+   * {@code BasicDriverFeatureStep} returns the proxy user. The operator builds the driver pod
+   * spec by invoking the feature steps directly, without an equivalent {@code doAs}, so
+   * {@code SPARK_USER} would otherwise be the operator's identity rather than the effective one.
+   */
+  private SparkPod overrideSparkUserForProxyUser(SparkPod pod) {
+    scala.Option<String> proxyUser = kubernetesDriverConf.proxyUser();
+    if (proxyUser.isEmpty()) {
+      return pod;
+    }
+    Container containerWithSparkUser =
+        new ContainerBuilder(pod.container())
+            .removeMatchingFromEnv(e -> Constants.ENV_SPARK_USER().equals(e.getName()))
+            .addNewEnv()
+            .withName(Constants.ENV_SPARK_USER())
+            .withValue(proxyUser.get())
+            .endEnv()
+            .build();
+    return new SparkPod(pod.pod(), containerWithSparkUser);
   }
 
   /**

--- a/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
+++ b/spark-submission-worker/src/main/java/org/apache/spark/k8s/operator/SparkAppResourceSpec.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -158,25 +160,64 @@ public class SparkAppResourceSpec {
 
   /**
    * Overrides the {@code SPARK_USER} environment variable on the driver container with the
-   * proxy user when one is configured. In {@code spark-submit}, {@code SparkSubmit} wraps
-   * {@code runMain} in {@code proxyUser.doAs(...)}, so {@code Utils.getCurrentUserName()} inside
-   * {@code BasicDriverFeatureStep} returns the proxy user. The operator builds the driver pod
-   * spec by invoking the feature steps directly, without an equivalent {@code doAs}, so
-   * {@code SPARK_USER} would otherwise be the operator's identity rather than the effective one.
+   * proxy user when one is configured.
+   *
+   * <p>Background: In {@code spark-submit}, {@code SparkSubmit} wraps {@code runMain} in
+   * {@code proxyUser.doAs(...)}, so {@code Utils.getCurrentUserName()} inside
+   * {@link org.apache.spark.deploy.k8s.features.BasicDriverFeatureStep} returns the proxy user.
+   * The operator builds the driver pod spec by invoking the feature steps directly, without an
+   * equivalent {@code doAs}, so {@code SPARK_USER} would otherwise be the operator's identity
+   * rather than the effective one. Note that {@code Utils.getCurrentUserName()} reads the
+   * {@code SPARK_USER} environment variable in preference to the UGI short user name, and the
+   * default Helm chart exports {@code SPARK_USER=spark} into the operator container; a
+   * {@code doAs} wrapper alone would therefore not correct the driver env, which is why the
+   * override is applied on the container spec here.
+   *
+   * <p>Replaces the entry in place so ordering established by {@code BasicDriverFeatureStep} is
+   * preserved. Ordering matters because kubelet resolves {@code $(VAR)} references only against
+   * variables defined earlier in the env list; moving {@code SPARK_USER} after
+   * {@code driverCustomEnvs} would break any {@code spark.kubernetes.driverEnv.*} value that
+   * uses {@code $(SPARK_USER)}.
+   *
+   * <p>If the user has explicitly set {@code spark.kubernetes.driverEnv.SPARK_USER}, the
+   * explicit value wins and the proxy user is not applied to the driver container. The
+   * override is a fallback for the default case where {@code SPARK_USER} is stamped by the
+   * feature step.
+   *
+   * <p>Known limitation: this only patches the driver container env. Kerberos delegation
+   * tokens minted by {@code KerberosConfDriverFeatureStep} are still obtained from the
+   * operator's UGI, i.e. as the operator principal rather than the proxy user. Applications
+   * that need proxy-user delegation tokens on kerberized clusters must supply the tokens via
+   * an existing secret.
    */
   private SparkPod overrideSparkUserForProxyUser(SparkPod pod) {
     scala.Option<String> proxyUser = kubernetesDriverConf.proxyUser();
     if (proxyUser.isEmpty()) {
       return pod;
     }
+    if (kubernetesDriverConf.environment().contains(Constants.ENV_SPARK_USER())) {
+      return pod;
+    }
+    List<EnvVar> patchedEnv = new ArrayList<>(pod.container().getEnv());
+    boolean replaced = false;
+    for (int i = 0; i < patchedEnv.size(); i++) {
+      if (Constants.ENV_SPARK_USER().equals(patchedEnv.get(i).getName())) {
+        patchedEnv.set(
+            i, new EnvVarBuilder(patchedEnv.get(i)).withValue(proxyUser.get()).build());
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) {
+      patchedEnv.add(
+          0,
+          new EnvVarBuilder()
+              .withName(Constants.ENV_SPARK_USER())
+              .withValue(proxyUser.get())
+              .build());
+    }
     Container containerWithSparkUser =
-        new ContainerBuilder(pod.container())
-            .removeMatchingFromEnv(e -> Constants.ENV_SPARK_USER().equals(e.getName()))
-            .addNewEnv()
-            .withName(Constants.ENV_SPARK_USER())
-            .withValue(proxyUser.get())
-            .endEnv()
-            .build();
+        new ContainerBuilder(pod.container()).withEnv(patchedEnv).build();
     return new SparkPod(pod.pod(), containerWithSparkUser);
   }
 

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
@@ -45,13 +44,11 @@ import org.apache.spark.deploy.k8s.SparkPod;
 
 class SparkAppResourceSpecTest {
 
+  private static final String DRIVER_CONTAINER_NAME = "foo-container";
+
   @Test
   void testDriverResourceIncludesConfigMap() {
-    SparkAppDriverConf mockConf = mock(SparkAppDriverConf.class);
-    when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
-    when(mockConf.sparkConf())
-        .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
-    when(mockConf.proxyUser()).thenReturn(scala.Option.empty());
+    SparkAppDriverConf mockConf = mockDriverConf(null, Map.of());
 
     Pod driver = buildBasicPod("driver");
     SparkPod sparkPod = new SparkPod(driver, buildBasicContainer());
@@ -108,51 +105,48 @@ class SparkAppResourceSpecTest {
 
   @Test
   void driverSparkUserShouldReflectProxyUserWhenSet() {
-    SparkAppDriverConf mockConf = mock(SparkAppDriverConf.class);
-    when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
-    when(mockConf.sparkConf())
-        .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
-    when(mockConf.proxyUser()).thenReturn(scala.Option.apply("alice"));
-
-    Container driverContainer =
-        new ContainerBuilder(buildBasicContainer())
-            .addNewEnv()
-            .withName(Constants.ENV_SPARK_USER())
-            .withValue("submitter")
-            .endEnv()
-            .build();
-    SparkPod sparkPod = new SparkPod(buildBasicPod("driver"), driverContainer);
-    KubernetesDriverSpec spec =
-        KubernetesDriverSpec.create(sparkPod, List.of(), List.of(), Map.of());
-
-    SparkAppResourceSpec appResourceSpec =
-        new SparkAppResourceSpec(mockConf, spec, List.of(), List.of(), List.of(), List.of());
-
-    Container configured =
-        appResourceSpec.getConfiguredPod().getSpec().getContainers().get(1);
-    List<EnvVar> sparkUserEnvs =
-        configured.getEnv().stream()
-            .filter(e -> Constants.ENV_SPARK_USER().equals(e.getName()))
-            .collect(Collectors.toList());
-    Assertions.assertEquals(1, sparkUserEnvs.size(), "SPARK_USER should appear exactly once");
-    Assertions.assertEquals("alice", sparkUserEnvs.get(0).getValue());
+    Container configured = buildDriverContainer("alice", Map.of(), "submitter");
+    Assertions.assertEquals("alice", sparkUserValue(configured));
   }
 
   @Test
   void driverSparkUserShouldBeUntouchedWhenProxyUserAbsent() {
-    SparkAppDriverConf mockConf = mock(SparkAppDriverConf.class);
-    when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
-    when(mockConf.sparkConf())
-        .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
-    when(mockConf.proxyUser()).thenReturn(scala.Option.empty());
+    Container configured = buildDriverContainer(null, Map.of(), "submitter");
+    Assertions.assertEquals("submitter", sparkUserValue(configured));
+  }
 
+  @Test
+  void driverSparkUserShouldRespectExplicitDriverEnvOverride() {
+    // If the user explicitly set spark.kubernetes.driverEnv.SPARK_USER, honor it over
+    // --proxy-user. Without this, driver identity would silently diverge from executor
+    // identity (spark.executorEnv.SPARK_USER is not touched here).
+    Container configured =
+        buildDriverContainer("alice", Map.of(Constants.ENV_SPARK_USER(), "carol"), "carol");
+    Assertions.assertEquals("carol", sparkUserValue(configured));
+  }
+
+  @Test
+  void driverSparkUserOverrideShouldPreservePosition() {
+    // BasicDriverFeatureStep puts SPARK_USER before driverCustomEnvs so that entries like
+    // spark.kubernetes.driverEnv.HADOOP_USER_NAME=$(SPARK_USER) can reference it. kubelet
+    // resolves $(VAR) only against variables earlier in the env list, so the override must
+    // leave SPARK_USER at its original position.
     Container driverContainer =
-        new ContainerBuilder(buildBasicContainer())
+        new ContainerBuilder()
+            .withName(DRIVER_CONTAINER_NAME)
+            .addNewVolumeMount()
+            .withName("placeholder")
+            .endVolumeMount()
             .addNewEnv()
             .withName(Constants.ENV_SPARK_USER())
             .withValue("submitter")
             .endEnv()
+            .addNewEnv()
+            .withName("HADOOP_USER_NAME")
+            .withValue("$(SPARK_USER)")
+            .endEnv()
             .build();
+    SparkAppDriverConf mockConf = mockDriverConf("alice", Map.of());
     SparkPod sparkPod = new SparkPod(buildBasicPod("driver"), driverContainer);
     KubernetesDriverSpec spec =
         KubernetesDriverSpec.create(sparkPod, List.of(), List.of(), Map.of());
@@ -160,17 +154,67 @@ class SparkAppResourceSpecTest {
     SparkAppResourceSpec appResourceSpec =
         new SparkAppResourceSpec(mockConf, spec, List.of(), List.of(), List.of(), List.of());
 
-    Container configured =
-        appResourceSpec.getConfiguredPod().getSpec().getContainers().get(1);
-    List<EnvVar> sparkUserEnvs =
-        configured.getEnv().stream()
+    Container configured = driverContainer(appResourceSpec);
+    List<String> envNames = configured.getEnv().stream().map(EnvVar::getName).toList();
+    Assertions.assertTrue(
+        envNames.indexOf(Constants.ENV_SPARK_USER()) < envNames.indexOf("HADOOP_USER_NAME"),
+        "SPARK_USER must remain before HADOOP_USER_NAME so $(SPARK_USER) resolves: " + envNames);
+    Assertions.assertEquals("alice", sparkUserValue(configured));
+  }
+
+  private Container buildDriverContainer(
+      String proxyUser, Map<String, String> driverEnv, String initialSparkUser) {
+    Container driverContainer =
+        new ContainerBuilder(buildBasicContainer())
+            .addNewEnv()
+            .withName(Constants.ENV_SPARK_USER())
+            .withValue(initialSparkUser)
+            .endEnv()
+            .build();
+    SparkAppDriverConf mockConf = mockDriverConf(proxyUser, driverEnv);
+    SparkPod sparkPod = new SparkPod(buildBasicPod("driver"), driverContainer);
+    KubernetesDriverSpec spec =
+        KubernetesDriverSpec.create(sparkPod, List.of(), List.of(), Map.of());
+    SparkAppResourceSpec appResourceSpec =
+        new SparkAppResourceSpec(mockConf, spec, List.of(), List.of(), List.of(), List.of());
+    return driverContainer(appResourceSpec);
+  }
+
+  private static SparkAppDriverConf mockDriverConf(
+      String proxyUser, Map<String, String> driverEnv) {
+    SparkAppDriverConf mockConf = mock(SparkAppDriverConf.class);
+    when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
+    when(mockConf.sparkConf())
+        .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
+    when(mockConf.proxyUser()).thenReturn(scala.Option.apply(proxyUser));
+    when(mockConf.environment()).thenReturn(toScalaMap(driverEnv));
+    return mockConf;
+  }
+
+  private static scala.collection.immutable.Map<String, String> toScalaMap(
+      Map<String, String> javaMap) {
+    scala.collection.immutable.Map<String, String> scalaMap =
+        scala.collection.immutable.Map$.MODULE$.empty();
+    for (Map.Entry<String, String> entry : javaMap.entrySet()) {
+      scalaMap = scalaMap.updated(entry.getKey(), entry.getValue());
+    }
+    return scalaMap;
+  }
+
+  private static Container driverContainer(SparkAppResourceSpec appResourceSpec) {
+    return appResourceSpec.getConfiguredPod().getSpec().getContainers().stream()
+        .filter(c -> DRIVER_CONTAINER_NAME.equals(c.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("driver container not found"));
+  }
+
+  private static String sparkUserValue(Container container) {
+    List<EnvVar> matches =
+        container.getEnv().stream()
             .filter(e -> Constants.ENV_SPARK_USER().equals(e.getName()))
-            .collect(Collectors.toList());
-    Assertions.assertEquals(1, sparkUserEnvs.size());
-    Assertions.assertEquals(
-        "submitter",
-        sparkUserEnvs.get(0).getValue(),
-        "SPARK_USER should be untouched when no proxy user is configured");
+            .toList();
+    Assertions.assertEquals(1, matches.size(), "SPARK_USER should appear exactly once");
+    return matches.get(0).getValue();
   }
 
   protected Container buildBasicContainer() {

--- a/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
+++ b/spark-submission-worker/src/test/java/org/apache/spark/k8s/operator/SparkAppResourceSpecTest.java
@@ -24,10 +24,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.apache.spark.SparkConf;
+import org.apache.spark.deploy.k8s.Constants;
 import org.apache.spark.deploy.k8s.KubernetesDriverSpec;
 import org.apache.spark.deploy.k8s.SparkPod;
 
@@ -48,6 +51,7 @@ class SparkAppResourceSpecTest {
     when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
     when(mockConf.sparkConf())
         .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
+    when(mockConf.proxyUser()).thenReturn(scala.Option.empty());
 
     Pod driver = buildBasicPod("driver");
     SparkPod sparkPod = new SparkPod(driver, buildBasicContainer());
@@ -100,6 +104,73 @@ class SparkAppResourceSpecTest {
             .getVolumeMounts()
             .get(1);
     Assertions.assertEquals(proposedConfigVolume.getName(), proposedConfigVolumeMount.getName());
+  }
+
+  @Test
+  void driverSparkUserShouldReflectProxyUserWhenSet() {
+    SparkAppDriverConf mockConf = mock(SparkAppDriverConf.class);
+    when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
+    when(mockConf.sparkConf())
+        .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
+    when(mockConf.proxyUser()).thenReturn(scala.Option.apply("alice"));
+
+    Container driverContainer =
+        new ContainerBuilder(buildBasicContainer())
+            .addNewEnv()
+            .withName(Constants.ENV_SPARK_USER())
+            .withValue("submitter")
+            .endEnv()
+            .build();
+    SparkPod sparkPod = new SparkPod(buildBasicPod("driver"), driverContainer);
+    KubernetesDriverSpec spec =
+        KubernetesDriverSpec.create(sparkPod, List.of(), List.of(), Map.of());
+
+    SparkAppResourceSpec appResourceSpec =
+        new SparkAppResourceSpec(mockConf, spec, List.of(), List.of(), List.of(), List.of());
+
+    Container configured =
+        appResourceSpec.getConfiguredPod().getSpec().getContainers().get(1);
+    List<EnvVar> sparkUserEnvs =
+        configured.getEnv().stream()
+            .filter(e -> Constants.ENV_SPARK_USER().equals(e.getName()))
+            .collect(Collectors.toList());
+    Assertions.assertEquals(1, sparkUserEnvs.size(), "SPARK_USER should appear exactly once");
+    Assertions.assertEquals("alice", sparkUserEnvs.get(0).getValue());
+  }
+
+  @Test
+  void driverSparkUserShouldBeUntouchedWhenProxyUserAbsent() {
+    SparkAppDriverConf mockConf = mock(SparkAppDriverConf.class);
+    when(mockConf.configMapNameDriver()).thenReturn("foo-configmap");
+    when(mockConf.sparkConf())
+        .thenReturn(new SparkConf().set("spark.kubernetes.namespace", "foo-namespace"));
+    when(mockConf.proxyUser()).thenReturn(scala.Option.empty());
+
+    Container driverContainer =
+        new ContainerBuilder(buildBasicContainer())
+            .addNewEnv()
+            .withName(Constants.ENV_SPARK_USER())
+            .withValue("submitter")
+            .endEnv()
+            .build();
+    SparkPod sparkPod = new SparkPod(buildBasicPod("driver"), driverContainer);
+    KubernetesDriverSpec spec =
+        KubernetesDriverSpec.create(sparkPod, List.of(), List.of(), Map.of());
+
+    SparkAppResourceSpec appResourceSpec =
+        new SparkAppResourceSpec(mockConf, spec, List.of(), List.of(), List.of(), List.of());
+
+    Container configured =
+        appResourceSpec.getConfiguredPod().getSpec().getContainers().get(1);
+    List<EnvVar> sparkUserEnvs =
+        configured.getEnv().stream()
+            .filter(e -> Constants.ENV_SPARK_USER().equals(e.getName()))
+            .collect(Collectors.toList());
+    Assertions.assertEquals(1, sparkUserEnvs.size());
+    Assertions.assertEquals(
+        "submitter",
+        sparkUserEnvs.get(0).getValue(),
+        "SPARK_USER should be untouched when no proxy user is configured");
   }
 
   protected Container buildBasicContainer() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

When the operator builds the driver pod spec by invoking Spark's driver feature steps directly, `BasicDriverFeatureStep` sets `SPARK_USER` via `Utils.getCurrentUserName()`. In `spark-submit`, `SparkSubmit` wraps `runMain` in `proxyUser.doAs(...)`, so that call returns the proxy user; the operator has no equivalent wrapper, so `SPARK_USER` ends up as the operator's identity rather than the effective one. This affects `SparkContext.sparkUser`, Spark UI ACLs, and external authorization integrations that key off `SPARK_USER`.

Override `SPARK_USER` on the driver container after the feature steps run when a proxy user is configured on the driver conf.

### Why are the changes needed?
Explained above.


### Does this PR introduce _any_ user-facing change?
Yes.


### How was this patch tested?
Unit tests


### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.7)
