### PR TITLE
[SPARK-59064] Update CI to test K8s 1.37

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         kubernetes-version:
           - "1.34.0"
-          - "1.36.0"
+          - "1.37.0"
         mode:
           - dynamic
           - static
@@ -125,16 +125,16 @@ jobs:
           - mode: selector
             test-group: driver-start-timeout
         include:
-          - kubernetes-version: "1.36.0"
+          - kubernetes-version: "1.37.0"
             mode: dynamic-file
             test-group: watched-namespaces-file
-          - kubernetes-version: "1.36.0"
+          - kubernetes-version: "1.37.0"
             mode: static
             test-group: pi-with-comet
-          - kubernetes-version: "1.36.0"
+          - kubernetes-version: "1.37.0"
             mode: static
             test-group: pi-with-gluten
-          - kubernetes-version: "1.36.0"
+          - kubernetes-version: "1.37.0"
             mode: static
             test-group: pi-java25
     steps:
@@ -233,7 +233,7 @@ jobs:
       max-parallel: 20
       matrix:
         kubernetes-version:
-          - "1.36.0"
+          - "1.37.0"
         test-group:
           - configmap-metadata
           - network-policy


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update CI to test K8s 1.37.

### Why are the changes needed?

To ensure Apache Spark K8s Operator works with the latest Kubernetes 1.37 release.
- https://kubernetes.io/releases/#release-v1-37
   - [KEP-5207: metrics.k8s.io API definition (GA)](https://github.com/kubernetes/enhancements/issues/5207)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the installed version manually in the log.

```
System Info:
  ...
  Kubelet Version:            v1.37.0
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5