### PR TITLE
[SPARK-59220] Pin Minikube `container-runtime` to `docker` to fix CI failures with Minikube 1.39.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -156,6 +156,8 @@ jobs:
         with:
           cache: true
           kubernetes-version: ${{ matrix.kubernetes-version }}
+          # Minikube 1.39.0 defaults to containerd, but `minikube docker-env` needs Docker
+          container-runtime: docker
           cpus: 3
           memory: 10240m
       - name: Set Up Go
@@ -257,6 +259,8 @@ jobs:
         with:
           cache: true
           kubernetes-version: ${{ matrix.kubernetes-version }}
+          # Minikube 1.39.0 defaults to containerd, but `minikube docker-env` needs Docker
+          container-runtime: docker
           cpus: 3
           memory: 10240m
       - name: Print K8S pods and nodes info


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `container-runtime: docker` in both `setup-minikube` steps (`k8s-integration-tests` and `helm-tests`) to fix the CI failures caused by Minikube 1.39.0.

### Why are the changes needed?

`setup-minikube` installs the `latest` Minikube by default, so CI picked up Minikube 1.39.0 as soon as it was released, which changed the default container runtime from `docker` to `containerd`.
- https://github.com/kubernetes/minikube/releases/tag/v1.39.0 (2026-09-02)
  - Default container runtime is now `containerd` (https://github.com/kubernetes/minikube/pull/23562)

Since then, all `K8s Integration Tests` and `Helm Tests` jobs fail at `buildDockerImage` because `minikube docker-env` no longer points to a real Docker daemon.
- https://github.com/apache/spark-kubernetes-operator/pull/806

```
* minikube v1.39.0 on Ubuntu 26.04
* Preparing Kubernetes v1.36.0 on containerd 2.3.4 ...
! Using the docker-env command with the containerd runtime is a highly experimental feature, please provide feedback or contribute to make it better
#1 [internal] booting buildkit
#1 ERROR: failed to inspect pulled image moby/buildkit:buildx-stable-1: Error response from daemon: 404 page not found
> Task :buildDockerImage FAILED
```

Pinning `container-runtime: docker` fixes the root cause while keeping `minikube-version` unpinned, so CI continues to use the latest Minikube, which also officially supports K8s 1.37.0 now.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5.1