### PR TITLE
[SPARK-59230] Upgrade `setup-gradle` GitHub Action to v6.3.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'zulu'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
           cache-provider: basic
       - name: Build with Gradle
@@ -61,7 +61,7 @@ jobs:
           java-version: 26
           distribution: 'zulu'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
           cache-provider: basic
       - name: Build Operator Image
@@ -146,7 +146,7 @@ jobs:
           java-version: 26
           distribution: 'zulu'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
           cache-provider: basic
       - name: Set up Minikube
@@ -249,7 +249,7 @@ jobs:
           java-version: 26
           distribution: 'zulu'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
           cache-provider: basic
       - name: Set up Minikube
@@ -292,7 +292,7 @@ jobs:
           java-version: 26
           distribution: 'zulu'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
         with:
           cache-provider: basic
       - name: Linters

--- a/.github/workflows/publish_snapshot_chart.yml
+++ b/.github/workflows/publish_snapshot_chart.yml
@@ -36,7 +36,7 @@ jobs:
         java-version: 25
         distribution: 'zulu'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
       with:
         cache-provider: basic
     - name: Build Operator


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `gradle/actions/setup-gradle` to the approved commit hash of [v6.3.0](https://github.com/gradle/actions/releases/tag/v6.3.0) (2026-08-02).

- `50e97c2cd7a37755bbfafc9c5b7cafaece252f6e` (v6.1.0) -> `9c971963bec38e04b3d30dcc455b5382be2fdbfb` (v6.3.0)

### Why are the changes needed?

ASF INFRA removed `gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e` from the approved action list on 2026-09-03.

- https://github.com/apache/infrastructure-actions/commit/63206b1 (`Remove Expired Refs`)

Since then, the `Build` workflow on `main` cannot start at all and ends with `startup_failure` before any job is created:

```
The action gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e is not
allowed in apache/spark-kubernetes-operator because all actions must be from a repository
owned by your enterprise, created by GitHub, or match one of the patterns: ...
```

- https://github.com/apache/spark-kubernetes-operator/actions/runs/33798400934

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5