### PR TITLE
[SPARK-59231] Use the latest `docker/*` GitHub Actions

### DIFF
--- a/.github/workflows/publish_snapshot_dockerhub.yml
+++ b/.github/workflows/publish_snapshot_dockerhub.yml
@@ -27,11 +27,11 @@ jobs:
         branch: ${{ fromJSON( inputs.branch || '["main"]' ) }}
     steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
     - name: Login to Docker Hub
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
     - name: Build and push
-      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
       with:
         # build cache on Github Actions, See: https://docs.docker.com/build/cache/backends/gha/#using-dockerbuild-push-action
         cache-from: type=gha


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `docker/*` GitHub Actions to the latest approved commit hashes.

- `docker/setup-qemu-action`: `ce360397dd3f832beb865e1373c09c0e9f86d70a` (v4.0.0) -> `96fe6ef7f33517b61c61be40b68a1882f3264fb8` ([v4.2.0](https://github.com/docker/setup-qemu-action/releases/tag/v4.2.0), 2026-07-01)
- `docker/setup-buildx-action`: `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` (v4.0.0) -> `37fe631027851001ddb9b187196cc803df7f5f0e` ([v4.3.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.3.0), 2026-08-19)
- `docker/login-action`: `4907a6ddec9925e35a0a9e82d7399ccc52663121` (v4.1.0) -> `dbcb813823bdd20940b903addbd779551569679f` ([v4.6.0](https://github.com/docker/login-action/releases/tag/v4.6.0), 2026-07-29)
- `docker/build-push-action`: `bcafcacb16a39f128d818304e6c9c0c18556b85f` (v7.1.0) -> `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` ([v7.3.0](https://github.com/docker/build-push-action/releases/tag/v7.3.0), 2026-07-01)

### Why are the changes needed?

ASF INFRA removed all four commit hashes from the approved action list on 2026-09-03.

- https://github.com/apache/infrastructure-actions/commit/63206b1 (`Remove Expired Refs`)

Since then, the `Publish Snapshot Image` workflow cannot start at all and ends with `startup_failure` before any job is created:

- https://github.com/apache/spark-kubernetes-operator/actions/workflows/publish_snapshot_dockerhub.yml
  - https://github.com/apache/spark-kubernetes-operator/actions/runs/33699649546

```
The actions docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a,
docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd,
docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121, and
docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f are not allowed in
apache/spark-kubernetes-operator because all actions must be from a repository owned by
your enterprise, created by GitHub, or match one of the patterns: ...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5