### PR TITLE
[SPARK-59262] Add Java 27-ea to GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 20
       matrix:
         os: [ 'ubuntu-26.04', 'ubuntu-26.04-arm' ]
-        java-version: [ 21, 25, 26 ]
+        java-version: [ 21, 25, 26, '27-ea' ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Java `27-ea` to the `build-test` GitHub Actions matrix as the runner environment.

### Why are the changes needed?

Apache Spark K8s Operator uses a `Java 26` toolchain. Like [SPARK-55737] which added `26-ea` before its GA, this PR only aims to test `Java 27-ea` as the runner environment ahead of the [JDK 27 GA on 2026-09-15](https://openjdk.org/projects/jdk/27/).

Note that `-XX:+UseCompactObjectHeaders` is intentionally left as is, because [JEP 534: Compact Object Headers by Default](https://openjdk.org/jeps/534) makes it the default in Java 27. Passing the flag explicitly would be a no-op there, while Java 25 and 26 still require it.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check the log.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5